### PR TITLE
feat: add Slack notification workflow for new issues

### DIFF
--- a/.github/workflows/slack-issue-notification.yml
+++ b/.github/workflows/slack-issue-notification.yml
@@ -1,0 +1,25 @@
+name: Slack Issue Notification
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send issue details to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            issue_title: "${{ github.event.issue.title }}"
+            issue_number: "${{ github.event.issue.number }}"
+            issue_url: "${{ github.event.issue.html_url }}"
+            issue_author: "${{ github.event.issue.user.login }}"
+            issue_body: "${{ github.event.issue.body }}"
+            repository: "${{ github.repository }}"
+            created_at: "${{ github.event.issue.created_at }}"


### PR DESCRIPTION
Add GitHub Actions workflow that automatically sends issue details to Slack via webhook when new issues are created. Includes issue title, number, URL, author, body, and timestamp.

This change mirrors the implementation from the Python SDK: https://github.com/aws/bedrock-agentcore-sdk-python/commit/a48944a31a9d624904ad0a87e70505b187a61142