### PR TITLE
chore: merge PR #108 MemoryClient into feat/agentcore-memory

### DIFF
--- a/src/_utils/__tests__/pagination.test.ts
+++ b/src/_utils/__tests__/pagination.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { paginateAll } from '../../_utils/pagination.js'
+
+describe('paginateAll', () => {
+  it('should return all items from a single page', async () => {
+    const pages = [{ items: [1, 2, 3], nextToken: undefined as string | undefined }]
+    let callCount = 0
+
+    const result = await paginateAll(
+      () => Promise.resolve(pages[callCount++]!),
+      (page) => page.items,
+      (page) => page.nextToken,
+    )
+
+    expect(result).toEqual([1, 2, 3])
+    expect(callCount).toBe(1)
+  })
+
+  it('should accumulate items across multiple pages', async () => {
+    const pages = [
+      { items: [1, 2], nextToken: 'tok1' as string | undefined },
+      { items: [3, 4], nextToken: 'tok2' as string | undefined },
+      { items: [5], nextToken: undefined as string | undefined },
+    ]
+    let callCount = 0
+    const tokensReceived: (string | undefined)[] = []
+
+    const result = await paginateAll(
+      (nextToken) => {
+        tokensReceived.push(nextToken)
+        return Promise.resolve(pages[callCount++]!)
+      },
+      (page) => page.items,
+      (page) => page.nextToken,
+    )
+
+    expect(result).toEqual([1, 2, 3, 4, 5])
+    expect(tokensReceived).toEqual([undefined, 'tok1', 'tok2'])
+  })
+
+  it('should return empty array when page has no items', async () => {
+    const result = await paginateAll(
+      () => Promise.resolve({ items: undefined as number[] | undefined, nextToken: undefined }),
+      (page) => page.items,
+      (page) => page.nextToken,
+    )
+
+    expect(result).toEqual([])
+  })
+})

