### PR TITLE
Add daily Slack notification for open PRs

### DIFF
--- a/.github/workflows/slack-open-prs-notification.yml
+++ b/.github/workflows/slack-open-prs-notification.yml
@@ -1,0 +1,51 @@
+name: Slack Open PRs Notification
+
+on:
+  schedule:
+    - cron: '0 13 * * *'  # 8:00 AM EST (13:00 UTC)
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get open PRs
+        id: open-prs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+
+            const count = prs.length;
+
+            // Format each PR on its own line with Slack mrkdwn link syntax
+            const prList = prs.map(pr =>
+              `• <${pr.html_url}|#${pr.number} - ${pr.title}> (by ${pr.user.login})`
+            ).join('\n');
+
+            core.setOutput('count', count);
+
+            // Use GITHUB_OUTPUT delimiter for multiline support
+            const fs = require('fs');
+            fs.appendFileSync(
+              process.env.GITHUB_OUTPUT,
+              `pr_list<<PRLIST_EOF\n${prList}\nPRLIST_EOF\n`
+            );
+
+      - name: Send open PRs summary to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_OPEN_PRS_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            pr_count: "${{ steps.open-prs.outputs.count }}"
+            pr_list: ${{ toJSON(steps.open-prs.outputs.pr_list) }}
+            repository: "${{ github.repository }}"
+            repository_url: "https://github.com/${{ github.repository }}/pulls"


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that sends a daily Slack summary of open PRs at 8:00 AM EST (13:00 UTC)
- Supports manual triggering via `workflow_dispatch`
- Uses `actions/github-script@v7` to fetch open PRs and `slackapi/slack-github-action@v2.0.0` to post to Slack
- Uses a separate `SLACK_OPEN_PRS_WEBHOOK_URL` secret (already configured)

## Test plan
- [ ] Merge to main, then trigger manually via `gh workflow run slack-open-prs-notification.yml`
- [ ] Verify Slack receives the message with PR count, linked PR list, and repo info
- [ ] Confirm cron fires at 13:00 UTC the following day