### PR TITLE
fix: enable manual approval for PRs modifying sensitive files

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -107,7 +107,6 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     needs: authorization-check
-    if: needs.authorization-check.outputs.should-run == 'true'
     environment: ${{ needs.authorization-check.outputs.approval-env }}
     permissions:
       id-token: write # Required for AWS OIDC


### PR DESCRIPTION
## Description

This PR fixes the integration test workflow to properly support manual approval for PRs that modify sensitive files (workflows, actions, test configs).

## Problem

Currently, when a PR modifies sensitive files, the integration tests are completely blocked and cannot run at all. The workflow has a redundant if condition that skips the entire job before it reaches the environment-based approval mechanism.

Current behavior:
- PRs modifying sensitive files → Integration tests completely skipped (no way to run them)
- PRs not modifying sensitive files → Integration tests run automatically

## Solution

Remove the redundant if: needs.authorization-check.outputs.should-run == 'true' condition. The environment-based approval system already provides proper gating.

After this fix:
- PRs modifying sensitive files → Integration tests pause for manual approval ✅
- PRs not modifying sensitive files → Integration tests run automatically ✅

## Changes

- Removed one line from .github/workflows/integration-testing.yml
- The environment parameter already handles approval gating correctly
- Maintainers can now review and manually approve integration test runs for PRs with sensitive file changes