### PR TITLE
docs(readme): fix incorrect code examples   

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ const app = new BedrockAgentCoreApp({
     requestSchema: z.object({ prompt: z.string() }),
     process: async function* (request) {
       for await (const event of agent.stream(request.prompt)) {
-        if (event.delta?.text) yield { text: event.delta.text }
+        if (event.type === 'modelContentBlockDeltaEvent' && event.delta?.type === 'textDelta') {
+          yield { event: 'message', data: { text: event.delta.text } }
+        }
       }
     },
   },


### PR DESCRIPTION
## Description

Fix incorrect README code examples:
- Import path: `tools/code-interpreter/strands` → `experimental/code-interpreter/strands`
- API: `.getTools()` → `.tools` (property, not method)
- Quick Start: Fix Strands SDK event handling and SSE yield format

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Documentation update

## Testing

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
