### PR TITLE
Fix PR list formatting in Slack notification

### DIFF
--- a/.github/workflows/slack-open-prs-notification.yml
+++ b/.github/workflows/slack-open-prs-notification.yml
@@ -25,9 +25,9 @@ jobs:
 
             const count = prs.length;
 
-            // Format each PR on its own line with Slack mrkdwn link syntax
+            // Format each PR with plain text and bare URL (Slack auto-links URLs)
             const prList = prs.map(pr =>
-              `• <${pr.html_url}|#${pr.number} - ${pr.title}> (by ${pr.user.login})`
+              `• #${pr.number} - ${pr.title} (by ${pr.user.login})\n  ${pr.html_url}`
             ).join('\n');
 
             core.setOutput('count', count);


### PR DESCRIPTION
## Summary
- Uses plain text with bare URLs instead of Slack mrkdwn `<url|text>` link syntax
- Slack Workflow Builder doesn't render mrkdwn inside variables, so links were showing as raw text
- Slack auto-links bare URLs, so each PR now shows as:
  ```
  • #42 - Add retry logic (by alice)
    https://github.com/org/repo/pull/42
  ```

## Test plan
- [ ] Merge and run `gh workflow run slack-open-prs-notification.yml`
- [ ] Verify PR links are clickable in Slack