--- a/src/_utils/__tests__/pagination.test.ts
+++ b/src/_utils/__tests__/pagination.test.ts
@@ -9,7 +9,7 @@ describe('paginateAll', () => {
     const result = await paginateAll(
       () => Promise.resolve(pages[callCount++]!),
       (page) => page.items,
-      (page) => page.nextToken,
+      (page) => page.nextToken
     )
 
     expect(result).toEqual([1, 2, 3])
@@ -31,7 +31,7 @@ describe('paginateAll', () => {
         return Promise.resolve(pages[callCount++]!)
       },
       (page) => page.items,
-      (page) => page.nextToken,
+      (page) => page.nextToken
     )
 
     expect(result).toEqual([1, 2, 3, 4, 5])
@@ -42,7 +42,7 @@ describe('paginateAll', () => {
     const result = await paginateAll(
       () => Promise.resolve({ items: undefined as number[] | undefined, nextToken: undefined }),
       (page) => page.items,
-      (page) => page.nextToken,
+      (page) => page.nextToken
     )
 
     expect(result).toEqual([])

--- a/src/_utils/__tests__/polling.test.ts
+++ b/src/_utils/__tests__/polling.test.ts
@@ -3,37 +3,29 @@ import { pollUntil } from '../../_utils/polling.js'
 
 describe('pollUntil', () => {
   it('should return true immediately when condition is met', async () => {
-    const result = await pollUntil(
-      () => Promise.resolve(true),
-      { maxWaitSeconds: 5, pollIntervalMs: 10 },
-    )
+    const result = await pollUntil(() => Promise.resolve(true), { maxWaitSeconds: 5, pollIntervalMs: 10 })
     expect(result).toBe(true)
   })
 
   it('should poll until condition becomes true', async () => {
     let calls = 0
-    const result = await pollUntil(
-      () => Promise.resolve(++calls >= 3),
-      { maxWaitSeconds: 5, pollIntervalMs: 10 },
-    )
+    const result = await pollUntil(() => Promise.resolve(++calls >= 3), { maxWaitSeconds: 5, pollIntervalMs: 10 })
     expect(result).toBe(true)
     expect(calls).toBe(3)
   })
 
   it('should return false on timeout when no timeoutErrorMessage', async () => {
-    const result = await pollUntil(
-      () => Promise.resolve(false),
-      { maxWaitSeconds: 0.05, pollIntervalMs: 10 },
-    )
+    const result = await pollUntil(() => Promise.resolve(false), { maxWaitSeconds: 0.05, pollIntervalMs: 10 })
     expect(result).toBe(false)
   })
 
   it('should throw on timeout when timeoutErrorMessage is set', async () => {
     await expect(
-      pollUntil(
-        () => Promise.resolve(false),
-        { maxWaitSeconds: 0.05, pollIntervalMs: 10, timeoutErrorMessage: 'timed out' },
-      ),
+      pollUntil(() => Promise.resolve(false), {
+        maxWaitSeconds: 0.05,
+        pollIntervalMs: 10,
+        timeoutErrorMessage: 'timed out',
+      })
     ).rejects.toThrow('timed out')
   })
 
@@ -45,7 +37,7 @@ describe('pollUntil', () => {
         if (calls < 2) throw new Error('transient')
         return Promise.resolve(true)
       },
-      { maxWaitSeconds: 5, pollIntervalMs: 10, shouldSwallowError: () => true },
+      { maxWaitSeconds: 5, pollIntervalMs: 10, shouldSwallowError: () => true }
     )
     expect(result).toBe(true)
     expect(calls).toBe(2)
@@ -54,18 +46,22 @@ describe('pollUntil', () => {
   it('should propagate errors not matched by shouldSwallowError', async () => {
     await expect(
       pollUntil(
-        () => { throw new Error('fatal') },
-        { maxWaitSeconds: 5, pollIntervalMs: 10, shouldSwallowError: (err) => (err as Error).message !== 'fatal' },
-      ),
+        () => {
+          throw new Error('fatal')
+        },
+        { maxWaitSeconds: 5, pollIntervalMs: 10, shouldSwallowError: (err) => (err as Error).message !== 'fatal' }
+      )
     ).rejects.toThrow('fatal')
   })
 
   it('should propagate all errors when shouldSwallowError is not provided', async () => {
     await expect(
       pollUntil(
-        () => { throw new Error('fatal') },
-        { maxWaitSeconds: 5, pollIntervalMs: 10 },
-      ),
+        () => {
+          throw new Error('fatal')
+        },
+        { maxWaitSeconds: 5, pollIntervalMs: 10 }
+      )
     ).rejects.toThrow('fatal')
   })
 })

--- a/src/_utils/__tests__/polling.test.ts
+++ b/src/_utils/__tests__/polling.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { pollUntil } from '../../_utils/polling.js'
+
+describe('pollUntil', () => {
+  it('should return true immediately when condition is met', async () => {
+    const result = await pollUntil(
+      () => Promise.resolve(true),
+      { maxWaitSeconds: 5, pollIntervalMs: 10 },
+    )
+    expect(result).toBe(true)
+  })
+
+  it('should poll until condition becomes true', async () => {
+    let calls = 0
+    const result = await pollUntil(
+      () => Promise.resolve(++calls >= 3),
+      { maxWaitSeconds: 5, pollIntervalMs: 10 },
+    )
+    expect(result).toBe(true)
+    expect(calls).toBe(3)
+  })
+
+  it('should return false on timeout when no timeoutErrorMessage', async () => {
+    const result = await pollUntil(
+      () => Promise.resolve(false),
+      { maxWaitSeconds: 0.05, pollIntervalMs: 10 },
+    )
+    expect(result).toBe(false)
+  })
+
+  it('should throw on timeout when timeoutErrorMessage is set', async () => {
+    await expect(
+      pollUntil(
+        () => Promise.resolve(false),
+        { maxWaitSeconds: 0.05, pollIntervalMs: 10, timeoutErrorMessage: 'timed out' },
+      ),
+    ).rejects.toThrow('timed out')
+  })
+
+  it('should swallow errors matching shouldSwallowError predicate', async () => {
+    let calls = 0
+    const result = await pollUntil(
+      () => {
+        calls++
+        if (calls < 2) throw new Error('transient')
+        return Promise.resolve(true)
+      },
+      { maxWaitSeconds: 5, pollIntervalMs: 10, shouldSwallowError: () => true },
+    )
+    expect(result).toBe(true)
+    expect(calls).toBe(2)
+  })
+
+  it('should propagate errors not matched by shouldSwallowError', async () => {
+    await expect(
+      pollUntil(
+        () => { throw new Error('fatal') },
+        { maxWaitSeconds: 5, pollIntervalMs: 10, shouldSwallowError: (err) => (err as Error).message !== 'fatal' },
+      ),
+    ).rejects.toThrow('fatal')
+  })
+
+  it('should propagate all errors when shouldSwallowError is not provided', async () => {
+    await expect(
+      pollUntil(
+        () => { throw new Error('fatal') },
+        { maxWaitSeconds: 5, pollIntervalMs: 10 },
+      ),
+    ).rejects.toThrow('fatal')
+  })
+})

--- a/src/_utils/pagination.ts
+++ b/src/_utils/pagination.ts
@@ -1,0 +1,34 @@
+export const DEFAULT_PAGE_SIZE = 100
+
+/**
+ * Paginate any SDK method that follows the nextToken request/response pattern.
+ *
+ * @param fetchPage - Fetches a single page, given an optional nextToken
+ * @param getItems - Extracts the item array from each page response
+ * @param getNextToken - Extracts the nextToken from each page response
+ * @returns All items accumulated across pages
+ *
+ * @example
+ * ```typescript
+ * const allEvents = await paginateAll(
+ *   (nextToken) => client.listEvents({ memoryId, actorId, sessionId, nextToken }),
+ *   (page) => page.events,
+ *   (page) => page.nextToken,
+ * );
+ * ```
+ */
+export async function paginateAll<TOutput, TItem>(
+  fetchPage: (nextToken?: string) => Promise<TOutput>,
+  getItems: (output: TOutput) => TItem[] | undefined,
+  getNextToken: (output: TOutput) => string | undefined,
+): Promise<TItem[]> {
+  const items: TItem[] = []
+  let nextToken: string | undefined
+  do {
+    const page = await fetchPage(nextToken)
+    const pageItems = getItems(page)
+    if (pageItems) items.push(...pageItems)
+    nextToken = getNextToken(page)
+  } while (nextToken)
+  return items
+}

--- a/src/_utils/pagination.ts
+++ b/src/_utils/pagination.ts
@@ -20,7 +20,7 @@ export const DEFAULT_PAGE_SIZE = 100
 export async function paginateAll<TOutput, TItem>(
   fetchPage: (nextToken?: string) => Promise<TOutput>,
   getItems: (output: TOutput) => TItem[] | undefined,
-  getNextToken: (output: TOutput) => string | undefined,
+  getNextToken: (output: TOutput) => string | undefined
 ): Promise<TItem[]> {
   const items: TItem[] = []
   let nextToken: string | undefined

--- a/src/_utils/polling.ts
+++ b/src/_utils/polling.ts
@@ -1,0 +1,29 @@
+/**
+ * Poll a condition function until it returns `true` or the timeout expires.
+ *
+ * @param condition - Async function that returns `true` when done. Throwing is treated as "not done yet" when `swallowErrors` is true.
+ * @param opts - Polling options
+ * @returns `true` if the condition was met, `false` if timed out (only when `timeoutErrorMessage` is not set)
+ * @throws Error with `timeoutErrorMessage` if provided and timeout expires
+ */
+export async function pollUntil(
+  condition: () => Promise<boolean>,
+  opts: {
+    maxWaitSeconds: number
+    pollIntervalMs: number
+    timeoutErrorMessage?: string
+    shouldSwallowError?: (err: unknown) => boolean
+  },
+): Promise<boolean> {
+  const deadline = Date.now() + opts.maxWaitSeconds * 1000
+  while (Date.now() < deadline) {
+    try {
+      if (await condition()) return true
+    } catch (err) {
+      if (!opts.shouldSwallowError?.(err)) throw err
+    }
+    await new Promise((resolve) => globalThis.setTimeout(resolve, opts.pollIntervalMs))
+  }
+  if (opts.timeoutErrorMessage) throw new Error(opts.timeoutErrorMessage)
+  return false
+}

--- a/src/_utils/polling.ts
+++ b/src/_utils/polling.ts
@@ -13,7 +13,7 @@ export async function pollUntil(
     pollIntervalMs: number
     timeoutErrorMessage?: string
     shouldSwallowError?: (err: unknown) => boolean
-  },
+  }
 ): Promise<boolean> {
   const deadline = Date.now() + opts.maxWaitSeconds * 1000
   while (Date.now() < deadline) {

--- a/src/memory/__tests__/client.test.ts
+++ b/src/memory/__tests__/client.test.ts
@@ -4,13 +4,7 @@ import type { BedrockAgentCoreControl } from '@aws-sdk/client-bedrock-agentcore-
 import { MemoryClient } from '../client.js'
 import { DATA_PLANE_METHODS, CONTROL_PLANE_METHODS } from '../types.js'
 
-function fakeControlPlane(overrides: Record<string, (input: unknown) => unknown>): Record<string, unknown> {
-  return new Proxy({} as Record<string, unknown>, {
-    get: (_, method) => overrides[method as string] ?? (() => Promise.resolve({})),
-  })
-}
-
-function fakeDataPlane(overrides: Record<string, (input: unknown) => unknown>): Record<string, unknown> {
+function fakeClient(overrides: Record<string, (input: unknown) => unknown>): Record<string, unknown> {
   return new Proxy({} as Record<string, unknown>, {
     get: (_, method) => overrides[method as string] ?? (() => Promise.resolve({})),
   })
@@ -41,22 +35,10 @@ describe('MemoryClient', () => {
     })
   })
 
-  describe('memory() scoping', () => {
-    const client = new MemoryClient({ region: 'us-west-2' })
-    const mem = client.memory('mem-1')
-
-    it('exposes scoped methods as functions', () => {
-      expect(typeof mem.createEvent).toBe('function')
-      expect(typeof mem.retrieveMemoryRecords).toBe('function')
-      expect(typeof mem.listEvents).toBe('function')
-      expect(typeof mem.listActors).toBe('function')
-    })
-  })
-
   describe('createOrGetMemory()', () => {
     it('returns existing memory when create throws already-exists', async () => {
       const client = new MemoryClient({
-        controlPlaneClient: fakeControlPlane({
+        controlPlaneClient: fakeClient({
           createMemory: () => {
             throw Object.assign(new Error('already exists'), { name: 'ValidationException' })
           },
@@ -70,7 +52,7 @@ describe('MemoryClient', () => {
 
     it('propagates non-conflict errors', async () => {
       const client = new MemoryClient({
-        controlPlaneClient: fakeControlPlane({
+        controlPlaneClient: fakeClient({
           createMemory: () => {
             throw Object.assign(new Error('throttled'), { name: 'ThrottlingException' })
           },
@@ -84,7 +66,7 @@ describe('MemoryClient', () => {
   describe('deleteMemoryAndWait()', () => {
     it('resolves when resource is not found after delete', async () => {
       const client = new MemoryClient({
-        controlPlaneClient: fakeControlPlane({
+        controlPlaneClient: fakeClient({
           deleteMemory: () => Promise.resolve({}),
           getMemory: () => {
             throw Object.assign(new Error(), { name: 'ResourceNotFoundException' })
@@ -101,7 +83,7 @@ describe('MemoryClient', () => {
   describe('getLastKTurns()', () => {
     it('groups messages into turns at USER boundaries', async () => {
       const client = new MemoryClient({
-        dataPlaneClient: fakeDataPlane({
+        dataPlaneClient: fakeClient({
           listEvents: () =>
             Promise.resolve({
               events: [
@@ -114,13 +96,13 @@ describe('MemoryClient', () => {
         }) as unknown as BedrockAgentCore,
       })
 
-      const turns = await client.memory('mem-1').getLastKTurns({ actorId: 'a1', sessionId: 's1', k: 1 })
+      const turns = await client.getLastKTurns({ memoryId: 'mem-1', actorId: 'a1', sessionId: 's1', k: 1 })
       expect(turns).toMatchObject([[{ role: 'USER' }, { role: 'ASSISTANT' }]])
     })
 
     it('returns all turns when k exceeds total', async () => {
       const client = new MemoryClient({
-        dataPlaneClient: fakeDataPlane({
+        dataPlaneClient: fakeClient({
           listEvents: () =>
             Promise.resolve({
               events: [
@@ -131,18 +113,18 @@ describe('MemoryClient', () => {
         }) as unknown as BedrockAgentCore,
       })
 
-      const turns = await client.memory('mem-1').getLastKTurns({ actorId: 'a1', sessionId: 's1', k: 5 })
+      const turns = await client.getLastKTurns({ memoryId: 'mem-1', actorId: 'a1', sessionId: 's1', k: 5 })
       expect(turns).toMatchObject([[{ role: 'USER' }, { role: 'ASSISTANT' }]])
     })
 
     it('returns empty array for empty session', async () => {
       const client = new MemoryClient({
-        dataPlaneClient: fakeDataPlane({
+        dataPlaneClient: fakeClient({
           listEvents: () => Promise.resolve({ events: [] }),
         }) as unknown as BedrockAgentCore,
       })
 
-      const turns = await client.memory('mem-1').getLastKTurns({ actorId: 'a1', sessionId: 's1', k: 5 })
+      const turns = await client.getLastKTurns({ memoryId: 'mem-1', actorId: 'a1', sessionId: 's1', k: 5 })
       expect(turns).toEqual([])
     })
   })
@@ -150,7 +132,7 @@ describe('MemoryClient', () => {
   describe('listBranches()', () => {
     it('aggregates branch info from events', async () => {
       const client = new MemoryClient({
-        dataPlaneClient: fakeDataPlane({
+        dataPlaneClient: fakeClient({
           listEvents: () =>
             Promise.resolve({
               events: [
@@ -162,7 +144,7 @@ describe('MemoryClient', () => {
         }) as unknown as BedrockAgentCore,
       })
 
-      const branches = await client.memory('mem-1').listBranches({ actorId: 'a1', sessionId: 's1' })
+      const branches = await client.listBranches({ memoryId: 'mem-1', actorId: 'a1', sessionId: 's1' })
       expect(branches).toMatchObject([
         { name: 'main', eventCount: 2 },
         { name: 'alt', eventCount: 1, rootEventId: 'e1' },

--- a/src/memory/__tests__/client.test.ts
+++ b/src/memory/__tests__/client.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import type { BedrockAgentCore } from '@aws-sdk/client-bedrock-agentcore'
+import type { BedrockAgentCoreControl } from '@aws-sdk/client-bedrock-agentcore-control'
+import { MemoryClient } from '../client.js'
+import { DATA_PLANE_METHODS, CONTROL_PLANE_METHODS } from '../types.js'
+
+function fakeControlPlane(overrides: Record<string, (input: unknown) => unknown>): Record<string, unknown> {
+  return new Proxy({} as Record<string, unknown>, {
+    get: (_, method) => overrides[method as string] ?? (() => Promise.resolve({})),
+  })
+}
+
+function fakeDataPlane(overrides: Record<string, (input: unknown) => unknown>): Record<string, unknown> {
+  return new Proxy({} as Record<string, unknown>, {
+    get: (_, method) => overrides[method as string] ?? (() => Promise.resolve({})),
+  })
+}
+
+describe('MemoryClient', () => {
+  describe('passthrough', () => {
+    const client = new MemoryClient({ region: 'us-west-2' })
+
+    it('exposes every data plane method as a function', () => {
+      for (const method of DATA_PLANE_METHODS) {
+        expect(typeof client[method]).toBe('function')
+      }
+    })
+
+    it('exposes every control plane method as a function', () => {
+      for (const method of CONTROL_PLANE_METHODS) {
+        expect(typeof client[method]).toBe('function')
+      }
+    })
+
+    it('does not expose arbitrary properties', () => {
+      expect((client as unknown as Record<string, unknown>)['nonExistentMethod']).toBeUndefined()
+    })
+
+    it('constructs without config using defaults', () => {
+      expect(new MemoryClient()).toBeDefined()
+    })
+  })
+
+  describe('memory() scoping', () => {
+    const client = new MemoryClient({ region: 'us-west-2' })
+    const mem = client.memory('mem-1')
+
+    it('exposes scoped methods as functions', () => {
+      expect(typeof mem.createEvent).toBe('function')
+      expect(typeof mem.retrieveMemoryRecords).toBe('function')
+      expect(typeof mem.listEvents).toBe('function')
+      expect(typeof mem.listActors).toBe('function')
+    })
+  })
+
+  describe('createOrGetMemory()', () => {
+    it('returns existing memory when create throws already-exists', async () => {
+      const client = new MemoryClient({
+        controlPlaneClient: fakeControlPlane({
+          createMemory: () => {
+            throw Object.assign(new Error('already exists'), { name: 'ValidationException' })
+          },
+          getMemory: () => Promise.resolve({ memory: { id: 'mem-1' }, $metadata: {} }),
+        }) as unknown as BedrockAgentCoreControl,
+      })
+
+      const result = await client.createOrGetMemory({ name: 'test', eventExpiryDuration: 30 })
+      expect(result.memory).toMatchObject({ id: 'mem-1' })
+    })
+
+    it('propagates non-conflict errors', async () => {
+      const client = new MemoryClient({
+        controlPlaneClient: fakeControlPlane({
+          createMemory: () => {
+            throw Object.assign(new Error('throttled'), { name: 'ThrottlingException' })
+          },
+        }) as unknown as BedrockAgentCoreControl,
+      })
+
+      await expect(client.createOrGetMemory({ name: 'test', eventExpiryDuration: 30 })).rejects.toThrow('throttled')
+    })
+  })
+
+  describe('deleteMemoryAndWait()', () => {
+    it('resolves when resource is not found after delete', async () => {
+      const client = new MemoryClient({
+        controlPlaneClient: fakeControlPlane({
+          deleteMemory: () => Promise.resolve({}),
+          getMemory: () => {
+            throw Object.assign(new Error(), { name: 'ResourceNotFoundException' })
+          },
+        }) as unknown as BedrockAgentCoreControl,
+      })
+
+      await expect(
+        client.deleteMemoryAndWait('mem-1', { maxWaitSeconds: 1, pollIntervalMs: 10 })
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('getLastKTurns()', () => {
+    it('groups messages into turns at USER boundaries', async () => {
+      const client = new MemoryClient({
+        dataPlaneClient: fakeDataPlane({
+          listEvents: () =>
+            Promise.resolve({
+              events: [
+                { eventId: 'e1', payload: [{ conversational: { role: 'USER', content: { text: 'hi' } } }] },
+                { eventId: 'e2', payload: [{ conversational: { role: 'ASSISTANT', content: { text: 'hello' } } }] },
+                { eventId: 'e3', payload: [{ conversational: { role: 'USER', content: { text: 'bye' } } }] },
+                { eventId: 'e4', payload: [{ conversational: { role: 'ASSISTANT', content: { text: 'goodbye' } } }] },
+              ],
+            }),
+        }) as unknown as BedrockAgentCore,
+      })
+
+      const turns = await client.memory('mem-1').getLastKTurns({ actorId: 'a1', sessionId: 's1', k: 1 })
+      expect(turns).toMatchObject([[{ role: 'USER' }, { role: 'ASSISTANT' }]])
+    })
+
+    it('returns all turns when k exceeds total', async () => {
+      const client = new MemoryClient({
+        dataPlaneClient: fakeDataPlane({
+          listEvents: () =>
+            Promise.resolve({
+              events: [
+                { eventId: 'e1', payload: [{ conversational: { role: 'USER', content: { text: 'hi' } } }] },
+                { eventId: 'e2', payload: [{ conversational: { role: 'ASSISTANT', content: { text: 'hello' } } }] },
+              ],
+            }),
+        }) as unknown as BedrockAgentCore,
+      })
+
+      const turns = await client.memory('mem-1').getLastKTurns({ actorId: 'a1', sessionId: 's1', k: 5 })
+      expect(turns).toMatchObject([[{ role: 'USER' }, { role: 'ASSISTANT' }]])
+    })
+
+    it('returns empty array for empty session', async () => {
+      const client = new MemoryClient({
+        dataPlaneClient: fakeDataPlane({
+          listEvents: () => Promise.resolve({ events: [] }),
+        }) as unknown as BedrockAgentCore,
+      })
+
+      const turns = await client.memory('mem-1').getLastKTurns({ actorId: 'a1', sessionId: 's1', k: 5 })
+      expect(turns).toEqual([])
+    })
+  })
+
+  describe('listBranches()', () => {
+    it('aggregates branch info from events', async () => {
+      const client = new MemoryClient({
+        dataPlaneClient: fakeDataPlane({
+          listEvents: () =>
+            Promise.resolve({
+              events: [
+                { eventId: 'e1' },
+                { eventId: 'e2' },
+                { eventId: 'e3', branch: { name: 'alt', rootEventId: 'e1' } },
+              ],
+            }),
+        }) as unknown as BedrockAgentCore,
+      })
+
+      const branches = await client.memory('mem-1').listBranches({ actorId: 'a1', sessionId: 's1' })
+      expect(branches).toMatchObject([
+        { name: 'main', eventCount: 2 },
+        { name: 'alt', eventCount: 1, rootEventId: 'e1' },
+      ])
+    })
+  })
+})

--- a/src/memory/__tests__/client.test.ts
+++ b/src/memory/__tests__/client.test.ts
@@ -42,12 +42,13 @@ describe('MemoryClient', () => {
           createMemory: () => {
             throw Object.assign(new Error('already exists'), { name: 'ValidationException' })
           },
-          getMemory: () => Promise.resolve({ memory: { id: 'mem-1' }, $metadata: {} }),
+          listMemories: () => Promise.resolve({ memories: [{ id: 'test-abc123' }] }),
+          getMemory: () => Promise.resolve({ memory: { id: 'test-abc123' }, $metadata: {} }),
         }) as unknown as BedrockAgentCoreControl,
       })
 
       const result = await client.createOrGetMemory({ name: 'test', eventExpiryDuration: 30 })
-      expect(result.memory).toMatchObject({ id: 'mem-1' })
+      expect(result.memory).toMatchObject({ id: 'test-abc123' })
     })
 
     it('propagates non-conflict errors', async () => {

--- a/src/memory/client.ts
+++ b/src/memory/client.ts
@@ -1,7 +1,4 @@
-import {
-  BedrockAgentCore,
-  type Conversational,
-} from '@aws-sdk/client-bedrock-agentcore'
+import { BedrockAgentCore, type Conversational } from '@aws-sdk/client-bedrock-agentcore'
 import {
   BedrockAgentCoreControl,
   type CreateMemoryCommandInput,
@@ -10,7 +7,6 @@ import {
 } from '@aws-sdk/client-bedrock-agentcore-control'
 import type {
   MemoryClientConfig,
-  ScopedMemory,
   WaitOptions,
   WaitForMemoriesParams,
   GetLastKTurnsParams,
@@ -72,19 +68,12 @@ class MemoryPassthroughClient {
  * Passthrough methods from both AWS SDK clients are available directly on this
  * class (e.g. `client.createEvent(...)`, `client.createMemory(...)`).
  *
- * Use `.memory(memoryId)` for memory-scoped operations.
- *
  * @example
  * ```typescript
  * const client = new MemoryClient({ region: 'us-west-2' });
  *
- * // Passthrough — delegates to the right AWS SDK client
  * await client.createMemory({ name: 'my-mem', eventExpiryDuration: 30, memoryStrategies: [] });
- *
- * // Memory-scoped — memoryId auto-filled
- * const mem = client.memory('mem-123');
- * await mem.listActors();
- * await mem.createEvent({ actorId: 'u1', sessionId: 's1', payload: [], eventTimestamp: new Date() });
+ * await client.createEvent({ memoryId: 'mem-123', actorId: 'u1', sessionId: 's1', payload: [], eventTimestamp: new Date() });
  * ```
  */
 class MemoryClient extends MemoryPassthroughClient {
@@ -92,16 +81,13 @@ class MemoryClient extends MemoryPassthroughClient {
     super(config)
   }
 
-  async createMemoryAndWait(
-    input: CreateMemoryCommandInput,
-    opts?: WaitOptions,
-  ): Promise<CreateMemoryCommandOutput> {
+  async createMemoryAndWait(input: CreateMemoryCommandInput, opts?: WaitOptions): Promise<CreateMemoryCommandOutput> {
     const result = await this.controlPlane.createMemory(input)
     const memoryId = result.memory!.id!
-    await this.controlPlane.waitUntilMemoryCreated(
-      { memoryId } satisfies GetMemoryCommandInput,
-      { maxWaitTime: opts?.maxWaitSeconds ?? 300, minDelay: opts?.pollIntervalMs ? opts.pollIntervalMs / 1000 : 10 },
-    )
+    await this.controlPlane.waitUntilMemoryCreated({ memoryId } satisfies GetMemoryCommandInput, {
+      maxWaitTime: opts?.maxWaitSeconds ?? 300,
+      minDelay: opts?.pollIntervalMs ? opts.pollIntervalMs / 1000 : 10,
+    })
     return result
   }
 
@@ -133,7 +119,7 @@ class MemoryClient extends MemoryPassthroughClient {
         maxWaitSeconds: opts?.maxWaitSeconds ?? 300,
         pollIntervalMs: opts?.pollIntervalMs ?? 10_000,
         timeoutErrorMessage: `Memory ${memoryId} was not deleted within ${opts?.maxWaitSeconds ?? 300}s`,
-      },
+      }
     )
   }
 
@@ -151,7 +137,7 @@ class MemoryClient extends MemoryPassthroughClient {
         maxWaitSeconds: params.maxWaitSeconds ?? 180,
         pollIntervalMs: params.pollIntervalMs ?? 15_000,
         shouldSwallowError: () => true,
-      },
+      }
     )
   }
 
@@ -175,7 +161,9 @@ class MemoryClient extends MemoryPassthroughClient {
     let nextToken: string | undefined
 
     while (turns.length < params.k) {
-      const response = await this.dataPlane.listEvents({ ...listParams, nextToken } as Parameters<BedrockAgentCore['listEvents']>[0])
+      const response = await this.dataPlane.listEvents({ ...listParams, nextToken } as Parameters<
+        BedrockAgentCore['listEvents']
+      >[0])
       const events = response.events ?? []
       if (events.length === 0) break
 
@@ -203,15 +191,18 @@ class MemoryClient extends MemoryPassthroughClient {
     return turns.slice(0, params.k)
   }
 
-  async listBranches(params: {
-    memoryId: string
-    actorId: string
-    sessionId: string
-  }): Promise<BranchInfo[]> {
+  async listBranches(params: { memoryId: string; actorId: string; sessionId: string }): Promise<BranchInfo[]> {
     const allEvents = await paginateAll(
-      (nextToken) => this.dataPlane.listEvents({ memoryId: params.memoryId, actorId: params.actorId, sessionId: params.sessionId, includePayloads: false, nextToken }),
+      (nextToken) =>
+        this.dataPlane.listEvents({
+          memoryId: params.memoryId,
+          actorId: params.actorId,
+          sessionId: params.sessionId,
+          includePayloads: false,
+          nextToken,
+        }),
       (page) => page.events,
-      (page) => page.nextToken,
+      (page) => page.nextToken
     )
 
     const branches = new Map<string, BranchInfo>()
@@ -230,51 +221,6 @@ class MemoryClient extends MemoryPassthroughClient {
     }
     return Array.from(branches.values())
   }
-
-  memory(memoryId: string): ScopedMemory {
-    const dp = this.dataPlane
-    const getLastK = this.getLastKTurns.bind(this)
-    const getBranches = this.listBranches.bind(this)
-
-    const scoped: ScopedMemory = {
-      createEvent: (input) =>
-        dp.createEvent({ ...input, memoryId }),
-
-      listEvents: (input) =>
-        dp.listEvents({ ...input, memoryId }),
-
-      listAllEvents: (input) =>
-        paginateAll(
-          (nextToken) => dp.listEvents({ ...input, memoryId, nextToken }),
-          (page) => page.events,
-          (page) => page.nextToken,
-        ),
-
-      getEvent: (input) =>
-        dp.getEvent({ ...input, memoryId }),
-
-      deleteEvent: (input) =>
-        dp.deleteEvent({ ...input, memoryId }),
-
-      retrieveMemoryRecords: (input) =>
-        dp.retrieveMemoryRecords({ ...input, memoryId }),
-
-      listActors: () =>
-        dp.listActors({ memoryId }),
-
-      listSessions: (input) =>
-        dp.listSessions({ memoryId, actorId: input.actorId }),
-
-      getLastKTurns: (params) =>
-        getLastK({ ...params, memoryId }),
-
-      listBranches: (params) =>
-        getBranches({ ...params, memoryId }),
-    }
-
-    return scoped
-  }
-
 }
 
 function hasName(err: unknown, name: string): boolean {

--- a/src/memory/client.ts
+++ b/src/memory/client.ts
@@ -96,7 +96,9 @@ class MemoryClient extends MemoryPassthroughClient {
       return await this.controlPlane.createMemory(input)
     } catch (err: unknown) {
       if (hasName(err, 'ValidationException') && String(err).includes('already exists')) {
-        const resp = await this.controlPlane.getMemory({ memoryId: input.name })
+        const existingId = await findMemoryIdByName(this.controlPlane, input.name!)
+        if (!existingId) throw err
+        const resp = await this.controlPlane.getMemory({ memoryId: existingId })
         return { memory: resp.memory, $metadata: resp.$metadata }
       }
       throw err
@@ -225,6 +227,17 @@ class MemoryClient extends MemoryPassthroughClient {
 
 function hasName(err: unknown, name: string): boolean {
   return typeof err === 'object' && err !== null && 'name' in err && (err as { name: unknown }).name === name
+}
+
+async function findMemoryIdByName(controlPlane: BedrockAgentCoreControl, name: string): Promise<string | undefined> {
+  let nextToken: string | undefined
+  do {
+    const resp = await controlPlane.listMemories({ nextToken })
+    const match = resp.memories?.find((m) => m.id?.startsWith(`${name}-`) || m.id === name)
+    if (match?.id) return match.id
+    nextToken = resp.nextToken
+  } while (nextToken)
+  return undefined
 }
 
 export { MemoryClient }

--- a/src/memory/client.ts
+++ b/src/memory/client.ts
@@ -82,13 +82,14 @@ class MemoryClient extends MemoryPassthroughClient {
   }
 
   async createMemoryAndWait(input: CreateMemoryCommandInput, opts?: WaitOptions): Promise<CreateMemoryCommandOutput> {
-    const result = await this.controlPlane.createMemory(input)
-    const memoryId = result.memory!.id!
+    const created = await this.controlPlane.createMemory(input)
+    const memoryId = created.memory!.id!
     await this.controlPlane.waitUntilMemoryCreated({ memoryId } satisfies GetMemoryCommandInput, {
       maxWaitTime: opts?.maxWaitSeconds ?? 300,
       minDelay: opts?.pollIntervalMs ? opts.pollIntervalMs / 1000 : 10,
     })
-    return result
+    const refreshed = await this.controlPlane.getMemory({ memoryId })
+    return { memory: refreshed.memory, $metadata: refreshed.$metadata }
   }
 
   async createOrGetMemory(input: CreateMemoryCommandInput): Promise<CreateMemoryCommandOutput> {

--- a/src/memory/client.ts
+++ b/src/memory/client.ts
@@ -1,0 +1,284 @@
+import {
+  BedrockAgentCore,
+  type Conversational,
+} from '@aws-sdk/client-bedrock-agentcore'
+import {
+  BedrockAgentCoreControl,
+  type CreateMemoryCommandInput,
+  type CreateMemoryCommandOutput,
+  type GetMemoryCommandInput,
+} from '@aws-sdk/client-bedrock-agentcore-control'
+import type {
+  MemoryClientConfig,
+  ScopedMemory,
+  WaitOptions,
+  WaitForMemoriesParams,
+  GetLastKTurnsParams,
+  BranchInfo,
+  DataPlaneMethods,
+  ControlPlaneMethods,
+} from './types.js'
+import { DATA_PLANE_METHODS, CONTROL_PLANE_METHODS } from './types.js'
+import { paginateAll, DEFAULT_PAGE_SIZE } from '../_utils/pagination.js'
+import { pollUntil } from '../_utils/polling.js'
+
+const DEFAULT_REGION = 'us-west-2'
+const DATA_PLANE_SET: Set<string> = new Set(DATA_PLANE_METHODS)
+const CONTROL_PLANE_SET: Set<string> = new Set(CONTROL_PLANE_METHODS)
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+interface MemoryPassthroughClient extends DataPlaneMethods, ControlPlaneMethods {}
+
+/**
+ * Passthrough layer that routes method calls to the appropriate AWS SDK client.
+ * Uses a Proxy to forward calls listed in DATA_PLANE_METHODS and CONTROL_PLANE_METHODS.
+ * See: https://www.typescriptlang.org/docs/handbook/declaration-merging.html
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging, no-redeclare
+class MemoryPassthroughClient {
+  protected readonly dataPlane: BedrockAgentCore
+  protected readonly controlPlane: BedrockAgentCoreControl
+
+  constructor(config?: MemoryClientConfig) {
+    const region = config?.region ?? process.env.AWS_REGION ?? DEFAULT_REGION
+    const clientConfig = {
+      region,
+      ...(config?.credentialsProvider && { credentials: config.credentialsProvider }),
+    }
+    this.dataPlane = config?.dataPlaneClient ?? new BedrockAgentCore(clientConfig)
+    this.controlPlane = config?.controlPlaneClient ?? new BedrockAgentCoreControl(clientConfig)
+
+    return new Proxy(this, {
+      get(target, prop, receiver): unknown {
+        if (typeof prop === 'string') {
+          if (DATA_PLANE_SET.has(prop)) {
+            const method = (target.dataPlane as unknown as Record<string, (...args: unknown[]) => unknown>)[prop]!
+            return method.bind(target.dataPlane)
+          }
+          if (CONTROL_PLANE_SET.has(prop)) {
+            const method = (target.controlPlane as unknown as Record<string, (...args: unknown[]) => unknown>)[prop]!
+            return method.bind(target.controlPlane)
+          }
+        }
+        return Reflect.get(target, prop, receiver)
+      },
+    })
+  }
+}
+
+/**
+ * Client for AWS Bedrock AgentCore Memory.
+ *
+ * Passthrough methods from both AWS SDK clients are available directly on this
+ * class (e.g. `client.createEvent(...)`, `client.createMemory(...)`).
+ *
+ * Use `.memory(memoryId)` for memory-scoped operations.
+ *
+ * @example
+ * ```typescript
+ * const client = new MemoryClient({ region: 'us-west-2' });
+ *
+ * // Passthrough — delegates to the right AWS SDK client
+ * await client.createMemory({ name: 'my-mem', eventExpiryDuration: 30, memoryStrategies: [] });
+ *
+ * // Memory-scoped — memoryId auto-filled
+ * const mem = client.memory('mem-123');
+ * await mem.listActors();
+ * await mem.createEvent({ actorId: 'u1', sessionId: 's1', payload: [], eventTimestamp: new Date() });
+ * ```
+ */
+class MemoryClient extends MemoryPassthroughClient {
+  constructor(config?: MemoryClientConfig) {
+    super(config)
+  }
+
+  async createMemoryAndWait(
+    input: CreateMemoryCommandInput,
+    opts?: WaitOptions,
+  ): Promise<CreateMemoryCommandOutput> {
+    const result = await this.controlPlane.createMemory(input)
+    const memoryId = result.memory!.id!
+    await this.controlPlane.waitUntilMemoryCreated(
+      { memoryId } satisfies GetMemoryCommandInput,
+      { maxWaitTime: opts?.maxWaitSeconds ?? 300, minDelay: opts?.pollIntervalMs ? opts.pollIntervalMs / 1000 : 10 },
+    )
+    return result
+  }
+
+  async createOrGetMemory(input: CreateMemoryCommandInput): Promise<CreateMemoryCommandOutput> {
+    try {
+      return await this.controlPlane.createMemory(input)
+    } catch (err: unknown) {
+      if (hasName(err, 'ValidationException') && String(err).includes('already exists')) {
+        const resp = await this.controlPlane.getMemory({ memoryId: input.name })
+        return { memory: resp.memory, $metadata: resp.$metadata }
+      }
+      throw err
+    }
+  }
+
+  async deleteMemoryAndWait(memoryId: string, opts?: WaitOptions): Promise<void> {
+    await this.controlPlane.deleteMemory({ memoryId })
+    await pollUntil(
+      async () => {
+        try {
+          await this.controlPlane.getMemory({ memoryId })
+          return false
+        } catch (err: unknown) {
+          if (hasName(err, 'ResourceNotFoundException')) return true
+          throw err
+        }
+      },
+      {
+        maxWaitSeconds: opts?.maxWaitSeconds ?? 300,
+        pollIntervalMs: opts?.pollIntervalMs ?? 10_000,
+        timeoutErrorMessage: `Memory ${memoryId} was not deleted within ${opts?.maxWaitSeconds ?? 300}s`,
+      },
+    )
+  }
+
+  async waitForMemories(params: WaitForMemoriesParams): Promise<boolean> {
+    return pollUntil(
+      async () => {
+        const resp = await this.dataPlane.retrieveMemoryRecords({
+          memoryId: params.memoryId,
+          namespace: params.namespace,
+          searchCriteria: { searchQuery: params.testQuery ?? 'test' },
+        })
+        return (resp.memoryRecordSummaries?.length ?? 0) > 0
+      },
+      {
+        maxWaitSeconds: params.maxWaitSeconds ?? 180,
+        pollIntervalMs: params.pollIntervalMs ?? 15_000,
+        shouldSwallowError: () => true,
+      },
+    )
+  }
+
+  async getLastKTurns(params: GetLastKTurnsParams): Promise<Conversational[][]> {
+    const listParams: Record<string, unknown> = {
+      memoryId: params.memoryId,
+      actorId: params.actorId,
+      sessionId: params.sessionId,
+      includePayloads: true,
+      maxResults: DEFAULT_PAGE_SIZE,
+    }
+
+    if (params.branchName && params.branchName !== 'main') {
+      listParams.filter = {
+        branch: { name: params.branchName, includeParentBranches: params.includeParentBranches ?? false },
+      }
+    }
+
+    const turns: Conversational[][] = []
+    let currentTurn: Conversational[] = []
+    let nextToken: string | undefined
+
+    while (turns.length < params.k) {
+      const response = await this.dataPlane.listEvents({ ...listParams, nextToken } as Parameters<BedrockAgentCore['listEvents']>[0])
+      const events = response.events ?? []
+      if (events.length === 0) break
+
+      for (const event of events) {
+        for (const payloadItem of event.payload ?? []) {
+          if (payloadItem.conversational) {
+            if (payloadItem.conversational.role === 'USER' && currentTurn.length > 0) {
+              turns.push(currentTurn)
+              currentTurn = []
+            }
+            currentTurn.push(payloadItem.conversational)
+          }
+        }
+        if (turns.length >= params.k) break
+      }
+
+      nextToken = response.nextToken
+      if (!nextToken) break
+    }
+
+    if (currentTurn.length > 0 && turns.length < params.k) {
+      turns.push(currentTurn)
+    }
+
+    return turns.slice(0, params.k)
+  }
+
+  async listBranches(params: {
+    memoryId: string
+    actorId: string
+    sessionId: string
+  }): Promise<BranchInfo[]> {
+    const allEvents = await paginateAll(
+      (nextToken) => this.dataPlane.listEvents({ memoryId: params.memoryId, actorId: params.actorId, sessionId: params.sessionId, includePayloads: false, nextToken }),
+      (page) => page.events,
+      (page) => page.nextToken,
+    )
+
+    const branches = new Map<string, BranchInfo>()
+    for (const event of allEvents) {
+      const name = event.branch?.name ?? 'main'
+      const existing = branches.get(name)
+      if (existing) {
+        existing.eventCount++
+      } else {
+        branches.set(name, {
+          name,
+          rootEventId: event.branch?.rootEventId,
+          eventCount: 1,
+        })
+      }
+    }
+    return Array.from(branches.values())
+  }
+
+  memory(memoryId: string): ScopedMemory {
+    const dp = this.dataPlane
+    const getLastK = this.getLastKTurns.bind(this)
+    const getBranches = this.listBranches.bind(this)
+
+    const scoped: ScopedMemory = {
+      createEvent: (input) =>
+        dp.createEvent({ ...input, memoryId }),
+
+      listEvents: (input) =>
+        dp.listEvents({ ...input, memoryId }),
+
+      listAllEvents: (input) =>
+        paginateAll(
+          (nextToken) => dp.listEvents({ ...input, memoryId, nextToken }),
+          (page) => page.events,
+          (page) => page.nextToken,
+        ),
+
+      getEvent: (input) =>
+        dp.getEvent({ ...input, memoryId }),
+
+      deleteEvent: (input) =>
+        dp.deleteEvent({ ...input, memoryId }),
+
+      retrieveMemoryRecords: (input) =>
+        dp.retrieveMemoryRecords({ ...input, memoryId }),
+
+      listActors: () =>
+        dp.listActors({ memoryId }),
+
+      listSessions: (input) =>
+        dp.listSessions({ memoryId, actorId: input.actorId }),
+
+      getLastKTurns: (params) =>
+        getLastK({ ...params, memoryId }),
+
+      listBranches: (params) =>
+        getBranches({ ...params, memoryId }),
+    }
+
+    return scoped
+  }
+
+}
+
+function hasName(err: unknown, name: string): boolean {
+  return typeof err === 'object' && err !== null && 'name' in err && (err as { name: unknown }).name === name
+}
+
+export { MemoryClient }

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,7 +1,6 @@
 export { MemoryClient } from './client.js'
 export type {
   MemoryClientConfig,
-  ScopedMemory,
   BranchInfo,
   WaitOptions,
   WaitForMemoriesParams,

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,0 +1,10 @@
+export { MemoryClient } from './client.js'
+export type {
+  MemoryClientConfig,
+  ScopedMemory,
+  BranchInfo,
+  WaitOptions,
+  WaitForMemoriesParams,
+  GetLastKTurnsParams,
+  MemoryEvent,
+} from './types.js'

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -1,0 +1,100 @@
+import type { AwsCredentialIdentityProvider } from '@aws-sdk/types'
+import type {
+  CreateEventCommandInput,
+  CreateEventCommandOutput,
+  ListEventsCommandInput,
+  ListEventsCommandOutput,
+  GetEventCommandInput,
+  GetEventCommandOutput,
+  DeleteEventCommandInput,
+  DeleteEventCommandOutput,
+  RetrieveMemoryRecordsCommandInput,
+  RetrieveMemoryRecordsCommandOutput,
+  ListActorsCommandOutput,
+  ListSessionsCommandOutput,
+  Event as MemoryEvent,
+  Conversational,
+  BedrockAgentCore,
+} from '@aws-sdk/client-bedrock-agentcore'
+import type { BedrockAgentCoreControl } from '@aws-sdk/client-bedrock-agentcore-control'
+
+export const DATA_PLANE_METHODS = [
+  'createEvent',
+  'listEvents',
+  'getEvent',
+  'deleteEvent',
+  'retrieveMemoryRecords',
+  'getMemoryRecord',
+  'deleteMemoryRecord',
+  'listMemoryRecords',
+  'listActors',
+  'listSessions',
+  'batchCreateMemoryRecords',
+  'batchDeleteMemoryRecords',
+  'batchUpdateMemoryRecords',
+  'listMemoryExtractionJobs',
+  'startMemoryExtractionJob',
+] as const
+
+export const CONTROL_PLANE_METHODS = [
+  'createMemory',
+  'getMemory',
+  'listMemories',
+  'updateMemory',
+  'deleteMemory',
+] as const
+
+export type DataPlaneMethods = Pick<BedrockAgentCore, (typeof DATA_PLANE_METHODS)[number]>
+export type ControlPlaneMethods = Pick<BedrockAgentCoreControl, (typeof CONTROL_PLANE_METHODS)[number]>
+
+export interface MemoryClientConfig {
+  region?: string
+  credentialsProvider?: AwsCredentialIdentityProvider
+  dataPlaneClient?: BedrockAgentCore
+  controlPlaneClient?: BedrockAgentCoreControl
+}
+
+export interface WaitOptions {
+  maxWaitSeconds?: number
+  pollIntervalMs?: number
+}
+
+type MemoryScoped = 'memoryId'
+
+export interface ScopedMemory {
+  createEvent(input: Omit<CreateEventCommandInput, MemoryScoped>): Promise<CreateEventCommandOutput>
+  listEvents(input: Omit<ListEventsCommandInput, MemoryScoped>): Promise<ListEventsCommandOutput>
+  listAllEvents(input: Omit<ListEventsCommandInput, MemoryScoped | 'nextToken'>): Promise<MemoryEvent[]>
+  getEvent(input: Omit<GetEventCommandInput, MemoryScoped>): Promise<GetEventCommandOutput>
+  deleteEvent(input: Omit<DeleteEventCommandInput, MemoryScoped>): Promise<DeleteEventCommandOutput>
+  retrieveMemoryRecords(input: Omit<RetrieveMemoryRecordsCommandInput, MemoryScoped>): Promise<RetrieveMemoryRecordsCommandOutput>
+  listActors(): Promise<ListActorsCommandOutput>
+  listSessions(input: { actorId: string }): Promise<ListSessionsCommandOutput>
+  getLastKTurns(params: Omit<GetLastKTurnsParams, MemoryScoped>): Promise<Conversational[][]>
+  listBranches(params: { actorId: string; sessionId: string }): Promise<BranchInfo[]>
+}
+
+export interface BranchInfo {
+  name: string
+  rootEventId?: string | undefined
+  eventCount: number
+}
+
+export interface WaitForMemoriesParams {
+  memoryId: string
+  namespace: string
+  testQuery?: string
+  maxWaitSeconds?: number
+  pollIntervalMs?: number
+}
+
+export interface GetLastKTurnsParams {
+  memoryId: string
+  actorId: string
+  sessionId: string
+  k: number
+  branchName?: string
+  includeParentBranches?: boolean
+}
+
+export type { MemoryEvent }

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -1,21 +1,5 @@
 import type { AwsCredentialIdentityProvider } from '@aws-sdk/types'
-import type {
-  CreateEventCommandInput,
-  CreateEventCommandOutput,
-  ListEventsCommandInput,
-  ListEventsCommandOutput,
-  GetEventCommandInput,
-  GetEventCommandOutput,
-  DeleteEventCommandInput,
-  DeleteEventCommandOutput,
-  RetrieveMemoryRecordsCommandInput,
-  RetrieveMemoryRecordsCommandOutput,
-  ListActorsCommandOutput,
-  ListSessionsCommandOutput,
-  Event as MemoryEvent,
-  Conversational,
-  BedrockAgentCore,
-} from '@aws-sdk/client-bedrock-agentcore'
+import type { Event as MemoryEvent, BedrockAgentCore } from '@aws-sdk/client-bedrock-agentcore'
 import type { BedrockAgentCoreControl } from '@aws-sdk/client-bedrock-agentcore-control'
 
 export const DATA_PLANE_METHODS = [
@@ -57,21 +41,6 @@ export interface MemoryClientConfig {
 export interface WaitOptions {
   maxWaitSeconds?: number
   pollIntervalMs?: number
-}
-
-type MemoryScoped = 'memoryId'
-
-export interface ScopedMemory {
-  createEvent(input: Omit<CreateEventCommandInput, MemoryScoped>): Promise<CreateEventCommandOutput>
-  listEvents(input: Omit<ListEventsCommandInput, MemoryScoped>): Promise<ListEventsCommandOutput>
-  listAllEvents(input: Omit<ListEventsCommandInput, MemoryScoped | 'nextToken'>): Promise<MemoryEvent[]>
-  getEvent(input: Omit<GetEventCommandInput, MemoryScoped>): Promise<GetEventCommandOutput>
-  deleteEvent(input: Omit<DeleteEventCommandInput, MemoryScoped>): Promise<DeleteEventCommandOutput>
-  retrieveMemoryRecords(input: Omit<RetrieveMemoryRecordsCommandInput, MemoryScoped>): Promise<RetrieveMemoryRecordsCommandOutput>
-  listActors(): Promise<ListActorsCommandOutput>
-  listSessions(input: { actorId: string }): Promise<ListSessionsCommandOutput>
-  getLastKTurns(params: Omit<GetLastKTurnsParams, MemoryScoped>): Promise<Conversational[][]>
-  listBranches(params: { actorId: string; sessionId: string }): Promise<BranchInfo[]>
 }
 
 export interface BranchInfo {

--- a/tests_integ/memory.test.ts
+++ b/tests_integ/memory.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Integration tests for MemoryClient custom helpers.
+ *
+ * Covers: createMemoryAndWait, createOrGetMemory, deleteMemoryAndWait,
+ *         waitForMemories, getLastKTurns, listBranches.
+ *
+ * Requires:
+ * - AWS credentials configured (SDK credential chain)
+ * - AWS_REGION env var (defaults to us-west-2)
+ * - IAM perms: bedrock-agentcore:{Create,Get,Delete}Memory, CreateEvent,
+ *   ListEvents, RetrieveMemoryRecords
+ *
+ * Note: waitForMemories test exercises live LTM extraction and can take
+ * several minutes. It has an extended per-test timeout.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { MemoryClient } from '../src/memory/client.js'
+
+const REGION = process.env.AWS_REGION || 'us-west-2'
+const RUN_ID = Date.now()
+const createdMemoryIds = new Set<string>()
+
+describe('MemoryClient Integration Tests', () => {
+  let client: MemoryClient
+
+  beforeAll(() => {
+    client = new MemoryClient({ region: REGION })
+  })
+
+  afterAll(async () => {
+    await Promise.allSettled(Array.from(createdMemoryIds).map((memoryId) => client.deleteMemory({ memoryId })))
+  })
+
+  describe('createMemoryAndWait()', () => {
+    it('creates a memory and waits for ACTIVE status', async () => {
+      const name = `test_mem_cmw_${RUN_ID}`
+      const result = await client.createMemoryAndWait(
+        { name, eventExpiryDuration: 30 },
+        { maxWaitSeconds: 600, pollIntervalMs: 5_000 }
+      )
+
+      expect(result.memory).toBeDefined()
+      expect(result.memory!.id).toEqual(expect.any(String))
+      expect(result.memory!.status).toBe('ACTIVE')
+      createdMemoryIds.add(result.memory!.id!)
+    }, 720_000)
+  })
+
+  describe('createOrGetMemory()', () => {
+    it('returns the existing memory on the second call', async () => {
+      const name = `test_mem_cog_${RUN_ID}`
+
+      const first = await client.createOrGetMemory({ name, eventExpiryDuration: 30 })
+      const firstId = first.memory!.id!
+      createdMemoryIds.add(firstId)
+
+      const second = await client.createOrGetMemory({ name, eventExpiryDuration: 30 })
+      expect(second.memory!.id).toBe(firstId)
+    }, 60_000)
+  })
+
+  describe('deleteMemoryAndWait()', () => {
+    it('deletes a memory and polls until it is gone', async () => {
+      const name = `test_mem_del_${RUN_ID}`
+      const created = await client.createMemoryAndWait(
+        { name, eventExpiryDuration: 30 },
+        { maxWaitSeconds: 600, pollIntervalMs: 5_000 }
+      )
+      const memoryId = created.memory!.id!
+
+      await client.deleteMemoryAndWait(memoryId, { maxWaitSeconds: 600, pollIntervalMs: 5_000 })
+
+      await expect(client.getMemory({ memoryId })).rejects.toThrow()
+    }, 720_000)
+  })
+
+  describe('getLastKTurns()', () => {
+    it('groups events into conversational turns and respects k', async () => {
+      const name = `test_mem_turns_${RUN_ID}`
+      const created = await client.createMemoryAndWait(
+        { name, eventExpiryDuration: 30 },
+        { maxWaitSeconds: 600, pollIntervalMs: 5_000 }
+      )
+      const memoryId = created.memory!.id!
+      createdMemoryIds.add(memoryId)
+
+      const actorId = 'actor-1'
+      const sessionId = `session-${RUN_ID}`
+      const baseTs = new Date()
+
+      // Post two full turns: USER/ASSISTANT, USER/ASSISTANT
+      const messages: Array<{ role: 'USER' | 'ASSISTANT'; text: string }> = [
+        { role: 'USER', text: 'hello' },
+        { role: 'ASSISTANT', text: 'hi there' },
+        { role: 'USER', text: 'how are you?' },
+        { role: 'ASSISTANT', text: 'doing well' },
+      ]
+      for (let i = 0; i < messages.length; i++) {
+        await client.createEvent({
+          memoryId,
+          actorId,
+          sessionId,
+          eventTimestamp: new Date(baseTs.getTime() + i * 1000),
+          payload: [{ conversational: { role: messages[i]!.role, content: { text: messages[i]!.text } } }],
+        })
+      }
+
+      const lastOne = await client.getLastKTurns({ memoryId, actorId, sessionId, k: 1 })
+      expect(lastOne).toHaveLength(1)
+      expect(lastOne[0]!.length).toBeGreaterThanOrEqual(1)
+
+      const lastMany = await client.getLastKTurns({ memoryId, actorId, sessionId, k: 10 })
+      expect(lastMany.length).toBeGreaterThanOrEqual(1)
+      expect(lastMany.length).toBeLessThanOrEqual(10)
+    }, 720_000)
+  })
+
+  describe('listBranches()', () => {
+    it('reports main plus any branched events', async () => {
+      const name = `test_mem_branch_${RUN_ID}`
+      const created = await client.createMemoryAndWait(
+        { name, eventExpiryDuration: 30 },
+        { maxWaitSeconds: 600, pollIntervalMs: 5_000 }
+      )
+      const memoryId = created.memory!.id!
+      createdMemoryIds.add(memoryId)
+
+      const actorId = 'actor-branch'
+      const sessionId = `session-branch-${RUN_ID}`
+      const baseTs = new Date()
+
+      const root = await client.createEvent({
+        memoryId,
+        actorId,
+        sessionId,
+        eventTimestamp: baseTs,
+        payload: [{ conversational: { role: 'USER', content: { text: 'root' } } }],
+      })
+      const rootEventId = root.event!.eventId!
+
+      await client.createEvent({
+        memoryId,
+        actorId,
+        sessionId,
+        eventTimestamp: new Date(baseTs.getTime() + 1000),
+        payload: [{ conversational: { role: 'ASSISTANT', content: { text: 'main reply' } } }],
+      })
+
+      await client.createEvent({
+        memoryId,
+        actorId,
+        sessionId,
+        eventTimestamp: new Date(baseTs.getTime() + 2000),
+        branch: { name: 'alt', rootEventId },
+        payload: [{ conversational: { role: 'ASSISTANT', content: { text: 'alt reply' } } }],
+      })
+
+      const branches = await client.listBranches({ memoryId, actorId, sessionId })
+      const names = branches.map((b) => b.name).sort()
+      expect(names).toContain('main')
+      expect(names).toContain('alt')
+
+      const alt = branches.find((b) => b.name === 'alt')!
+      expect(alt.rootEventId).toBe(rootEventId)
+      expect(alt.eventCount).toBeGreaterThanOrEqual(1)
+    }, 720_000)
+  })
+
+  describe('waitForMemories()', () => {
+    it('returns true once LTM extraction produces searchable records', async () => {
+      const name = `test_mem_ltm_${RUN_ID}`
+      const strategyName = `semantic_${RUN_ID}`
+      const namespace = `/strategies/${strategyName}/actors/{actorId}`
+      const created = await client.createMemoryAndWait(
+        {
+          name,
+          eventExpiryDuration: 30,
+          memoryStrategies: [
+            {
+              semanticMemoryStrategy: {
+                name: strategyName,
+                namespaces: [namespace],
+              },
+            },
+          ],
+        },
+        { maxWaitSeconds: 600, pollIntervalMs: 10_000 }
+      )
+      const memoryId = created.memory!.id!
+      createdMemoryIds.add(memoryId)
+
+      const actorId = 'ltm-actor'
+      const sessionId = `ltm-session-${RUN_ID}`
+      const baseTs = new Date()
+
+      const messages: Array<{ role: 'USER' | 'ASSISTANT'; text: string }> = [
+        { role: 'USER', text: 'My favorite color is ultraviolet.' },
+        { role: 'ASSISTANT', text: 'Ultraviolet is a beautiful color.' },
+        { role: 'USER', text: 'I also love watching meteor showers.' },
+        { role: 'ASSISTANT', text: 'Meteor showers are spectacular.' },
+      ]
+      for (let i = 0; i < messages.length; i++) {
+        await client.createEvent({
+          memoryId,
+          actorId,
+          sessionId,
+          eventTimestamp: new Date(baseTs.getTime() + i * 1000),
+          payload: [{ conversational: { role: messages[i]!.role, content: { text: messages[i]!.text } } }],
+        })
+      }
+
+      const resolvedNamespace = namespace.replace('{actorId}', actorId)
+      const ready = await client.waitForMemories({
+        memoryId,
+        namespace: resolvedNamespace,
+        testQuery: 'favorite color',
+        maxWaitSeconds: 420,
+        pollIntervalMs: 20_000,
+      })
+      expect(ready).toBe(true)
+    }, 1_200_000)
+  })
+})

--- a/tests_integ/memory.test.ts
+++ b/tests_integ/memory.test.ts
@@ -2,16 +2,13 @@
  * Integration tests for MemoryClient custom helpers.
  *
  * Covers: createMemoryAndWait, createOrGetMemory, deleteMemoryAndWait,
- *         waitForMemories, getLastKTurns, listBranches.
+ *         getLastKTurns, listBranches.
  *
  * Requires:
  * - AWS credentials configured (SDK credential chain)
  * - AWS_REGION env var (defaults to us-west-2)
  * - IAM perms: bedrock-agentcore:{Create,Get,Delete}Memory, CreateEvent,
- *   ListEvents, RetrieveMemoryRecords
- *
- * Note: waitForMemories test exercises live LTM extraction and can take
- * several minutes. It has an extended per-test timeout.
+ *   ListEvents
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
@@ -21,7 +18,7 @@ const REGION = process.env.AWS_REGION || 'us-west-2'
 const RUN_ID = Date.now()
 const createdMemoryIds = new Set<string>()
 
-describe('MemoryClient Integration Tests', () => {
+describe.concurrent('MemoryClient Integration Tests', () => {
   let client: MemoryClient
 
   beforeAll(() => {
@@ -165,60 +162,5 @@ describe('MemoryClient Integration Tests', () => {
       expect(alt.rootEventId).toBe(rootEventId)
       expect(alt.eventCount).toBeGreaterThanOrEqual(1)
     }, 720_000)
-  })
-
-  describe('waitForMemories()', () => {
-    it('returns true once LTM extraction produces searchable records', async () => {
-      const name = `test_mem_ltm_${RUN_ID}`
-      const strategyName = `semantic_${RUN_ID}`
-      const namespace = `/strategies/${strategyName}/actors/{actorId}`
-      const created = await client.createMemoryAndWait(
-        {
-          name,
-          eventExpiryDuration: 30,
-          memoryStrategies: [
-            {
-              semanticMemoryStrategy: {
-                name: strategyName,
-                namespaces: [namespace],
-              },
-            },
-          ],
-        },
-        { maxWaitSeconds: 600, pollIntervalMs: 10_000 }
-      )
-      const memoryId = created.memory!.id!
-      createdMemoryIds.add(memoryId)
-
-      const actorId = 'ltm-actor'
-      const sessionId = `ltm-session-${RUN_ID}`
-      const baseTs = new Date()
-
-      const messages: Array<{ role: 'USER' | 'ASSISTANT'; text: string }> = [
-        { role: 'USER', text: 'My favorite color is ultraviolet.' },
-        { role: 'ASSISTANT', text: 'Ultraviolet is a beautiful color.' },
-        { role: 'USER', text: 'I also love watching meteor showers.' },
-        { role: 'ASSISTANT', text: 'Meteor showers are spectacular.' },
-      ]
-      for (let i = 0; i < messages.length; i++) {
-        await client.createEvent({
-          memoryId,
-          actorId,
-          sessionId,
-          eventTimestamp: new Date(baseTs.getTime() + i * 1000),
-          payload: [{ conversational: { role: messages[i]!.role, content: { text: messages[i]!.text } } }],
-        })
-      }
-
-      const resolvedNamespace = namespace.replace('{actorId}', actorId)
-      const ready = await client.waitForMemories({
-        memoryId,
-        namespace: resolvedNamespace,
-        testQuery: 'favorite color',
-        maxWaitSeconds: 420,
-        pollIntervalMs: 20_000,
-      })
-      expect(ready).toBe(true)
-    }, 1_200_000)
   })
 })


### PR DESCRIPTION
## Description

Merges [PR #108](https://github.com/aws/bedrock-agentcore-sdk-typescript/pull/108) (`feat: add MemoryClient for control plane + data plane passthrough`) into the `feat/agentcore-memory` feature branch so the Strands plugin work can build on top of the new `MemoryClient`.

This is a merge-forward only — no additional changes on top of PR #108's commit (`18dd5ee`).

## Related Issues

- Upstream PR: #108

## Type of Change

Other: integration merge into feature branch

## Testing

- [x] `npm run build` passes
- [x] `npm test` passes (401 tests, 19 files)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] Tests from PR #108 are included and passing
- [x] My changes generate no new warnings

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.