### PR TITLE
fix(memory): address PR #139 review feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
     "./identity": {
       "import": "./dist/src/identity/index.js",
       "types": "./dist/src/identity/index.d.ts"
+    },
+    "./memory": {
+      "import": "./dist/src/memory/index.js",
+      "types": "./dist/src/memory/index.d.ts"
     }
   },
   "scripts": {

--- a/src/_utils/__tests__/polling.test.ts
+++ b/src/_utils/__tests__/polling.test.ts
@@ -64,4 +64,29 @@ describe('pollUntil', () => {
       )
     ).rejects.toThrow('fatal')
   })
+
+  it('should run condition at least once even with maxWaitSeconds=0', async () => {
+    let called = false
+    const result = await pollUntil(
+      () => {
+        called = true
+        return Promise.resolve(false)
+      },
+      { maxWaitSeconds: 0, pollIntervalMs: 10 }
+    )
+    expect(called).toBe(true)
+    expect(result).toBe(false)
+  })
+
+  it('should return true on first attempt with maxWaitSeconds=0 when condition is met', async () => {
+    const result = await pollUntil(() => Promise.resolve(true), { maxWaitSeconds: 0, pollIntervalMs: 10 })
+    expect(result).toBe(true)
+  })
+
+  it('should not sleep past the deadline', async () => {
+    const start = Date.now()
+    await pollUntil(() => Promise.resolve(false), { maxWaitSeconds: 0.05, pollIntervalMs: 5000 })
+    const elapsed = Date.now() - start
+    expect(elapsed).toBeLessThan(1000)
+  })
 })

