### PR TITLE
Chore: Remove bedrock-agent-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
   "homepage": "https://github.com/aws/bedrock-agentcore-sdk-typescript#readme",
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
-    "@aws-sdk/client-bedrock-agent-runtime": "^3.939.0",
     "@aws-sdk/client-bedrock-agentcore": "^3.939.0",
     "@aws-sdk/credential-providers": "^3.939.0",
     "@smithy/protocol-http": "^5.3.5",


### PR DESCRIPTION
Removed dependency on @aws-sdk/client-bedrock-agent-runtime.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
