### PR TITLE
Clarify framework compatibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@
 - **Managed tools** — Secure code execution and browser automation, ready to use.
 - **Credential management** — Centralized API keys and OAuth tokens, injected at runtime.
 
-Works with [Strands Agents](https://strandsagents.com), [Vercel AI SDK](https://ai-sdk.dev), or any framework.
+### Framework Compatibility
+
+The SDK is designed to work with any agent framework. Here's how:
+
+- **Runtime** — Deploy agents built with any framework. The `BedrockAgentCoreApp` accepts any request handler — plug in [Strands Agents](https://strandsagents.com), [Vercel AI SDK](https://ai-sdk.dev), [LangChain](https://js.langchain.com), or your own custom logic.
+- **Tools** — Code Interpreter and Browser tools include built-in integrations for [Strands Agents](https://strandsagents.com) and [Vercel AI SDK](https://ai-sdk.dev), so tools can be passed directly to those frameworks' agents. For other frameworks, use the core clients (`CodeInterpreter`, `PlaywrightBrowser`) directly and wire them into your own tool definitions.
+- **Identity** — Credential wrappers (`withAccessToken`, `withApiKey`) work with any async function, regardless of framework.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the vague "Works with Strands Agents, Vercel AI SDK, or any framework" one-liner with a **Framework Compatibility** section that explains what "works with" means for each SDK primitive
- **Runtime**: any framework via `BedrockAgentCoreApp` request handlers
- **Tools**: built-in Strands/Vercel AI integrations; other frameworks use core clients directly
- **Identity**: credential wrappers work with any async function

## Motivation

The previous wording was being misinterpreted as full Strands/Vercel support across all AgentCore primitives. The reality is more nuanced — framework compatibility varies by primitive. This change sets accurate expectations.

## Test plan

- [x] Pre-commit hooks pass (tests, lint, format, type-check)
- [ ] Verify rendered markdown looks correct on the PR's Files tab