### PR TITLE
fix: return time_of_last_update as Unix timestamp in seconds

### DIFF
--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -160,7 +160,7 @@ Returns:
 ```json
 {
   "status": "Healthy",
-  "time_of_last_update": "2024-12-16T21:00:00.000Z"
+  "time_of_last_update": 1734382800
 }
 ```
 

--- a/src/runtime/__tests__/app.test.ts
+++ b/src/runtime/__tests__/app.test.ts
@@ -210,7 +210,7 @@ describe('BedrockAgentCoreApp', () => {
       await pingHandler(mockReq, mockReply)
       expect(mockReply.send).toHaveBeenCalledWith({
         status: expect.stringMatching(/^(Healthy|HealthyBusy)$/),
-        time_of_last_update: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+        time_of_last_update: expect.any(Number),
       })
     })
   })

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -315,7 +315,7 @@ export class BedrockAgentCoreApp<TSchema extends z.ZodSchema = z.ZodSchema<unkno
     const status = this.getCurrentPingStatus()
     const response: HealthCheckResponse = {
       status,
-      time_of_last_update: new Date(this._lastStatusUpdateTime).toISOString(),
+      time_of_last_update: Math.floor(this._lastStatusUpdateTime / 1000),
     }
     await reply.send(response)
   }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -282,9 +282,9 @@ export interface HealthCheckResponse {
   status: HealthStatus
 
   /**
-   * ISO 8601 timestamp of the last update.
+   * Unix timestamp in seconds of the last status update.
    */
-  time_of_last_update: string
+  time_of_last_update: number
 }
 
 /**

--- a/tests_integ/runtime.test.ts
+++ b/tests_integ/runtime.test.ts
@@ -51,13 +51,14 @@ describe('BedrockAgentCoreApp Integration', () => {
         })
     })
 
-    it('returns valid ISO 8601 timestamp', async () => {
+    it('returns valid Unix timestamp in seconds', async () => {
       await request(fastify.server)
         .get('/ping')
         .expect(200)
         .expect(function (res) {
-          const timestamp = new Date(res.body.time_of_last_update)
-          expect(timestamp.toISOString()).toBe(res.body.time_of_last_update)
+          expect(typeof res.body.time_of_last_update).toBe('number')
+          expect(res.body.time_of_last_update).toBeGreaterThan(0)
+          expect(res.body.time_of_last_update).toBeLessThanOrEqual(Math.floor(Date.now() / 1000))
         })
     })
 


### PR DESCRIPTION
The `/ping` endpoint was returning `time_of_last_update` as an ISO 8601 string (e.g., `"2026-04-09T06:26:53.699Z"`), but the AgentCore runtime expects a Unix timestamp in seconds (number). This caused the runtime to not recognize the `HealthyBusy` status, leading to containers being suspended after `idleRuntimeSessionTimeout` even while background tasks were still running.

## Description
<!-- Provide a detailed description of the changes in this PR -->

- `src/runtime/app.ts`: Changed `time_of_last_update` from `.toISOString()` to `Math.floor(... / 1000)` (Unix seconds)
- `src/runtime/types.ts`: Updated `HealthCheckResponse.time_of_last_update` type from `string` to `number`
- Updated unit tests, integration tests, and README to reflect the new format

## Related Issues

<!-- Link to related issues using #issue-number format -->

N/A

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

N/A

## Type of Change

<!-- Choose one of the following types of changes, delete the rest -->

Bug fix

## Testing

How have you tested the change?

Reproduced the issue by deploying a runtime with a background async task and varying `idleRuntimeSessionTimeout` values (1, 2, 3 minutes). With the ISO string format, the container was suspended after the idle timeout despite returning `HealthyBusy`. After switching to a Unix timestamp in seconds, the container correctly stayed alive for the duration of the background task.

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