--- a/src/_utils/polling.ts
+++ b/src/_utils/polling.ts
@@ -16,12 +16,13 @@ export async function pollUntil(
   }
 ): Promise<boolean> {
   const deadline = Date.now() + opts.maxWaitSeconds * 1000
-  while (Date.now() < deadline) {
+  while (true) {
     try {
       if (await condition()) return true
     } catch (err) {
       if (!opts.shouldSwallowError?.(err)) throw err
     }
+    if (Date.now() + opts.pollIntervalMs > deadline) break
     await new Promise((resolve) => globalThis.setTimeout(resolve, opts.pollIntervalMs))
   }
   if (opts.timeoutErrorMessage) throw new Error(opts.timeoutErrorMessage)

--- a/src/memory/__tests__/client.test.ts
+++ b/src/memory/__tests__/client.test.ts
@@ -51,6 +51,22 @@ describe('MemoryClient', () => {
       expect(result.memory).toMatchObject({ id: 'test-abc123' })
     })
 
+    it('does not match memories with similar name prefixes', async () => {
+      const client = new MemoryClient({
+        controlPlaneClient: fakeClient({
+          createMemory: () => {
+            throw Object.assign(new Error('already exists'), { name: 'ValidationException' })
+          },
+          listMemories: () => Promise.resolve({ memories: [{ id: 'prod-east-abc123' }, { id: 'prod-abc123' }] }),
+          getMemory: (input: { memoryId: string }) =>
+            Promise.resolve({ memory: { id: input.memoryId }, $metadata: {} }),
+        }) as unknown as BedrockAgentCoreControl,
+      })
+
+      const result = await client.createOrGetMemory({ name: 'prod', eventExpiryDuration: 30 })
+      expect(result.memory).toMatchObject({ id: 'prod-abc123' })
+    })
+
     it('propagates non-conflict errors', async () => {
       const client = new MemoryClient({
         controlPlaneClient: fakeClient({
@@ -99,6 +115,28 @@ describe('MemoryClient', () => {
 
       const turns = await client.getLastKTurns({ memoryId: 'mem-1', actorId: 'a1', sessionId: 's1', k: 1 })
       expect(turns).toMatchObject([[{ role: 'USER' }, { role: 'ASSISTANT' }]])
+    })
+
+    it('returns the last K turns, not the first K', async () => {
+      const events = Array.from({ length: 10 }, (_, i) => [
+        { eventId: `e${i * 2}`, payload: [{ conversational: { role: 'USER', content: { text: `q${i + 1}` } } }] },
+        {
+          eventId: `e${i * 2 + 1}`,
+          payload: [{ conversational: { role: 'ASSISTANT', content: { text: `a${i + 1}` } } }],
+        },
+      ]).flat()
+
+      const client = new MemoryClient({
+        dataPlaneClient: fakeClient({
+          listEvents: () => Promise.resolve({ events }),
+        }) as unknown as BedrockAgentCore,
+      })
+
+      const turns = await client.getLastKTurns({ memoryId: 'mem-1', actorId: 'a1', sessionId: 's1', k: 3 })
+      expect(turns).toHaveLength(3)
+      expect(turns[0]![0]).toMatchObject({ role: 'USER', content: { text: 'q8' } })
+      expect(turns[1]![0]).toMatchObject({ role: 'USER', content: { text: 'q9' } })
+      expect(turns[2]![0]).toMatchObject({ role: 'USER', content: { text: 'q10' } })
     })
 
     it('returns all turns when k exceeds total', async () => {

--- a/src/memory/client.ts
+++ b/src/memory/client.ts
@@ -39,7 +39,9 @@ class MemoryPassthroughClient {
     const region = config?.region ?? process.env.AWS_REGION ?? DEFAULT_REGION
     const clientConfig = {
       region,
-      ...(config?.credentialsProvider && { credentials: config.credentialsProvider }),
+      ...(config?.credentials && { credentials: config.credentials }),
+      ...(config?.maxAttempts && { maxAttempts: config.maxAttempts }),
+      ...(config?.retryMode && { retryMode: config.retryMode }),
     }
     this.dataPlane = config?.dataPlaneClient ?? new BedrockAgentCore(clientConfig)
     this.controlPlane = config?.controlPlaneClient ?? new BedrockAgentCoreControl(clientConfig)
@@ -126,6 +128,13 @@ class MemoryClient extends MemoryPassthroughClient {
     )
   }
 
+  /**
+   * Poll the LTM retrieval endpoint until at least one record is returned.
+   *
+   * @returns `true` if records appeared within the timeout, `false` if timed out.
+   *          Transient service errors (throttling, 5xx) are retried silently;
+   *          configuration errors (auth, validation, not-found) are thrown immediately.
+   */
   async waitForMemories(params: WaitForMemoriesParams): Promise<boolean> {
     return pollUntil(
       async () => {
@@ -139,7 +148,14 @@ class MemoryClient extends MemoryPassthroughClient {
       {
         maxWaitSeconds: params.maxWaitSeconds ?? 180,
         pollIntervalMs: params.pollIntervalMs ?? 15_000,
-        shouldSwallowError: () => true,
+        shouldSwallowError: (err) => {
+          const name = (err as { name?: string })?.name
+          return (
+            name === 'ThrottlingException' ||
+            name === 'ServiceUnavailableException' ||
+            name === 'InternalServerException'
+          )
+        },
       }
     )
   }
@@ -159,39 +175,33 @@ class MemoryClient extends MemoryPassthroughClient {
       }
     }
 
+    const allEvents = await paginateAll(
+      (nextToken) =>
+        this.dataPlane.listEvents({ ...listParams, nextToken } as Parameters<BedrockAgentCore['listEvents']>[0]),
+      (page) => page.events,
+      (page) => page.nextToken
+    )
+
     const turns: Conversational[][] = []
     let currentTurn: Conversational[] = []
-    let nextToken: string | undefined
 
-    while (turns.length < params.k) {
-      const response = await this.dataPlane.listEvents({ ...listParams, nextToken } as Parameters<
-        BedrockAgentCore['listEvents']
-      >[0])
-      const events = response.events ?? []
-      if (events.length === 0) break
-
-      for (const event of events) {
-        for (const payloadItem of event.payload ?? []) {
-          if (payloadItem.conversational) {
-            if (payloadItem.conversational.role === 'USER' && currentTurn.length > 0) {
-              turns.push(currentTurn)
-              currentTurn = []
-            }
-            currentTurn.push(payloadItem.conversational)
+    for (const event of allEvents) {
+      for (const payloadItem of event.payload ?? []) {
+        if (payloadItem.conversational) {
+          if (payloadItem.conversational.role === 'USER' && currentTurn.length > 0) {
+            turns.push(currentTurn)
+            currentTurn = []
           }
+          currentTurn.push(payloadItem.conversational)
         }
-        if (turns.length >= params.k) break
       }
-
-      nextToken = response.nextToken
-      if (!nextToken) break
     }
 
-    if (currentTurn.length > 0 && turns.length < params.k) {
+    if (currentTurn.length > 0) {
       turns.push(currentTurn)
     }
 
-    return turns.slice(0, params.k)
+    return turns.slice(-params.k)
   }
 
   async listBranches(params: { memoryId: string; actorId: string; sessionId: string }): Promise<BranchInfo[]> {
@@ -234,7 +244,12 @@ async function findMemoryIdByName(controlPlane: BedrockAgentCoreControl, name: s
   let nextToken: string | undefined
   do {
     const resp = await controlPlane.listMemories({ nextToken })
-    const match = resp.memories?.find((m) => m.id?.startsWith(`${name}-`) || m.id === name)
+    const match = resp.memories?.find((m) => {
+      if (m.id === name) return true
+      if (!m.id?.startsWith(`${name}-`)) return false
+      const suffix = m.id.slice(name.length + 1)
+      return /^[a-z0-9]+$/i.test(suffix)
+    })
     if (match?.id) return match.id
     nextToken = resp.nextToken
   } while (nextToken)

--- a/src/memory/client.ts
+++ b/src/memory/client.ts
@@ -182,7 +182,6 @@ class MemoryClient extends MemoryPassthroughClient {
       (page) => page.nextToken
     )
 
-    // Sort by timestamp ascending to guarantee chronological order regardless of API default
     allEvents.sort((a, b) => (a.eventTimestamp?.getTime() ?? 0) - (b.eventTimestamp?.getTime() ?? 0))
 
     const turns: Conversational[][] = []

--- a/src/memory/client.ts
+++ b/src/memory/client.ts
@@ -182,6 +182,9 @@ class MemoryClient extends MemoryPassthroughClient {
       (page) => page.nextToken
     )
 
+    // Sort by timestamp ascending to guarantee chronological order regardless of API default
+    allEvents.sort((a, b) => (a.eventTimestamp?.getTime() ?? 0) - (b.eventTimestamp?.getTime() ?? 0))
+
     const turns: Conversational[][] = []
     let currentTurn: Conversational[] = []
 

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -33,7 +33,10 @@ export type ControlPlaneMethods = Pick<BedrockAgentCoreControl, (typeof CONTROL_
 
 export interface MemoryClientConfig {
   region?: string
-  credentialsProvider?: AwsCredentialIdentityProvider
+  /** Credential provider function (e.g. fromSSO, fromTemporaryCredentials). */
+  credentials?: AwsCredentialIdentityProvider
+  maxAttempts?: number
+  retryMode?: 'standard' | 'adaptive'
   dataPlaneClient?: BedrockAgentCore
   controlPlaneClient?: BedrockAgentCoreControl
 }

--- a/tests_integ/memory.test.ts
+++ b/tests_integ/memory.test.ts
@@ -105,11 +105,17 @@ describe.concurrent('MemoryClient Integration Tests', () => {
 
       const lastOne = await client.getLastKTurns({ memoryId, actorId, sessionId, k: 1 })
       expect(lastOne).toHaveLength(1)
-      expect(lastOne[0]!.length).toBeGreaterThanOrEqual(1)
+      // k=1 should return the LAST turn (the second USER/ASSISTANT pair)
+      const lastTurnUser = lastOne[0]!.find((m) => m.role === 'USER')
+      expect(lastTurnUser?.content?.text).toBe('how are you?')
+      const lastTurnAssistant = lastOne[0]!.find((m) => m.role === 'ASSISTANT')
+      expect(lastTurnAssistant?.content?.text).toBe('doing well')
 
       const lastMany = await client.getLastKTurns({ memoryId, actorId, sessionId, k: 10 })
-      expect(lastMany.length).toBeGreaterThanOrEqual(1)
-      expect(lastMany.length).toBeLessThanOrEqual(10)
+      expect(lastMany).toHaveLength(2)
+      // First turn in the result should be the earlier one
+      const firstTurnUser = lastMany[0]!.find((m) => m.role === 'USER')
+      expect(firstTurnUser?.content?.text).toBe('hello')
     }, 720_000)
   })
 


### PR DESCRIPTION
## Description

Addresses all review comments from PR #139. Key fixes:

- **`getLastKTurns` correctness** — was returning the first K turns instead of the last K. Now paginates all events and slices the tail.
- **`findMemoryIdByName` collision** — prefix match `prod` could match `prod-east-xxx`. Tightened to require a single alphanumeric suffix segment.
- **`waitForMemories` error handling** — was swallowing all errors (including auth/config). Now only swallows transient errors (throttling, 5xx).
- **`pollUntil` edge cases** — `maxWaitSeconds: 0` now runs at least one attempt; no longer sleeps past deadline.
- **`credentialsProvider` → `credentials`** — renamed to match AWS SDK v3 convention.
- **`maxAttempts`/`retryMode`** — added to `MemoryClientConfig` and passed through to SDK clients.
- **`./memory` export** — added to `package.json` exports map.
- **JSDoc** — added `@returns` documentation to `waitForMemories`.

## Related Issues

Addresses review comments on #139

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- [x] Added unit tests for last-K-turns ordering (10 turns, request k=3, assert turns 8-10)
- [x] Added unit test for name-collision rejection (prod vs prod-east)
- [x] Added unit tests for pollUntil edge cases (maxWaitSeconds=0, no sleep past deadline)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.