### PR TITLE
docs: improve SDK scope visibility and browser automation description

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Amazon Bedrock AgentCore enables you to deploy and operate highly effective agen
 - 📊 **Observability** - OpenTelemetry tracing: **[Observability Quick Start](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-get-started.html)**
 - 🔐 **Identity** - AWS & third-party auth: **[Identity Quick Start](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/identity-getting-started-cognito.html)**
 
-> **TypeScript SDK:** This SDK currently provides Code Interpreter and Browser tools. Additional service integrations are on the roadmap.
+## ⚠️ TypeScript SDK Scope
+
+This SDK currently provides Code Interpreter and Browser tools. Additional service integrations are on the roadmap.
 
 ## AgentCore Tools
 
@@ -67,7 +69,7 @@ import { CodeInterpreterClient } from 'bedrock-agentcore/code-interpreter'
 ```
 
 ### 🌐 Browser
-Automate web browsing with cloud-based Playwright:
+Automate web browsing with cloud-based browser automation (compatible with Playwright, Puppeteer, and other browser automation SDKs):
 
 ```typescript
 // Playwright client (framework-agnostic)


### PR DESCRIPTION
## Changes

- Convert TypeScript SDK scope note from blockquote to a prominent **⚠️ TypeScript SDK Scope** heading for better visibility
- Clarify browser automation compatibility by explicitly mentioning Playwright, Puppeteer, and other browser automation SDKs

## Why

The SDK scope limitation (only Code Interpreter and Browser tools currently available) is important information that users should notice immediately. Making it a heading with a warning icon ensures developers understand the current SDK coverage.

The browser automation description now clarifies that the service works with multiple browser automation frameworks, not just Playwright.

## Testing

- Verified markdown rendering locally
- No code changes, documentation only