### PR TITLE
feat(memory): AgentCoreMemory plugin for Strands SDK

### DIFF
--- a/.workspace/notes/implementation-plan.md
+++ b/.workspace/notes/implementation-plan.md
@@ -1,0 +1,497 @@
+# AgentCoreMemory Plugin — Implementation Plan
+
+**Status:** Approved (Ralplan consensus: Planner → Architect → Critic)
+**Date:** 2026-04-22
+**Branch:** `feat/agentcore-memory` → feature branches per step
+
+---
+
+## RALPLAN-DR Summary
+
+### Principles
+1. Memory is never critical path — all failures log + continue, never crash the agent
+2. Follow existing SDK patterns — mirror integrations/strands/ directory structure
+3. Plugin interface is the contract — implement Strands Plugin (0.7.0)
+4. Extraction and injection are independent — customer opts into each separately
+5. Batch by default — reduce API call volume without customer effort
+
+### Decision Drivers
+1. API shape matches team consensus — `extraction:`/`injection:` naming, `automatic`/`searchTool` booleans
+2. MemoryClient is the only integration surface — `createEvent()` and `retrieveMemoryRecords()`
+3. Existing tool patterns set the structure — `src/memory/integrations/strands/`
+
+### Chosen Option: Single Plugin class + tool factory
+Single `AgentCoreMemory` class implementing Plugin interface, with internal helper functions (not classes) for formatting and batching. Also exports `createSearchMemoryTool` as a standalone factory for advanced composability.
+
+---
+
+## Naming Changes from Design Doc
+
+The following names were changed per team review consensus (Quip comments). The design doc examples still use the old names and will need updating:
+
+| Design Doc | Implementation | Rationale |
+|---|---|---|
+| `AgentCoreMemoryPlugin` | `AgentCoreMemory` | Jack Yuan: "Plugin doesn't need Plugin in the name" |
+| `storeMessages:` | `extraction:` | Team consensus: options 1 or 3 from Quip thread |
+| `injectContext:` | `injection:` | Parallel naming with extraction |
+| `mode: 'tool'` | `automatic: false, searchTool: true` | Jesse's `automaticInjection` suggestion (2 likes) |
+| `bedrock-agentcore/memory/strands` | `bedrock-agentcore/experimental/memory/strands` | Matches existing SDK export convention |
+
+## Design Decision Resolutions
+
+Open questions from the design doc, resolved during review:
+
+| Question | Resolution | Source |
+|---|---|---|
+| Prefetch mode needed on day one? | No — deferred until customer demand | Design doc Decision 1 recommendation, no objection |
+| searchTool auto vs explicit opt-in? | Explicit opt-in (`searchTool: false` default) | Design doc recommendation adopted |
+| batchSize default? | 10 (match Python SDK) | Design doc Decision 2, no objection |
+| Built-in filter presets? | Deferred — leave filtering to customer via `messageFilter` | No team feedback requesting presets |
+| Auto-derive namespace labels? | Yes, from path | Design doc Decision 3 recommendation adopted |
+| Staleness metadata in injection? | Deferred — not enough signal to justify extra tokens | No team feedback requesting it |
+| contextTag configurability? | Yes — TJ requested it | Quip comment, moved from open question |
+| System prompt reinforcement for tool mode? | No — TJ + Mackenzie consensus | Quip comment: "shouldn't interfere with customer's system prompt" |
+| Await vs fire-and-forget flush? | Await by default, `fireAndForget: true` escape hatch | Aidan's decision |
+
+## Why BeforeInvocationEvent, Not BeforeModelCallEvent
+
+We considered `BeforeModelCallEvent` for injection — it fires after user message is appended, so the current user message would be available as a search query. We rejected it because `BeforeModelCallEvent` fires on **every model call within an invocation**, including after each tool-use loop iteration. With ephemeral injection, this would mean stripping and re-injecting memory context (with a retrieval API call) on every loop iteration — wasteful and potentially 5-10x the API calls per turn for tool-heavy agents. `BeforeInvocationEvent` fires once per invocation, which is the right granularity.
+
+## Verified Strands SDK 0.7.0 Facts
+
+- `Plugin` interface: `{ readonly name: string; initAgent(agent: LocalAgent): void | Promise<void>; getTools?(): Tool[] }`
+- `AgentConfig` has `plugins?: Plugin[]`
+- `initAgent()` receives the `Agent` instance at runtime (typed as `LocalAgent`, but Agent passes `this`)
+- `systemPrompt` is on `Agent`, NOT on `LocalAgent` — must cast in initAgent
+- `BeforeInvocationEvent` fires BEFORE user message is appended to `agent.messages`
+- **`MessageAddedEvent` DOES fire for user input** despite JSDoc claiming otherwise. Verified: `_appendMessage()` is called for user messages and yields `MessageAddedEvent`. The JSDoc is stale.
+- `AfterInvocationEvent` fires in the `finally` block (always runs)
+- `SystemPrompt = string | SystemContentBlock[]` where `SystemContentBlock = TextBlock | CachePointBlock | GuardContentBlock`
+
+## MemoryClient API Surface (PR #139, merged)
+
+- `createEvent({ memoryId, actorId, sessionId, eventTimestamp, payload, metadata?, clientToken? })` — single event, NO batch event API. `payload` is `PayloadType[]` (array — can hold multiple conversational items per event). `clientToken` enables idempotent retries.
+- `retrieveMemoryRecords({ memoryId, namespace, searchCriteria: { searchQuery, topK? } })` — `namespace` is a **prefix filter** (not exact match). One call per namespace needed for per-namespace `topK` control. Requires `searchQuery` string.
+- Payload: `PayloadType[] where ConversationalMember = { conversational: { role: Role, content: { text: string } } }`
+- Role: AWS SDK uses uppercase `'USER' | 'ASSISTANT' | 'TOOL' | 'OTHER'`. Strands uses lowercase `'user' | 'assistant'`.
+- MetadataValue: discriminated union `{ stringValue: string; $unknown?: never }` from `@aws-sdk/client-bedrock-agentcore`
+
+---
+
+## Step 1: Types & Configuration
+
+**File:** `src/memory/integrations/strands/types.ts`
+**Tests:** Type-only — TypeScript compiler validates
+
+```typescript
+export interface NamespaceConfig {
+  topK?: number              // default: 5
+  relevanceScore?: number    // client-side post-filter on response scores (NOT an API param)
+                             // records below this threshold are dropped after retrieval
+}
+
+export interface ExtractionConfig {
+  batchSize?: number              // default: 10
+  batchTimeoutMs?: number         // default: 5000
+  messageFilter?: (message: Message) => boolean
+  fireAndForget?: boolean         // default: false (await flush)
+}
+
+export interface InjectionConfig {
+  namespaces: Record<string, NamespaceConfig>
+  automatic?: boolean              // default: true
+  searchTool?: boolean             // default: false
+  maxInjectionChars?: number       // default: 8000 (~2000 tokens)
+  contextTag?: string              // default: 'agentcore_memory'
+  formatMemories?: (records: MemoryRecordGroup[]) => string
+}
+
+export interface AgentCoreMemoryConfig {
+  memoryId: string
+  actorId: string
+  sessionId: string
+  extraction?: boolean | ExtractionConfig    // Resolution: undefined/false = disabled,
+                                             // true/{} = enabled with defaults,
+                                             // { batchSize: 20 } = enabled with overrides
+  injection?: InjectionConfig
+  metadataProvider?: (message: Message) => Record<string, MetadataValue>
+  memoryClient?: MemoryClientConfig
+}
+
+export interface MemoryRecordGroup {
+  namespace: string
+  label: string              // auto-derived: '/facts/{actorId}/' → 'facts'
+  records: MemoryRecord[]
+}
+
+export interface MemoryRecord {
+  content: string
+  score?: number
+  createdAt?: Date
+}
+
+// Internal — defaults applied
+export interface ResolvedExtractionConfig {
+  batchSize: number          // 10
+  batchTimeoutMs: number     // 5000
+  messageFilter: (message: Message) => boolean  // () => true
+  fireAndForget: boolean     // false
+}
+```
+
+---
+
+## Step 2: Formatting & Utilities
+
+**File:** `src/memory/integrations/strands/format.ts`
+**Tests:** `src/memory/integrations/strands/__tests__/format.test.ts` — pure functions, no mocks
+
+### Functions
+
+**`deriveLabel(namespacePath: string): string`**
+- Split on `/`, filter out empty strings and `{...}` placeholders, return the last remaining segment
+- If no segments remain, return the full path stripped of `{...}` and `/`
+- Examples: `/facts/{actorId}/` → `facts`, `/preferences/{actorId}/summaries/` → `summaries`, `/{actorId}/` → path itself, `/facts/` → `facts`
+
+**`formatMemoryBlock(groups: MemoryRecordGroup[], contextTag: string): string`**
+- If groups contain zero total records, return empty string (caller skips injection)
+- Produces: `<agentcore_memory>\nThe following are relevant memories...\n\n[facts]\n- record1\n...\n</agentcore_memory>`
+
+**`truncateToCharBudget(groups: MemoryRecordGroup[], maxChars: number): MemoryRecordGroup[]`**
+- Flatten all records across groups, sort by score **descending** (most relevant first). Records with `undefined` score are treated as score 0 (least relevant).
+- Take records from the top until cumulative char count exceeds `maxChars`. Discard the rest.
+- Reconstruct groups from the surviving records.
+
+**`stripMemoryBlock(prompt: SystemPrompt | undefined, tag: string): SystemPrompt | undefined`**
+- **Escape `tag` for regex metacharacters** before building the pattern (e.g., `memory.v2` → `memory\.v2`)
+- Three code paths:
+  - `undefined` → return undefined
+  - `string` → regex `<escaped_tag>[\s\S]*?</escaped_tag>` with global flag `/g` to strip all occurrences. Do NOT trim (preserve customer whitespace).
+  - `SystemContentBlock[]` → map TextBlocks: strip tag content from text, filter out empty blocks, pass CachePointBlock/GuardContentBlock through unchanged
+
+**`appendMemoryBlock(prompt: SystemPrompt | undefined, block: string): SystemPrompt`**
+- `undefined` → return block as string
+- `string` → `${prompt}\n\n${block}`
+- `SystemContentBlock[]` → `[...prompt, { text: block }]` (preserves CachePointBlocks)
+
+**`extractText(message: Message): string`**
+- Iterate `message.content` (which is `ContentBlock[]`), concatenate text from supported block types:
+  - `TextBlock` → use `.text`
+  - `ToolUseBlock` → stringify as `[tool_use: ${name}(${JSON.stringify(input)})]`
+  - `ToolResultBlock` → extract text from `.content` (which is `TextBlock | JsonBlock`)
+  - `ReasoningBlock` → use `.text` if present
+  - `ImageBlock`, `VideoBlock`, `DocumentBlock` → skip (lossy — binary content not extractable)
+  - `CachePointBlock`, `GuardContentBlock`, `CitationsBlock` → skip
+- Multi-modal messages are lossy by design — only text-representable content is extracted.
+
+**`mapRole(message: Message): 'USER' | 'ASSISTANT'`**
+- `message.role === 'user'` → `'USER'`
+- `message.role === 'assistant'` → `'ASSISTANT'`
+- Strands only has two roles. Tool results are `user`-role messages with `ToolResultBlock` content — they map to `'USER'` (the service handles the distinction via content inspection).
+
+---
+
+## Step 3: search_memory Tool Factory
+
+**File:** `src/memory/integrations/strands/search-memory-tool.ts`
+**Tests:** `src/memory/integrations/strands/__tests__/search-memory-tool.test.ts` — mock MemoryClient
+
+Follows the `createExecuteCodeTool()` pattern from code-interpreter:
+
+```typescript
+import { tool } from '@strands-agents/sdk'
+import { z } from 'zod'
+
+export function createSearchMemoryTool(
+  client: MemoryClient,
+  config: { memoryId: string; namespaces: Record<string, NamespaceConfig> }
+) {
+  return tool({
+    name: 'search_memory',
+    description: 'Search long-term memory for relevant user context, preferences, or past interactions.',
+    inputSchema: z.object({
+      query: z.string().describe('What to search for in memory'),
+      namespace: z.string().optional().describe('Specific namespace to search (default: all configured)'),
+    }),
+    callback: async ({ query, namespace }) => {
+      // If namespace specified, search only that one. Otherwise search all configured.
+      // Format results and return as string.
+    },
+  })
+}
+```
+
+---
+
+## Step 4: AgentCoreMemory Plugin Class
+
+**File:** `src/memory/integrations/strands/plugin.ts`
+**Tests:** `src/memory/integrations/strands/__tests__/plugin.test.ts`
+
+### Class Shape
+
+```typescript
+export class AgentCoreMemory implements Plugin {
+  readonly name = 'agentcore-memory'
+
+  private client: MemoryClient
+  private config: AgentCoreMemoryConfig
+  private extractionConfig: ResolvedExtractionConfig | null
+  private injectionConfig: InjectionConfig | null
+  private agent!: AgentWithSystemPrompt  // set in initAgent
+  private initialized = false            // guard against double-registration
+  private buffer: Message[] = []
+  private flushTimer?: ReturnType<typeof setTimeout>
+  private flushing = false               // guard against concurrent flushes
+  private searchMemoryTool?: ReturnType<typeof createSearchMemoryTool>
+
+  constructor(config: AgentCoreMemoryConfig)
+
+  // --- Plugin interface ---
+  initAgent(agent: LocalAgent): void     // throws if called twice on same instance
+  getTools(): Tool[]
+
+  // --- Multi-agent helpers ---
+  withActor(actorId: string): AgentCoreMemory       // returns uninitialized instance for new Agent
+  withMetadataProvider(fn: MetadataProviderFn): AgentCoreMemory
+
+  // --- Private: Injection ---
+  private async handleBeforeInvocation(): Promise<void>
+  private async retrieveAndInject(): Promise<void>
+  private getSearchQuery(): string
+  private buildGenericQuery(): string    // e.g., "Retrieve relevant context about: facts, preferences"
+
+  // --- Private: Extraction ---
+  private handleMessageAdded(event: MessageAddedEvent): void
+  private async handleAfterInvocation(): Promise<void>
+  private bufferMessage(message: Message): void
+  private shouldBuffer(message: Message): boolean
+  private async flushBuffer(): Promise<void>
+  private createEventFromMessage(message: Message): Promise<CreateEventCommandOutput>
+  private generateClientToken(message: Message, index: number): string
+  private clearFlushTimer(): void
+}
+```
+
+### Key Implementation Details
+
+**initAgent — conditional hook registration + double-registration guard:**
+```typescript
+initAgent(agent: LocalAgent): void {
+  if (this.initialized) {
+    throw new Error('AgentCoreMemory plugin already initialized. Use withActor() or withMetadataProvider() to create a new instance for a different agent.')
+  }
+  this.initialized = true
+  this.agent = agent as unknown as AgentWithSystemPrompt
+
+  if (this.injectionConfig?.automatic !== false) {
+    agent.addHook(BeforeInvocationEvent, () => this.handleBeforeInvocation())
+  }
+  if (this.extractionConfig) {
+    agent.addHook(MessageAddedEvent, (e) => this.handleMessageAdded(e))
+    agent.addHook(AfterInvocationEvent, () => this.handleAfterInvocation())
+  }
+}
+```
+
+**Injection — search query strategy:**
+- BeforeInvocationEvent fires BEFORE user message is appended
+- Use last message in `agent.messages` (previous turn's content)
+- Fresh session with empty messages: `buildGenericQuery()` derives from namespace paths, e.g., `"Retrieve relevant context about: facts, preferences"` from `/facts/{actorId}/` and `/preferences/{actorId}/`
+- Retrieve from all configured namespaces in parallel via `Promise.all()` (N calls needed for per-namespace `topK`)
+- If all namespaces return zero records, **skip injection entirely** (don't inject empty block)
+- Apply client-side `relevanceScore` post-filter: drop records with `score < config.relevanceScore` after retrieval
+
+**Extraction — simplified (MessageAddedEvent fires for ALL messages including user):**
+- **Key finding:** Despite the JSDoc, `MessageAddedEvent` DOES fire for user input in SDK 0.7.0 (verified in source). The `_appendMessage()` method yields `MessageAddedEvent` for all messages.
+- This simplifies extraction: `handleMessageAdded` receives ALL messages (user, assistant, tool results). No index-diffing needed.
+- `handleMessageAdded`: apply `messageFilter`, then `bufferMessage()`
+- Buffer flushed when `buffer.length >= batchSize` (early flush) OR at `AfterInvocationEvent` (end-of-turn flush)
+- `batchTimeoutMs` timer: started on first `bufferMessage()` after buffer was empty. Cleared in `flushBuffer()` and in `handleAfterInvocation()`.
+
+**Flush — Promise.allSettled + clientToken + retry-once-then-drop:**
+```
+1. If this.flushing, return (guard against concurrent flush from timer + AfterInvocation)
+2. this.flushing = true
+3. Copy buffer, clear buffer, clear timer
+4. Promise.allSettled(toFlush.map((msg, i) => createEventFromMessage(msg, i)))
+5. Collect rejected results
+6. If any rejected: Promise.allSettled(retry failed ones with same clientTokens)
+7. If still rejected: log warning with count, drop
+8. this.flushing = false
+```
+
+**Message-to-Event conversion:**
+```typescript
+private createEventFromMessage(message: Message, index: number): Promise<CreateEventCommandOutput> {
+  return this.client.createEvent({
+    memoryId: this.config.memoryId,
+    actorId: this.config.actorId,
+    sessionId: this.config.sessionId,
+    eventTimestamp: new Date(),
+    clientToken: this.generateClientToken(message, index),
+    payload: [{ conversational: { role: mapRole(message), content: { text: extractText(message) } } }],
+    ...(this.config.metadataProvider && { metadata: this.config.metadataProvider(message) }),
+  })
+}
+```
+
+**Note on payload batching opportunity:** The `payload` field accepts an array of items. A future optimization could batch an entire turn's messages into a single `createEvent` call with multiple payload items, reducing API calls further. For v1, we use one event per message for simplicity and clearer event-to-message mapping.
+```
+
+**Error handling in hooks:**
+```typescript
+private async handleBeforeInvocation(): Promise<void> {
+  try {
+    await this.retrieveAndInject()
+  } catch (err) {
+    // Strip any existing memory block (don't leave stale data)
+    this.agent.systemPrompt = stripMemoryBlock(this.agent.systemPrompt, this.injectionConfig!.contextTag ?? 'agentcore_memory')
+    console.warn('[agentcore-memory] Injection failed, continuing without memory context:', err)
+  }
+}
+```
+
+**withActor / withMetadataProvider:**
+- Return new `AgentCoreMemory` instance with overridden config
+- Share the MemoryClient instance (no reason to create a new one)
+- Fresh buffer (independent extraction state)
+
+---
+
+## Step 5: Exports & Package Configuration
+
+**File:** `src/memory/integrations/strands/index.ts`
+```typescript
+export { AgentCoreMemory } from './plugin.js'
+export { createSearchMemoryTool } from './search-memory-tool.js'
+export type {
+  AgentCoreMemoryConfig,
+  ExtractionConfig,
+  InjectionConfig,
+  NamespaceConfig,
+  MemoryRecordGroup,
+  MemoryRecord,
+} from './types.js'
+```
+
+**package.json updates:**
+```json
+// exports
+"./experimental/memory/strands": {
+  "import": "./dist/src/memory/integrations/strands/index.js",
+  "types": "./dist/src/memory/integrations/strands/index.d.ts"
+}
+
+// devDependencies
+"@strands-agents/sdk": "^0.7.0"
+
+// peerDependencies
+"@strands-agents/sdk": ">=0.7.0"
+```
+
+---
+
+## Step 6: Integration Tests
+
+**File:** `tests_integ/memory-strands.test.ts`
+
+Pattern matches existing `tests_integ/memory.test.ts`. Use a **real Strands Agent with a mock Model** — do not manually simulate hooks. This ensures the real event ordering drives the plugin and catches assumptions like the MessageAddedEvent user-input behavior.
+
+1. Create memory resource via `createMemoryAndWait()`
+2. Create `AgentCoreMemory` plugin with extraction + injection
+3. Create a real `Agent` with the plugin and a mock Model that returns canned responses
+4. Invoke the agent with a user message — real Strands event machinery drives hooks
+5. Verify events created via `listEvents()` (user + assistant messages extracted)
+6. Wait for LTM insights via `waitForMemories()`
+7. Invoke the agent again — verify injection retrieves and injects LTM into systemPrompt
+8. Test search_memory tool callback directly (with real MemoryClient)
+9. Cleanup: delete memory resource
+
+---
+
+## Build Sequence
+
+```
+Step 1: types.ts              (no deps)           ─┐
+Step 2: format.ts             (depends on types)    ├── parallelizable
+Step 3: search-memory-tool.ts (depends on types)   ─┘
+Step 4: plugin.ts             (depends on 1-3)
+Step 5: index.ts + package.json (depends on 4)
+Step 6: integration tests     (depends on 5)
+```
+
+## Known Limitations to Document
+
+These should be documented in the plugin's JSDoc and/or README:
+
+1. **Snapshot rewinding may cause duplicate extraction.** If a customer restores an older snapshot (rewinding from turn 10 to turn 3), the plugin will re-extract messages that were already extracted in the original session. The service handles duplicates gracefully (no data corruption), but it's wasted API calls and may produce redundant LTM insights. Branching (when Strands adds support) is the proper solution.
+
+2. **First-turn injection uses a generic search query.** `BeforeInvocationEvent` fires before the user's message is appended to `agent.messages`. On the first turn of a fresh session, there are no previous messages to use as a search query, so a generic fallback is used. LTM insights are broad enough that this still returns useful results, but relevance may be lower on the very first turn.
+
+3. **`systemPrompt` access requires type cast.** The Plugin interface's `initAgent()` receives `LocalAgent`, which does not expose `systemPrompt`. The runtime value is the full `Agent` instance, so we cast. If Strands changes this internal behavior, the cast would break. This is mitigated by the peer dependency pin (`>=0.7.0`).
+
+4. **No `mode` field.** The design doc originally proposed `mode: 'ephemeral' | 'tool' | 'prefetch'`. Per team review, this was simplified to two independent booleans: `automatic` (default true) and `searchTool` (default false). `prefetch` mode is deferred until customer demand.
+
+5. **`fireAndForget: true` may lose messages on process exit.** When enabled, extraction flushes are not awaited. If the process exits before the flush completes (Lambda cold shutdown, container eviction), buffered messages are silently lost. Do not use `fireAndForget: true` in Lambda or other short-lived processes.
+
+6. **`automatic: false` + `searchTool: false` is a valid but useless state.** If injection is configured with namespaces but both booleans are false, the plugin does nothing for injection. The constructor should log a warning for this degenerate configuration.
+
+## Git Workflow
+
+Each step = feature branch off `feat/agentcore-memory` → PR targeting `feat/agentcore-memory`.
+
+---
+
+## Acceptance Criteria
+
+1. `npm run build` passes with no type errors
+2. `npm test` passes with >=60% coverage on new files
+3. `import { AgentCoreMemory } from 'bedrock-agentcore/experimental/memory/strands'` resolves
+4. Plugin conditionally registers only hooks for enabled features
+5. Plugin registers `search_memory` tool only when `injection.searchTool = true`
+6. Extraction flushes via `Promise.allSettled()` with `clientToken` for idempotent retries + retry-once-then-drop
+7. Extraction captures ALL messages via `MessageAddedEvent` (including user input — no index-diffing)
+8. Injection strips stale `<contextTag>` block (with escaped regex), retrieves fresh LTM, injects into systemPrompt
+9. Injection handles `string`, `SystemContentBlock[]`, and `undefined` systemPrompt types
+10. Injection skips when all namespaces return zero records (no empty block injected)
+11. All failures log warning and continue (never throw from hooks)
+12. `withActor()` and `withMetadataProvider()` return independent uninitialized instances with shared MemoryClient
+13. `extraction: true` and `extraction: {}` both resolve to default config `{ batchSize: 10, batchTimeoutMs: 5000 }`
+14. `messageFilter` callback applied before buffering
+15. `maxInjectionChars` truncates least-relevant records (score descending, undefined scores treated as 0)
+16. `formatMemories` override replaces default formatter entirely
+17. `initAgent()` throws if called twice on the same instance
+18. `flushing` guard prevents concurrent flushes from timer + AfterInvocationEvent
+19. Integration test uses real Agent with mock Model (not manual hook simulation)
+20. Integration test proves end-to-end: extraction → wait for LTM → injection retrieves results
+
+---
+
+## Review Notes (Incorporated)
+
+### Architect + Critic Review (Ralplan consensus)
+- Plugin interface confirmed in SDK 0.7.0 — no HookProvider fallback needed
+- systemPrompt access: cast `LocalAgent` in initAgent (Agent passes `this` at runtime)
+- searchQuery for injection: use last message in agent.messages; generic fallback for fresh sessions
+- SystemPrompt type: three code paths (string, array, undefined)
+- Flush: Promise.allSettled() with retry, not Promise.all()
+- Also export createSearchMemoryTool as standalone factory for composability
+- Branching: hardcode to main branch
+- Concurrency: Strands acquireLock() handles it, no plugin-level mutex
+
+### Grumpy Reviewer Findings (5 independent reviewers, post-approval)
+- **MessageAddedEvent DOES fire for user input** in 0.7.0 (JSDoc is stale). Simplified extraction: use MessageAddedEvent for all messages, dropped index-diffing hack.
+- **`relevanceScore` is not an API input param** — clarified as client-side post-filter on response scores
+- **`extractText()` is non-trivial** — specified behavior per ContentBlock type (TextBlock, ToolUseBlock, ToolResultBlock, skip binary)
+- **Role mapping** — Strands lowercase → AWS SDK uppercase, explicitly defined
+- **Payload batching opportunity** — deferred to v2, documented rationale
+- **`clientToken`** — added for idempotent retry safety
+- **Double-registration guard** — throw if `initAgent` called twice
+- **Regex tag escaping** — escape `contextTag` before building strip pattern
+- **Empty injection skip** — skip when zero records across all namespaces
+- **`fireAndForget` data loss** — added to Known Limitations
+- **Integration tests** — use real Agent with mock Model, not manual hook simulation
+- **Naming changes documented** — added explicit table mapping old → new names
+- **`extraction: {}` behavior** — documented resolution logic (same as `true`)
+- **BeforeModelCallEvent rejection rationale** — documented why it fires too often for injection

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
       "devDependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.0-beta.67",
         "@aws-sdk/client-cognito-identity-provider": "^3.957.0",
-        "@strands-agents/sdk": "^0.6.0",
+        "@eslint/js": "^10.0.1",
+        "@strands-agents/sdk": "^0.7.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/express": "^5.0.6",
@@ -57,7 +58,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@strands-agents/sdk": ">=0.1.0",
+        "@strands-agents/sdk": ">=0.7.0",
         "ai": ">=6.0.0-beta",
         "playwright": ">=1.56.0",
         "react": ">=18.0.0",
@@ -2180,6 +2181,27 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
@@ -2637,6 +2659,7 @@
       "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -2651,6 +2674,7 @@
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -2668,6 +2692,7 @@
       "integrity": "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
@@ -2689,6 +2714,7 @@
       "integrity": "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
@@ -2707,6 +2733,7 @@
       "integrity": "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
@@ -2730,6 +2757,7 @@
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
@@ -2748,6 +2776,7 @@
       "integrity": "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
@@ -2767,6 +2796,7 @@
       "integrity": "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
@@ -2785,6 +2815,7 @@
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
@@ -2804,6 +2835,7 @@
       "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14"
@@ -2851,6 +2883,7 @@
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/base64": {
@@ -2859,6 +2892,7 @@
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/codegen": {
@@ -2867,6 +2901,7 @@
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -2875,6 +2910,7 @@
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/fetch": {
@@ -2883,6 +2919,7 @@
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -2895,6 +2932,7 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/inquire": {
@@ -2903,6 +2941,7 @@
       "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/path": {
@@ -2911,6 +2950,7 @@
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/pool": {
@@ -2919,6 +2959,7 @@
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/utf8": {
@@ -2927,6 +2968,7 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3864,32 +3906,40 @@
       "license": "MIT"
     },
     "node_modules/@strands-agents/sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@strands-agents/sdk/-/sdk-0.6.0.tgz",
-      "integrity": "sha512-Ve5ydbz0jzSf2r8Cr4iQbEkm95WjkcnvhbiHTbHFo60PPgkSK5VD66A6l1qb9XBqSywfQZnyWrQUrCpCP3OiNA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@strands-agents/sdk/-/sdk-0.7.0.tgz",
+      "integrity": "sha512-rTfRQ/p7BnoD+ODLwO8+6M4/skPdxthobVsFchmY8PkbRWMkmhTYTsmGv5Nl9Jz+yONJWK0K2pEww1WtLFAfHw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.943.0",
+        "@types/json-schema": "^7.0.15",
         "uuid": "^10.0.0"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@a2a-js/sdk": "^0.3.10",
         "@anthropic-ai/sdk": "^0.71.2",
         "@aws-sdk/client-s3": "^3.943.0",
         "@google/genai": "^1.40.0",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.57.2",
         "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
         "@opentelemetry/resources": "^1.30.1",
+        "@opentelemetry/sdk-metrics": "^1.30.1",
         "@opentelemetry/sdk-trace-base": "^1.30.1",
         "@opentelemetry/sdk-trace-node": "^1.30.1",
+        "express": "^5.1.0",
         "openai": "^6.7.0",
         "zod": "^4.1.12"
       },
       "peerDependenciesMeta": {
+        "@a2a-js/sdk": {
+          "optional": true
+        },
         "@anthropic-ai/sdk": {
           "optional": true
         },
@@ -3899,7 +3949,25 @@
         "@google/genai": {
           "optional": true
         },
+        "@opentelemetry/exporter-metrics-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-metrics": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
         "@opentelemetry/sdk-trace-node": {
+          "optional": true
+        },
+        "express": {
           "optional": true
         },
         "openai": {
@@ -7248,6 +7316,7 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/lru-cache": {
@@ -7875,6 +7944,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       "import": "./dist/src/tools/code-interpreter/integrations/strands/index.js",
       "types": "./dist/src/tools/code-interpreter/integrations/strands/index.d.ts"
     },
+    "./experimental/memory/strands": {
+      "import": "./dist/src/memory/integrations/strands/index.js",
+      "types": "./dist/src/memory/integrations/strands/index.d.ts"
+    },
     "./runtime": {
       "import": "./dist/src/runtime/index.js",
       "types": "./dist/src/runtime/index.d.ts"
@@ -90,7 +94,8 @@
   "devDependencies": {
     "@ai-sdk/amazon-bedrock": "^4.0.0-beta.67",
     "@aws-sdk/client-cognito-identity-provider": "^3.957.0",
-    "@strands-agents/sdk": "^0.6.0",
+    "@eslint/js": "^10.0.1",
+    "@strands-agents/sdk": "^0.7.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/express": "^5.0.6",
@@ -144,7 +149,7 @@
     "zod": "^4.1.13"
   },
   "peerDependencies": {
-    "@strands-agents/sdk": ">=0.1.0",
+    "@strands-agents/sdk": ">=0.7.0",
     "ai": ">=6.0.0-beta",
     "playwright": ">=1.56.0",
     "react": ">=18.0.0",

--- a/src/memory/integrations/strands/__tests__/_verify_concerns.test.ts
+++ b/src/memory/integrations/strands/__tests__/_verify_concerns.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AgentCoreMemory } from '../plugin.js'
+
+const mockRetrieveMemoryRecords = vi.fn()
+const mockCreateEvent = vi.fn()
+
+vi.mock('../../../client.js', () => ({
+  MemoryClient: vi.fn(function (this: any) {
+    this.retrieveMemoryRecords = mockRetrieveMemoryRecords
+    this.createEvent = mockCreateEvent
+    return this
+  }),
+}))
+
+vi.mock('@strands-agents/sdk', () => {
+  class BeforeInvocationEvent {
+    readonly type = 'beforeInvocationEvent'
+    readonly agent: any
+    constructor(d: { agent: any }) {
+      this.agent = d.agent
+    }
+  }
+  class MessageAddedEvent {
+    readonly type = 'messageAddedEvent'
+    readonly agent: any
+    readonly message: any
+    constructor(d: { agent: any; message: any }) {
+      this.agent = d.agent
+      this.message = d.message
+    }
+  }
+  class AfterInvocationEvent {
+    readonly type = 'afterInvocationEvent'
+    readonly agent: any
+    constructor(d: { agent: any }) {
+      this.agent = d.agent
+    }
+  }
+  return { BeforeInvocationEvent, MessageAddedEvent, AfterInvocationEvent, tool: vi.fn((c: any) => c) }
+})
+
+interface HookEntry {
+  eventName: string
+  callback: (event: any) => any
+}
+function createMockAgent() {
+  const hooks: HookEntry[] = []
+  return {
+    systemPrompt: 'You are helpful.' as any,
+    messages: [] as any[],
+    addHook: vi.fn((eventType: any, callback: any) => {
+      hooks.push({ eventName: eventType.name ?? 'unknown', callback })
+      return () => {}
+    }),
+    async fireHooks(eventName: string, event: any) {
+      for (const h of hooks.filter((h) => h.eventName === eventName)) await h.callback(event)
+    },
+  }
+}
+const msg = (role: any, text: string) => ({ role, content: [{ type: 'textBlock', text }] })
+const BASE = { memoryId: 'mem', actorId: 'a1', sessionId: 's1' }
+
+beforeEach(() => {
+  mockRetrieveMemoryRecords.mockReset()
+  mockCreateEvent.mockReset()
+  mockRetrieveMemoryRecords.mockResolvedValue({ memoryRecordSummaries: [] })
+  mockCreateEvent.mockResolvedValue({})
+})
+
+describe('CONCERN 1: retry uses SAME clientToken (idempotency)', () => {
+  it('retry uses identical clientToken', async () => {
+    const tokens: string[] = []
+    let callNum = 0
+    mockCreateEvent.mockImplementation((args: any) => {
+      tokens.push(args.clientToken)
+      callNum++
+      if (callNum === 1) return Promise.reject(new Error('boom'))
+      return Promise.resolve({})
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const plugin = new AgentCoreMemory({ ...BASE, extraction: true })
+    const agent = createMockAgent()
+    plugin.initAgent(agent as any)
+    await agent.fireHooks('MessageAddedEvent', { agent, message: msg('user', 'hi') })
+    await agent.fireHooks('AfterInvocationEvent', { agent })
+
+    expect(tokens.length).toBe(2)
+    expect(tokens[0]).toBe(tokens[1])
+  })
+})
+
+describe('CONCERN 2: msg buffered DURING in-flight flush gets drained', () => {
+  it('with batchSize:2, msg3 added during in-flight flush is drained by AfterInvocation', async () => {
+    let resolveSlow!: () => void
+    const slow = new Promise<void>((r) => {
+      resolveSlow = r
+    })
+    let isFirstBatch = true
+    mockCreateEvent.mockImplementation(() => {
+      if (isFirstBatch) return slow.then(() => ({}))
+      return Promise.resolve({})
+    })
+
+    const plugin = new AgentCoreMemory({ ...BASE, extraction: { batchSize: 2 } })
+    const agent = createMockAgent()
+    plugin.initAgent(agent as any)
+
+    await agent.fireHooks('MessageAddedEvent', { agent, message: msg('user', 'msg1') })
+    await agent.fireHooks('MessageAddedEvent', { agent, message: msg('user', 'msg2') })
+    await agent.fireHooks('MessageAddedEvent', { agent, message: msg('assistant', 'msg3') })
+
+    expect((plugin as any).batcher.size).toBe(1)
+
+    isFirstBatch = false
+    const afterPromise = agent.fireHooks('AfterInvocationEvent', { agent })
+    resolveSlow()
+    await afterPromise
+
+    const calls = mockCreateEvent.mock.calls.length
+    const remaining = (plugin as any).batcher.size
+    console.log(`createEvent calls: ${calls}; buffer remaining: ${remaining}`)
+    expect(calls).toBe(3)
+    expect(remaining).toBe(0)
+  })
+})
+
+describe('CONCERN 3: timer cleared when batchSize flush triggers', () => {
+  it('timer is cleared, not left running to fire on empty buffer', async () => {
+    vi.useFakeTimers()
+    try {
+      const plugin = new AgentCoreMemory({ ...BASE, extraction: { batchSize: 2, batchTimeoutMs: 5000 } })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: msg('user', 'msg1') })
+      expect((plugin as any).batcher.flushTimer).toBeDefined()
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: msg('user', 'msg2') })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect((plugin as any).batcher.flushTimer).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('CONCERN 4: tool/reasoning/empty messages produce zero API calls', () => {
+  it('empty content array → no createEvent', async () => {
+    const plugin = new AgentCoreMemory({ ...BASE, extraction: true })
+    const agent = createMockAgent()
+    plugin.initAgent(agent as any)
+
+    await agent.fireHooks('MessageAddedEvent', { agent, message: { role: 'assistant', content: [] } })
+    await agent.fireHooks('AfterInvocationEvent', { agent })
+
+    expect(mockCreateEvent).toHaveBeenCalledTimes(0)
+  })
+
+  it('tool_use + reasoning blocks → no createEvent', async () => {
+    const plugin = new AgentCoreMemory({ ...BASE, extraction: true })
+    const agent = createMockAgent()
+    plugin.initAgent(agent as any)
+
+    const toolMsg = {
+      role: 'assistant',
+      content: [
+        { type: 'reasoningBlock', text: 'Let me think...' },
+        { type: 'toolUseBlock', name: 'search', input: { query: 'x' } },
+      ],
+    }
+    await agent.fireHooks('MessageAddedEvent', { agent, message: toolMsg })
+    await agent.fireHooks('AfterInvocationEvent', { agent })
+
+    expect(mockCreateEvent).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('CONCERN 5: namespace template resolution', () => {
+  it('{actorId} resolves at construct time', async () => {
+    const plugin = new AgentCoreMemory({
+      ...BASE,
+      actorId: 'real-actor-123',
+      injection: { namespaces: { '/users/{actorId}/facts': { topK: 5 } } },
+    })
+    const agent = createMockAgent()
+    agent.messages = [msg('user', 'hello')]
+    plugin.initAgent(agent as any)
+
+    await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+    const ns = mockRetrieveMemoryRecords.mock.calls[0]?.[0]?.namespace
+    expect(ns).toBe('/users/real-actor-123/facts')
+  })
+
+  it('withActor() forks re-resolve template', async () => {
+    const base = new AgentCoreMemory({
+      ...BASE,
+      actorId: 'alice',
+      injection: { namespaces: { '/users/{actorId}/facts': {} } },
+    })
+    const forked = base.withActor('bob')
+    const agent = createMockAgent()
+    agent.messages = [msg('user', 'hi')]
+    forked.initAgent(agent as any)
+
+    await agent.fireHooks('BeforeInvocationEvent', { agent })
+    const ns = mockRetrieveMemoryRecords.mock.calls[0]?.[0]?.namespace
+    expect(ns).toBe('/users/bob/facts')
+  })
+})
+
+describe('CONCERN 6: validation throws on invalid config', () => {
+  it.each([
+    ['batchSize: 0', { batchSize: 0 }],
+    ['batchSize: -1', { batchSize: -1 }],
+    ['batchSize: NaN', { batchSize: NaN }],
+    ['batchSize: Infinity', { batchSize: Infinity }],
+    ['batchSize: 1.5 (non-integer)', { batchSize: 1.5 }],
+    ['batchTimeoutMs: -100', { batchTimeoutMs: -100 }],
+    ['flushTimeoutMs: 0', { flushTimeoutMs: 0 }],
+    ['maxDrainIterations: 0', { maxDrainIterations: 0 }],
+  ])('throws TypeError for %s', (_name, cfg: any) => {
+    expect(() => new AgentCoreMemory({ ...BASE, extraction: cfg })).toThrow(TypeError)
+  })
+})
+
+describe('CONCERN 7: lifecycle APIs exist and work', () => {
+  it('flush() drains buffered messages', async () => {
+    const plugin = new AgentCoreMemory({
+      ...BASE,
+      extraction: { batchSize: 100, batchTimeoutMs: 60000 },
+    })
+    const agent = createMockAgent()
+    plugin.initAgent(agent as any)
+
+    await agent.fireHooks('MessageAddedEvent', { agent, message: msg('user', 'hello') })
+    expect(mockCreateEvent).toHaveBeenCalledTimes(0)
+
+    await plugin.flush()
+    expect(mockCreateEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('shutdown() makes plugin inert', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const plugin = new AgentCoreMemory({ ...BASE, extraction: true })
+    const agent = createMockAgent()
+    plugin.initAgent(agent as any)
+
+    await plugin.shutdown()
+    await agent.fireHooks('MessageAddedEvent', { agent, message: msg('user', 'after-shutdown') })
+    await agent.fireHooks('AfterInvocationEvent', { agent })
+
+    expect(mockCreateEvent).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/memory/integrations/strands/__tests__/batcher.test.ts
+++ b/src/memory/integrations/strands/__tests__/batcher.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AsyncBatcher } from '../batcher.js'
+import type { BatchDropInfo, AsyncBatcherConfig } from '../batcher.js'
+
+const DEFAULT_CONFIG = {
+  batchSize: 10,
+  batchTimeoutMs: 5000,
+  sendTimeoutMs: 10000,
+  maxDrainIterations: 10,
+}
+
+function makeBatcher<T>(
+  overrides: Partial<AsyncBatcherConfig<T>> & Pick<AsyncBatcherConfig<T>, 'send'>
+): AsyncBatcher<T> {
+  return new AsyncBatcher<T>({
+    ...DEFAULT_CONFIG,
+    ...overrides,
+  })
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+afterEach(() => {
+  warnSpy.mockRestore()
+})
+
+describe('AsyncBatcher: size trigger', () => {
+  it('flushes when buffer reaches batchSize', async () => {
+    const send = vi.fn().mockResolvedValue('ok')
+    const b = makeBatcher<string>({ batchSize: 3, send })
+
+    b.add('a')
+    b.add('b')
+    expect(send).not.toHaveBeenCalled()
+
+    b.add('c')
+    await b.flush()
+
+    expect(send).toHaveBeenCalledTimes(3)
+    expect(b.size).toBe(0)
+  })
+})
+
+describe('AsyncBatcher: time trigger', () => {
+  it('flushes after batchTimeoutMs even below batchSize', async () => {
+    vi.useFakeTimers()
+    try {
+      const send = vi.fn().mockResolvedValue('ok')
+      const b = makeBatcher<string>({ batchSize: 100, batchTimeoutMs: 200, send })
+
+      b.add('a')
+      expect(send).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(200)
+      expect(send).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('timer is cleared when size triggers a flush first', async () => {
+    vi.useFakeTimers()
+    try {
+      const send = vi.fn().mockResolvedValue('ok')
+      const b = makeBatcher<string>({ batchSize: 2, batchTimeoutMs: 5000, send })
+
+      b.add('a')
+      b.add('b')
+      await vi.advanceTimersByTimeAsync(0)
+      // After size-triggered drain, timer should be cleared (not pending another empty flush)
+      expect((b as any).flushTimer).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('AsyncBatcher: idempotent retry', () => {
+  it('retries failed items with the SAME item reference (caller controls idempotency key)', async () => {
+    const seen: string[] = []
+    let firstFail = true
+    const send = vi.fn().mockImplementation(async (item: string) => {
+      seen.push(item)
+      if (firstFail && item === 'a') {
+        firstFail = false
+        throw new Error('transient')
+      }
+      return 'ok'
+    })
+    const b = makeBatcher<string>({ send })
+    b.add('a')
+    b.add('b')
+    await b.flush()
+
+    // 3 calls: a (fail), b (ok), a-retry (ok)
+    expect(seen).toEqual(['a', 'b', 'a'])
+  })
+
+  it('drops items that fail twice and reports via onDropped', async () => {
+    const onDropped = vi.fn()
+    const send = vi.fn().mockRejectedValue(new Error('persistent'))
+    const b = makeBatcher<string>({ send, onDropped, keyOf: (s) => s })
+
+    b.add('a')
+    b.add('b')
+    await b.flush()
+
+    expect(send).toHaveBeenCalledTimes(4) // 2 originals + 2 retries
+    expect(onDropped).toHaveBeenCalledTimes(2)
+    const reasons = onDropped.mock.calls.map((c) => (c[0] as BatchDropInfo).reason)
+    expect(reasons).toEqual(['retry-failed', 'retry-failed'])
+    const keys = onDropped.mock.calls.map((c) => (c[0] as BatchDropInfo).key)
+    expect(keys.sort()).toEqual(['a', 'b'])
+  })
+})
+
+describe('AsyncBatcher: per-send timeout', () => {
+  it('rejects send that exceeds sendTimeoutMs and surfaces via onDropped', async () => {
+    vi.useFakeTimers()
+    try {
+      const onDropped = vi.fn()
+      const hangingSend = vi.fn().mockImplementation(() => new Promise(() => {})) // never resolves
+      const b = makeBatcher<string>({ send: hangingSend, sendTimeoutMs: 100, onDropped, keyOf: (s) => s })
+
+      b.add('a')
+      const flushPromise = b.flush()
+
+      // Advance past timeout — should reject the in-flight send, then retry, then time out again
+      await vi.advanceTimersByTimeAsync(100) // first timeout fires
+      await vi.advanceTimersByTimeAsync(100) // retry timeout fires
+      await flushPromise
+
+      // Two timeout drops (initial + retry), then one retry-failed drop
+      const reasons = onDropped.mock.calls.map((c) => (c[0] as BatchDropInfo).reason)
+      expect(reasons).toContain('timeout')
+      expect(reasons).toContain('retry-failed')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('synchronous throw in send is isolated as a rejection (does not escape allSettled)', async () => {
+    // Every call to send throws synchronously — verifies the
+    // Promise.resolve().then(...) wrap converts sync throws into rejections.
+    const send = vi.fn().mockImplementation(() => {
+      throw new Error('sync boom')
+    })
+    const onDropped = vi.fn()
+    const b = makeBatcher<string>({ send, onDropped, keyOf: (s) => s })
+
+    b.add('a')
+    b.add('b')
+    // Must not throw — sync throws are caught by the Promise.resolve().then(...) wrap
+    await expect(b.flush()).resolves.toBeUndefined()
+
+    // 2 originals throw, 2 retries throw, both items dropped via 'retry-failed'
+    expect(send).toHaveBeenCalledTimes(4)
+    expect(onDropped).toHaveBeenCalledTimes(2)
+    const reasons = onDropped.mock.calls.map((c) => (c[0] as BatchDropInfo).reason)
+    expect(reasons).toEqual(['retry-failed', 'retry-failed'])
+  })
+})
+
+describe('AsyncBatcher: drain dedup', () => {
+  it('concurrent flush() calls share a single in-flight drain', async () => {
+    let resolveSend!: () => void
+    const sendPromise = new Promise((r) => {
+      resolveSend = r as () => void
+    })
+    const send = vi.fn().mockImplementation(() => sendPromise.then(() => 'ok'))
+    const b = makeBatcher<string>({ send })
+
+    b.add('a')
+    const f1 = b.flush()
+    const f2 = b.flush()
+    const f3 = b.flush()
+
+    resolveSend()
+    await Promise.all([f1, f2, f3])
+
+    expect(send).toHaveBeenCalledTimes(1) // not 3
+  })
+})
+
+describe('AsyncBatcher: maxDrainIterations cap', () => {
+  it('stops looping after the cap and reports residual drop', async () => {
+    const send = vi.fn().mockResolvedValue('ok')
+    const onDropped = vi.fn()
+    const b = makeBatcher<string>({ batchSize: 2, maxDrainIterations: 2, send, onDropped })
+
+    // Pre-populate buffer beyond what 2 iterations can drain
+    for (let i = 0; i < 10; i++) b.add(`item-${i}`)
+
+    // Each iteration drains the buffer snapshot. With batchSize 2 each add triggers
+    // an immediate flush — so by the time we await, drain has already happened.
+    await b.flush()
+
+    // No items should remain stranded — the size triggers fired during add.
+    // This test really validates the cap kicks in only when size+timer aren't
+    // draining fast enough; for that we need a slow producer scenario.
+    expect(b.size).toBe(0)
+    expect(send).toHaveBeenCalled()
+  })
+
+  it('cap fires when each iteration finds new items', async () => {
+    // Each send call adds another item to the buffer before resolving. With
+    // maxDrainIterations=2, the drain loop runs exactly 2 iterations:
+    //   iter-1: snapshot=[1], send adds 2 → buffer=[2] after iter
+    //   iter-2: snapshot=[2], send adds 3 → buffer=[3] after iter
+    //   loop exits at i=2; buffer=[3] is stranded
+    let counter = 1
+    const onDropped = vi.fn()
+    const send = vi.fn().mockImplementation(async () => {
+      counter++
+      if (counter <= 3) {
+        b.add(counter)
+      }
+      return 'ok'
+    })
+    const b: AsyncBatcher<number> = makeBatcher<number>({
+      batchSize: 100, // ensure size-trigger doesn't kick in
+      maxDrainIterations: 2,
+      send,
+      onDropped,
+      keyOf: (n) => `n-${n}`,
+    })
+
+    ;(b as any).buffer.push(1)
+    await b.flush()
+
+    const reasons = onDropped.mock.calls.map((c) => (c[0] as BatchDropInfo).reason)
+    expect(reasons).toContain('max-drain-iterations')
+    expect(b.size).toBe(1) // item 3 stranded
+  })
+})
+
+describe('AsyncBatcher: shutdown', () => {
+  it('drains buffer then refuses new items', async () => {
+    const send = vi.fn().mockResolvedValue('ok')
+    const onDropped = vi.fn()
+    const b = makeBatcher<string>({ send, onDropped, keyOf: (s) => s })
+
+    b.add('a')
+    b.add('b')
+    await b.shutdown()
+    expect(send).toHaveBeenCalledTimes(2)
+
+    b.add('c')
+    expect(send).toHaveBeenCalledTimes(2) // unchanged
+
+    expect(onDropped).toHaveBeenCalledWith(expect.objectContaining({ reason: 'post-shutdown', key: 'c' }))
+  })
+
+  it('post-shutdown warning logs only once', async () => {
+    const b = makeBatcher<string>({ send: vi.fn() })
+
+    await b.shutdown()
+    b.add('a')
+    b.add('b')
+    b.add('c')
+
+    const postShutdownWarns = warnSpy.mock.calls.filter((c: unknown[]) => String(c[0]).includes('after shutdown()'))
+    expect(postShutdownWarns.length).toBe(1)
+  })
+})
+
+describe('AsyncBatcher: onDropped error isolation', () => {
+  it('throwing onDropped does not break the batcher', async () => {
+    const onDropped = vi.fn().mockImplementation(() => {
+      throw new Error('callback boom')
+    })
+    const send = vi.fn().mockRejectedValue(new Error('persistent'))
+    const b = makeBatcher<string>({ send, onDropped })
+
+    b.add('a')
+    await expect(b.flush()).resolves.toBeUndefined()
+    expect(onDropped).toHaveBeenCalled()
+  })
+})
+
+describe('AsyncBatcher: empty operations', () => {
+  it('flush() on empty buffer is a no-op', async () => {
+    const send = vi.fn()
+    const b = makeBatcher<string>({ send })
+    await b.flush()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('shutdown() on empty buffer is a no-op', async () => {
+    const send = vi.fn()
+    const b = makeBatcher<string>({ send })
+    await b.shutdown()
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/src/memory/integrations/strands/__tests__/format.test.ts
+++ b/src/memory/integrations/strands/__tests__/format.test.ts
@@ -268,14 +268,14 @@ describe('extractText', () => {
     expect(extractText(message)).toBe('hello\nworld')
   })
 
-  it('extracts text from tool use blocks', () => {
+  it('skips tool use blocks (agent internals, not user content)', () => {
     const message = msg('assistant', [
       { type: 'toolUseBlock', name: 'search', toolUseId: 't1', input: { query: 'test' } },
     ])
-    expect(extractText(message)).toBe('[tool_use: search({"query":"test"})]')
+    expect(extractText(message)).toBe('')
   })
 
-  it('extracts text from tool result blocks', () => {
+  it('skips tool result blocks (agent internals, not user content)', () => {
     const message = msg('user', [
       {
         type: 'toolResultBlock',
@@ -287,12 +287,12 @@ describe('extractText', () => {
         ],
       },
     ])
-    expect(extractText(message)).toBe('result text\n{"key":"value"}')
+    expect(extractText(message)).toBe('')
   })
 
-  it('extracts text from reasoning blocks', () => {
+  it('skips reasoning blocks (chain-of-thought, not user content)', () => {
     const message = msg('assistant', [{ type: 'reasoningBlock', text: 'thinking...' }])
-    expect(extractText(message)).toBe('thinking...')
+    expect(extractText(message)).toBe('')
   })
 
   it('skips reasoning blocks without text', () => {
@@ -303,12 +303,12 @@ describe('extractText', () => {
     expect(extractText(message)).toBe('visible')
   })
 
-  it('extracts mixed content', () => {
+  it('extracts text and skips tool-use blocks in mixed content', () => {
     const message = msg('assistant', [
       { type: 'textBlock', text: 'I will search' },
       { type: 'toolUseBlock', name: 'lookup', toolUseId: 't1', input: 'q' },
     ])
-    expect(extractText(message)).toBe('I will search\n[tool_use: lookup("q")]')
+    expect(extractText(message)).toBe('I will search')
   })
 
   it('skips binary content blocks', () => {

--- a/src/memory/integrations/strands/__tests__/format.test.ts
+++ b/src/memory/integrations/strands/__tests__/format.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from 'vitest'
+import type { Message, SystemContentBlock } from '@strands-agents/sdk'
+import {
+  escapeRegex,
+  deriveLabel,
+  formatMemoryBlock,
+  truncateToCharBudget,
+  stripMemoryBlock,
+  appendMemoryBlock,
+  extractText,
+  mapRole,
+} from '../format.js'
+import type { MemoryRecordGroup } from '../types.js'
+
+function msg(role: 'user' | 'assistant', content: unknown[]): Message {
+  return { role, content } as unknown as Message
+}
+
+describe('escapeRegex', () => {
+  it('escapes all regex metacharacters', () => {
+    expect(escapeRegex('hello.world')).toBe('hello\\.world')
+    expect(escapeRegex('a+b*c?d')).toBe('a\\+b\\*c\\?d')
+    expect(escapeRegex('[foo](bar)')).toBe('\\[foo\\]\\(bar\\)')
+    expect(escapeRegex('a{1}|b$^c')).toBe('a\\{1\\}\\|b\\$\\^c')
+  })
+
+  it('returns plain strings unchanged', () => {
+    expect(escapeRegex('hello')).toBe('hello')
+  })
+})
+
+describe('deriveLabel', () => {
+  it('extracts label from path with placeholders', () => {
+    expect(deriveLabel('/facts/{actorId}/')).toBe('facts')
+  })
+
+  it('extracts last segment from nested path', () => {
+    expect(deriveLabel('/preferences/{actorId}/summaries/')).toBe('summaries')
+  })
+
+  it('falls back to memory for placeholder-only path', () => {
+    expect(deriveLabel('/{actorId}/')).toBe('memory')
+  })
+
+  it('extracts label from simple path', () => {
+    expect(deriveLabel('/facts/')).toBe('facts')
+  })
+
+  it('handles path without leading/trailing slashes', () => {
+    expect(deriveLabel('facts')).toBe('facts')
+  })
+
+  it('returns memory for empty string', () => {
+    expect(deriveLabel('')).toBe('memory')
+  })
+
+  it('returns memory for only slashes', () => {
+    expect(deriveLabel('///')).toBe('memory')
+  })
+})
+
+describe('formatMemoryBlock', () => {
+  it('formats multiple groups', () => {
+    const groups: MemoryRecordGroup[] = [
+      { namespace: 'ns1', label: 'facts', records: [{ content: 'likes cats' }, { content: 'lives in Seattle' }] },
+      { namespace: 'ns2', label: 'prefs', records: [{ content: 'prefers dark mode' }] },
+    ]
+    const result = formatMemoryBlock(groups, 'memory_context')
+    expect(result).toBe(
+      '<memory_context>\n' +
+        'The following are relevant memories about the user:\n\n' +
+        '[facts]\n- likes cats\n- lives in Seattle\n\n' +
+        '[prefs]\n- prefers dark mode\n' +
+        '</memory_context>'
+    )
+  })
+
+  it('returns empty string when all groups have zero records', () => {
+    const groups: MemoryRecordGroup[] = [
+      { namespace: 'ns1', label: 'facts', records: [] },
+      { namespace: 'ns2', label: 'prefs', records: [] },
+    ]
+    expect(formatMemoryBlock(groups, 'tag')).toBe('')
+  })
+
+  it('returns empty string for empty groups array', () => {
+    expect(formatMemoryBlock([], 'tag')).toBe('')
+  })
+
+  it('formats a single group with single record', () => {
+    const groups: MemoryRecordGroup[] = [{ namespace: 'ns', label: 'info', records: [{ content: 'one item' }] }]
+    const result = formatMemoryBlock(groups, 'ctx')
+    expect(result).toBe('<ctx>\nThe following are relevant memories about the user:\n\n[info]\n- one item\n</ctx>')
+  })
+
+  it('uses custom contextTag', () => {
+    const groups: MemoryRecordGroup[] = [{ namespace: 'ns', label: 'data', records: [{ content: 'hello' }] }]
+    const result = formatMemoryBlock(groups, 'my_custom_tag')
+    expect(result).toContain('<my_custom_tag>')
+    expect(result).toContain('</my_custom_tag>')
+  })
+
+  it('skips groups with zero records when mixed with non-empty', () => {
+    const groups: MemoryRecordGroup[] = [
+      { namespace: 'ns1', label: 'empty', records: [] },
+      { namespace: 'ns2', label: 'full', records: [{ content: 'data' }] },
+    ]
+    const result = formatMemoryBlock(groups, 'tag')
+    expect(result).not.toContain('[empty]')
+    expect(result).toContain('[full]')
+  })
+})
+
+describe('truncateToCharBudget', () => {
+  it('returns all records when within budget', () => {
+    const groups: MemoryRecordGroup[] = [{ namespace: 'ns', label: 'a', records: [{ content: 'short', score: 1 }] }]
+    const result = truncateToCharBudget(groups, 1000)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.records).toHaveLength(1)
+  })
+
+  it('drops least relevant records when over budget', () => {
+    const groups: MemoryRecordGroup[] = [
+      {
+        namespace: 'ns',
+        label: 'a',
+        records: [
+          { content: 'high relevance', score: 0.9 },
+          { content: 'low relevance', score: 0.1 },
+        ],
+      },
+    ]
+    const result = truncateToCharBudget(groups, 20)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.records).toHaveLength(1)
+    expect(result[0]!.records[0]!.content).toBe('high relevance')
+  })
+
+  it('treats undefined score as 0', () => {
+    const groups: MemoryRecordGroup[] = [
+      {
+        namespace: 'ns',
+        label: 'a',
+        records: [{ content: 'scored', score: 0.5 }, { content: 'unscored' }],
+      },
+    ]
+    const result = truncateToCharBudget(groups, 10)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.records[0]!.content).toBe('scored')
+  })
+
+  it('drops empty groups after truncation', () => {
+    const groups: MemoryRecordGroup[] = [
+      { namespace: 'ns1', label: 'high', records: [{ content: 'important', score: 0.9 }] },
+      { namespace: 'ns2', label: 'low', records: [{ content: 'not important at all', score: 0.1 }] },
+    ]
+    const result = truncateToCharBudget(groups, 15)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.label).toBe('high')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(truncateToCharBudget([], 100)).toEqual([])
+  })
+
+  it('maintains original group order', () => {
+    const groups: MemoryRecordGroup[] = [
+      { namespace: 'ns1', label: 'first', records: [{ content: 'aa', score: 0.5 }] },
+      { namespace: 'ns2', label: 'second', records: [{ content: 'bb', score: 0.9 }] },
+    ]
+    const result = truncateToCharBudget(groups, 100)
+    expect(result[0]!.label).toBe('first')
+    expect(result[1]!.label).toBe('second')
+  })
+})
+
+describe('stripMemoryBlock', () => {
+  it('returns undefined for undefined prompt', () => {
+    expect(stripMemoryBlock(undefined, 'tag')).toBeUndefined()
+  })
+
+  it('strips tag from string prompt', () => {
+    const prompt = 'before <memory>some content</memory> after'
+    expect(stripMemoryBlock(prompt, 'memory')).toBe('before  after')
+  })
+
+  it('leaves string prompt unchanged when tag is absent', () => {
+    const prompt = 'no tags here'
+    expect(stripMemoryBlock(prompt, 'memory')).toBe('no tags here')
+  })
+
+  it('does not trim the result for string prompts', () => {
+    const prompt = '  <memory>content</memory>  '
+    expect(stripMemoryBlock(prompt, 'memory')).toBe('    ')
+  })
+
+  it('strips multiple occurrences with global flag', () => {
+    const prompt = '<m>first</m> middle <m>second</m>'
+    expect(stripMemoryBlock(prompt, 'm')).toBe(' middle ')
+  })
+
+  it('handles regex metacharacters in tag name', () => {
+    const prompt = '<tag.name>content</tag.name> rest'
+    expect(stripMemoryBlock(prompt, 'tag.name')).toBe(' rest')
+  })
+
+  it('strips tag from TextBlock in array prompt', () => {
+    const prompt: SystemContentBlock[] = [
+      { type: 'textBlock', text: 'before <memory>stuff</memory> after' } as SystemContentBlock,
+    ]
+    const result = stripMemoryBlock(prompt, 'memory') as SystemContentBlock[]
+    expect(result).toHaveLength(1)
+    expect((result[0] as { text: string }).text).toBe('before  after')
+  })
+
+  it('removes TextBlock entirely when text is empty after stripping', () => {
+    const prompt: SystemContentBlock[] = [
+      { type: 'textBlock', text: '<memory>only this</memory>' } as SystemContentBlock,
+      { type: 'cachePointBlock', cacheType: 'default' } as unknown as SystemContentBlock,
+    ]
+    const result = stripMemoryBlock(prompt, 'memory') as SystemContentBlock[]
+    expect(result).toHaveLength(1)
+    expect((result[0] as { type: string }).type).toBe('cachePointBlock')
+  })
+
+  it('passes through CachePointBlock and GuardContentBlock unchanged', () => {
+    const cacheBlock = { type: 'cachePointBlock', cacheType: 'default' } as unknown as SystemContentBlock
+    const guardBlock = { type: 'guardContentBlock' } as unknown as SystemContentBlock
+    const prompt: SystemContentBlock[] = [cacheBlock, guardBlock]
+    const result = stripMemoryBlock(prompt, 'tag') as SystemContentBlock[]
+    expect(result).toHaveLength(2)
+    expect(result[0]).toBe(cacheBlock)
+    expect(result[1]).toBe(guardBlock)
+  })
+})
+
+describe('appendMemoryBlock', () => {
+  it('returns block as string when prompt is undefined', () => {
+    expect(appendMemoryBlock(undefined, 'hello')).toBe('hello')
+  })
+
+  it('appends to string prompt with double newline', () => {
+    expect(appendMemoryBlock('existing', 'new')).toBe('existing\n\nnew')
+  })
+
+  it('appends TextBlock to array prompt', () => {
+    const prompt: SystemContentBlock[] = [{ type: 'textBlock', text: 'existing' } as SystemContentBlock]
+    const result = appendMemoryBlock(prompt, 'new block') as SystemContentBlock[]
+    expect(result).toHaveLength(2)
+    expect((result[1] as { type: string; text: string }).type).toBe('textBlock')
+    expect((result[1] as { type: string; text: string }).text).toBe('new block')
+  })
+
+  it('preserves existing blocks in array prompt', () => {
+    const cacheBlock = { type: 'cachePointBlock', cacheType: 'default' } as unknown as SystemContentBlock
+    const prompt: SystemContentBlock[] = [cacheBlock]
+    const result = appendMemoryBlock(prompt, 'new') as SystemContentBlock[]
+    expect(result[0]).toBe(cacheBlock)
+  })
+})
+
+describe('extractText', () => {
+  it('extracts text from text blocks', () => {
+    const message = msg('user', [
+      { type: 'textBlock', text: 'hello' },
+      { type: 'textBlock', text: 'world' },
+    ])
+    expect(extractText(message)).toBe('hello\nworld')
+  })
+
+  it('extracts text from tool use blocks', () => {
+    const message = msg('assistant', [
+      { type: 'toolUseBlock', name: 'search', toolUseId: 't1', input: { query: 'test' } },
+    ])
+    expect(extractText(message)).toBe('[tool_use: search({"query":"test"})]')
+  })
+
+  it('extracts text from tool result blocks', () => {
+    const message = msg('user', [
+      {
+        type: 'toolResultBlock',
+        toolUseId: 't1',
+        status: 'success',
+        content: [
+          { type: 'textBlock', text: 'result text' },
+          { type: 'jsonBlock', json: { key: 'value' } },
+        ],
+      },
+    ])
+    expect(extractText(message)).toBe('result text\n{"key":"value"}')
+  })
+
+  it('extracts text from reasoning blocks', () => {
+    const message = msg('assistant', [{ type: 'reasoningBlock', text: 'thinking...' }])
+    expect(extractText(message)).toBe('thinking...')
+  })
+
+  it('skips reasoning blocks without text', () => {
+    const message = msg('assistant', [
+      { type: 'reasoningBlock', signature: 'sig' },
+      { type: 'textBlock', text: 'visible' },
+    ])
+    expect(extractText(message)).toBe('visible')
+  })
+
+  it('extracts mixed content', () => {
+    const message = msg('assistant', [
+      { type: 'textBlock', text: 'I will search' },
+      { type: 'toolUseBlock', name: 'lookup', toolUseId: 't1', input: 'q' },
+    ])
+    expect(extractText(message)).toBe('I will search\n[tool_use: lookup("q")]')
+  })
+
+  it('skips binary content blocks', () => {
+    const message = msg('user', [
+      { type: 'imageBlock' },
+      { type: 'videoBlock' },
+      { type: 'documentBlock' },
+      { type: 'cachePointBlock' },
+      { type: 'guardContentBlock' },
+      { type: 'citationsBlock' },
+    ])
+    expect(extractText(message)).toBe('')
+  })
+
+  it('returns empty string for empty message', () => {
+    const message = msg('user', [])
+    expect(extractText(message)).toBe('')
+  })
+})
+
+describe('mapRole', () => {
+  it('maps user to USER', () => {
+    expect(mapRole(msg('user', []))).toBe('USER')
+  })
+
+  it('maps assistant to ASSISTANT', () => {
+    expect(mapRole(msg('assistant', []))).toBe('ASSISTANT')
+  })
+})

--- a/src/memory/integrations/strands/__tests__/plugin.test.ts
+++ b/src/memory/integrations/strands/__tests__/plugin.test.ts
@@ -114,6 +114,8 @@ describe('AgentCoreMemory', () => {
         batchTimeoutMs: 5000,
         messageFilter: expect.any(Function),
         fireAndForget: false,
+        flushTimeoutMs: 10000,
+        maxDrainIterations: 10,
       })
     })
 
@@ -124,6 +126,8 @@ describe('AgentCoreMemory', () => {
         batchTimeoutMs: 5000,
         messageFilter: expect.any(Function),
         fireAndForget: false,
+        flushTimeoutMs: 10000,
+        maxDrainIterations: 10,
       })
     })
 
@@ -240,7 +244,7 @@ describe('AgentCoreMemory', () => {
 
       expect(mockRetrieveMemoryRecords).toHaveBeenCalledWith({
         memoryId: 'mem-1',
-        namespace: '/facts/{actorId}/',
+        namespace: '/facts/user-1/',
         searchCriteria: { searchQuery: 'hello', topK: 5 },
       })
       expect(agent.systemPrompt).toContain('<agentcore_memory>')
@@ -552,7 +556,7 @@ describe('AgentCoreMemory', () => {
       expect(mockCreateEvent).toHaveBeenCalledTimes(2)
     })
 
-    it('guards against concurrent flushes', async () => {
+    it('reentrant flushBuffer calls are serialized (no double-send of in-flight batch)', async () => {
       let resolveFirst!: () => void
       const firstCallPromise = new Promise<void>((resolve) => {
         resolveFirst = resolve
@@ -563,10 +567,9 @@ describe('AgentCoreMemory', () => {
       const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
       const agent = createMockAgent()
       plugin.initAgent(agent as any)
-      ;(plugin as any).buffer = [createMessage('assistant', 'msg1')]
+      ;(plugin as any).buffer = [{ message: createMessage('assistant', 'msg1'), clientToken: 'tok-1' }]
 
       const flush1 = (plugin as any).flushBuffer()
-      ;(plugin as any).buffer = [createMessage('assistant', 'msg2')]
       const flush2 = (plugin as any).flushBuffer()
 
       resolveFirst()
@@ -574,6 +577,31 @@ describe('AgentCoreMemory', () => {
       await flush2
 
       expect(mockCreateEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('messages buffered during in-flight flush are drained on the next pass (B1 regression)', async () => {
+      let resolveFirst!: () => void
+      const firstCallPromise = new Promise<void>((resolve) => {
+        resolveFirst = resolve
+      })
+      mockCreateEvent.mockImplementationOnce(() => firstCallPromise.then(() => ({})))
+      mockCreateEvent.mockResolvedValue({})
+
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: { batchSize: 2 } })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'a') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'b') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'c') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'd') })
+      const after = agent.fireHooks('AfterInvocationEvent', { agent })
+
+      resolveFirst()
+      await after
+
+      expect(mockCreateEvent).toHaveBeenCalledTimes(4)
+      expect((plugin as any).buffer).toEqual([])
     })
   })
 
@@ -605,6 +633,157 @@ describe('AgentCoreMemory', () => {
       const cloned = plugin.withMetadataProvider(fn)
       expect((cloned as any).originalConfig.metadataProvider).toBe(fn)
       expect((cloned as any).initialized).toBe(false)
+    })
+  })
+
+  describe('bug bash regressions', () => {
+    it('H1: clientToken is stable across retry', async () => {
+      let firstCall = true
+      const tokensSeen: string[] = []
+      mockCreateEvent.mockImplementation(async (req: any) => {
+        tokensSeen.push(req.clientToken)
+        if (firstCall) {
+          firstCall = false
+          throw new Error('simulated transient failure')
+        }
+        return {}
+      })
+
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'hi') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(tokensSeen).toHaveLength(2)
+      expect(tokensSeen[0]).toBe(tokensSeen[1])
+    })
+
+    it('H2: metadataProvider sync throw does not drop sibling messages', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: true,
+        metadataProvider: (m) => {
+          const text = m.content[0]?.type === 'textBlock' ? m.content[0].text : ''
+          if (text === 'throw') throw new Error('boom')
+          return { ok: { stringValue: 'yes' } }
+        },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'a') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'throw') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'c') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'd') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      // 4 messages attempted; 'throw' rejects both initial + retry; siblings succeed.
+      expect(mockCreateEvent).toHaveBeenCalled()
+      const successTexts = mockCreateEvent.mock.calls
+        .filter((c: any[]) => {
+          // Every call passes. Filter out the throw-message attempts by checking if the promise succeeds.
+          return c[0].payload[0].conversational.content.text !== 'throw'
+        })
+        .map((c: any[]) => c[0].payload[0].conversational.content.text)
+      // Three unique non-throw messages landed: a, c, d
+      expect(new Set(successTexts)).toEqual(new Set(['a', 'c', 'd']))
+      warnSpy.mockRestore()
+    })
+
+    it('H3: {actorId} and {sessionId} templates resolved at construct time', async () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        actorId: 'aidan',
+        sessionId: 'sess-12345',
+        injection: {
+          namespaces: {
+            '/users/{actorId}/facts': { topK: 3 },
+            '/sessions/{sessionId}/summary': { topK: 2 },
+          },
+        },
+      })
+      const agent = createMockAgent()
+      agent.messages = [createMessage('user', 'hi')]
+      plugin.initAgent(agent as any)
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      const calls = mockRetrieveMemoryRecords.mock.calls.map((c: any[]) => c[0].namespace)
+      expect(calls).toContain('/users/aidan/facts')
+      expect(calls).toContain('/sessions/sess-12345/summary')
+      expect(calls).not.toContain('/users/{actorId}/facts')
+    })
+
+    it('H3: withActor re-resolves {actorId} templates for fork', async () => {
+      const base = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        actorId: 'user-1',
+        injection: { namespaces: { '/users/{actorId}/facts': {} } },
+      })
+      const fork = base.withActor('user-2')
+      const agent = createMockAgent()
+      fork.initAgent(agent as any)
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+      const calls = mockRetrieveMemoryRecords.mock.calls.map((c: any[]) => c[0].namespace)
+      expect(calls).toContain('/users/user-2/facts')
+      expect(calls).not.toContain('/users/user-1/facts')
+    })
+
+    it('B2: flushTimeoutMs rejects hung createEvent instead of stalling', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      mockCreateEvent.mockImplementation(() => new Promise(() => {}))
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: { flushTimeoutMs: 50 },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'hi') })
+
+      const afterInvoke = agent.fireHooks('AfterInvocationEvent', { agent })
+      await vi.advanceTimersByTimeAsync(200)
+      await afterInvoke
+
+      expect(warnSpy).toHaveBeenCalled()
+      warnSpy.mockRestore()
+    })
+
+    it('public flush() drains buffer synchronously', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: { batchTimeoutMs: 60000 } })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'hi') })
+      expect(mockCreateEvent).not.toHaveBeenCalled()
+      await plugin.flush()
+      expect(mockCreateEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('shutdown() stops accepting new messages', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await plugin.shutdown()
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'hi') })
+      expect(mockCreateEvent).not.toHaveBeenCalled()
+    })
+
+    it('extraction batchSize: 0 throws at construct time (M3)', () => {
+      expect(() => new AgentCoreMemory({ ...BASE_CONFIG, extraction: { batchSize: 0 } })).toThrow(
+        /batchSize must be a positive integer/
+      )
+    })
+
+    it('silently coerces system/tool roles away (M1) — not buffered', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      const sysMsg = { role: 'system', content: [{ type: 'textBlock', text: 'sys' }] }
+      await agent.fireHooks('MessageAddedEvent', { agent, message: sysMsg })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+      expect(mockCreateEvent).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/memory/integrations/strands/__tests__/plugin.test.ts
+++ b/src/memory/integrations/strands/__tests__/plugin.test.ts
@@ -461,7 +461,7 @@ describe('AgentCoreMemory', () => {
       const msg = createMessage('assistant', 'Hello!')
       await agent.fireHooks('MessageAddedEvent', { agent, message: msg })
 
-      expect((plugin as any).buffer).toHaveLength(1)
+      expect((plugin as any).batcher.size).toBe(1)
     })
 
     it('flushes buffer on AfterInvocationEvent', async () => {
@@ -474,7 +474,7 @@ describe('AgentCoreMemory', () => {
       await agent.fireHooks('AfterInvocationEvent', { agent })
 
       expect(mockCreateEvent).toHaveBeenCalledTimes(2)
-      expect((plugin as any).buffer).toHaveLength(0)
+      expect((plugin as any).batcher.size).toBe(0)
     })
 
     it('applies messageFilter before buffering', async () => {
@@ -488,7 +488,7 @@ describe('AgentCoreMemory', () => {
       await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'Hi') })
       await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'Hello!') })
 
-      expect((plugin as any).buffer).toHaveLength(1)
+      expect((plugin as any).batcher.size).toBe(1)
     })
 
     it('sends correct payload to createEvent', async () => {
@@ -573,7 +573,7 @@ describe('AgentCoreMemory', () => {
       expect(mockCreateEvent).toHaveBeenCalledTimes(2)
     })
 
-    it('reentrant flushBuffer calls are serialized (no double-send of in-flight batch)', async () => {
+    it('concurrent flush() calls are deduplicated (no double-send of in-flight batch)', async () => {
       let resolveFirst!: () => void
       const firstCallPromise = new Promise<void>((resolve) => {
         resolveFirst = resolve
@@ -584,10 +584,11 @@ describe('AgentCoreMemory', () => {
       const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
       const agent = createMockAgent()
       plugin.initAgent(agent as any)
-      ;(plugin as any).buffer = [{ message: createMessage('assistant', 'msg1'), clientToken: 'tok-1' }]
 
-      const flush1 = (plugin as any).flushBuffer()
-      const flush2 = (plugin as any).flushBuffer()
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'msg1') })
+
+      const flush1 = plugin.flush()
+      const flush2 = plugin.flush()
 
       resolveFirst()
       await flush1
@@ -618,7 +619,7 @@ describe('AgentCoreMemory', () => {
       await after
 
       expect(mockCreateEvent).toHaveBeenCalledTimes(4)
-      expect((plugin as any).buffer).toEqual([])
+      expect((plugin as any).batcher.size).toBe(0)
     })
   })
 
@@ -636,10 +637,10 @@ describe('AgentCoreMemory', () => {
       expect((cloned as any).client).toBe((plugin as any).client)
     })
 
-    it('has independent buffer', () => {
+    it('has independent batcher', () => {
       const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
       const cloned = plugin.withActor('actor-2')
-      expect((cloned as any).buffer).not.toBe((plugin as any).buffer)
+      expect((cloned as any).batcher).not.toBe((plugin as any).batcher)
     })
   })
 
@@ -932,7 +933,7 @@ describe('AgentCoreMemory', () => {
       await agent.fireHooks('AfterInvocationEvent', { agent })
 
       expect(mockCreateEvent).toHaveBeenCalledTimes(1)
-      const sentText = mockCreateEvent.mock.calls[0][0].payload[0].conversational.content.text
+      const sentText = mockCreateEvent.mock.calls[0]![0].payload[0].conversational.content.text
       expect(sentText).toBe('here is my answer')
       expect(sentText).not.toContain('tool_use')
       expect(sentText).not.toContain('chain of thought')

--- a/src/memory/integrations/strands/__tests__/plugin.test.ts
+++ b/src/memory/integrations/strands/__tests__/plugin.test.ts
@@ -201,6 +201,23 @@ describe('AgentCoreMemory', () => {
       plugin.initAgent(agent as any)
       expect(() => plugin.initAgent(agent as any)).toThrow('AgentCoreMemory plugin already initialized')
     })
+
+    it('M6: throws when a second plugin tries to register on the same agent', () => {
+      const first = new AgentCoreMemory({ ...BASE_CONFIG, actorId: 'A', extraction: true })
+      const second = new AgentCoreMemory({ ...BASE_CONFIG, actorId: 'B', extraction: true })
+      const agent = createMockAgent()
+      first.initAgent(agent as any)
+      expect(() => second.initAgent(agent as any)).toThrow('another AgentCoreMemory plugin is already registered')
+    })
+
+    it('M6: different agents can each have their own plugin', () => {
+      const a = new AgentCoreMemory({ ...BASE_CONFIG, actorId: 'A', extraction: true })
+      const b = new AgentCoreMemory({ ...BASE_CONFIG, actorId: 'B', extraction: true })
+      const agent1 = createMockAgent()
+      const agent2 = createMockAgent()
+      a.initAgent(agent1 as any)
+      expect(() => b.initAgent(agent2 as any)).not.toThrow()
+    })
   })
 
   describe('getTools', () => {

--- a/src/memory/integrations/strands/__tests__/plugin.test.ts
+++ b/src/memory/integrations/strands/__tests__/plugin.test.ts
@@ -1,0 +1,610 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AgentCoreMemory } from '../plugin.js'
+
+const mockRetrieveMemoryRecords = vi.fn()
+const mockCreateEvent = vi.fn()
+
+vi.mock('../../../client.js', () => ({
+  MemoryClient: vi.fn(function (this: any) {
+    this.retrieveMemoryRecords = mockRetrieveMemoryRecords
+    this.createEvent = mockCreateEvent
+    return this
+  }),
+}))
+
+vi.mock('@strands-agents/sdk', () => {
+  class BeforeInvocationEvent {
+    readonly type = 'beforeInvocationEvent'
+    readonly agent: any
+    constructor(data: { agent: any }) {
+      this.agent = data.agent
+    }
+  }
+  class MessageAddedEvent {
+    readonly type = 'messageAddedEvent'
+    readonly agent: any
+    readonly message: any
+    constructor(data: { agent: any; message: any }) {
+      this.agent = data.agent
+      this.message = data.message
+    }
+  }
+  class AfterInvocationEvent {
+    readonly type = 'afterInvocationEvent'
+    readonly agent: any
+    constructor(data: { agent: any }) {
+      this.agent = data.agent
+    }
+  }
+  return {
+    BeforeInvocationEvent,
+    MessageAddedEvent,
+    AfterInvocationEvent,
+    tool: vi.fn((config: any) => ({
+      name: config.name,
+      description: config.description,
+      inputSchema: config.inputSchema,
+      callback: config.callback,
+    })),
+  }
+})
+
+interface HookEntry {
+  eventName: string
+  callback: (event: any) => any
+}
+
+function createMockAgent() {
+  const hooks: HookEntry[] = []
+  return {
+    systemPrompt: 'You are a helpful assistant.' as any,
+    messages: [] as any[],
+    addHook: vi.fn((eventType: any, callback: any) => {
+      hooks.push({ eventName: eventType.name ?? eventType.prototype?.constructor?.name ?? 'unknown', callback })
+      return () => {}
+    }),
+    _hooks: hooks,
+    async fireHooks(eventName: string, event: any) {
+      for (const h of hooks.filter((h) => h.eventName === eventName)) {
+        await h.callback(event)
+      }
+    },
+  }
+}
+
+function createMessage(role: 'user' | 'assistant', text: string): any {
+  return {
+    role,
+    content: [{ type: 'textBlock', text }],
+  }
+}
+
+const BASE_CONFIG = {
+  memoryId: 'mem-1',
+  actorId: 'user-1',
+  sessionId: 'session-1',
+}
+
+describe('AgentCoreMemory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    mockRetrieveMemoryRecords.mockResolvedValue({ memoryRecordSummaries: [] })
+    mockCreateEvent.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('constructor', () => {
+    it('creates instance with extraction and injection', () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: true,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      expect(plugin.name).toBe('agentcore-memory')
+    })
+
+    it('extraction: true resolves to defaults', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      expect((plugin as any).extractionConfig).toEqual({
+        batchSize: 10,
+        batchTimeoutMs: 5000,
+        messageFilter: expect.any(Function),
+        fireAndForget: false,
+      })
+    })
+
+    it('extraction: {} resolves to defaults', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: {} })
+      expect((plugin as any).extractionConfig).toEqual({
+        batchSize: 10,
+        batchTimeoutMs: 5000,
+        messageFilter: expect.any(Function),
+        fireAndForget: false,
+      })
+    })
+
+    it('extraction: false resolves to null', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: false })
+      expect((plugin as any).extractionConfig).toBeNull()
+    })
+
+    it('extraction with custom config merges with defaults', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: { batchSize: 20 } })
+      expect((plugin as any).extractionConfig.batchSize).toBe(20)
+      expect((plugin as any).extractionConfig.batchTimeoutMs).toBe(5000)
+    })
+
+    it('warns on degenerate injection config', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} }, automatic: false, searchTool: false },
+      })
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('injection will do nothing'))
+      warnSpy.mockRestore()
+    })
+  })
+
+  describe('initAgent', () => {
+    it('registers injection hook when automatic: true (default)', () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      expect(agent.addHook).toHaveBeenCalledTimes(1)
+      expect(agent._hooks[0]!.eventName).toBe('BeforeInvocationEvent')
+    })
+
+    it('does not register injection hook when automatic: false', () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} }, automatic: false, searchTool: true },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      expect(agent.addHook).not.toHaveBeenCalled()
+    })
+
+    it('registers extraction hooks when extraction configured', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      expect(agent.addHook).toHaveBeenCalledTimes(2)
+      expect(agent._hooks[0]!.eventName).toBe('MessageAddedEvent')
+      expect(agent._hooks[1]!.eventName).toBe('AfterInvocationEvent')
+    })
+
+    it('registers both injection and extraction hooks', () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: true,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      expect(agent.addHook).toHaveBeenCalledTimes(3)
+    })
+
+    it('throws on double registration', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      expect(() => plugin.initAgent(agent as any)).toThrow('AgentCoreMemory plugin already initialized')
+    })
+  })
+
+  describe('getTools', () => {
+    it('returns empty array when searchTool not configured', () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      expect(plugin.getTools()).toEqual([])
+    })
+
+    it('returns search_memory tool when searchTool: true', () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} }, searchTool: true },
+      })
+      const tools = plugin.getTools()
+      expect(tools).toHaveLength(1)
+      expect((tools[0] as any).name).toBe('search_memory')
+    })
+  })
+
+  describe('injection pipeline', () => {
+    it('retrieves and injects memory into system prompt', async () => {
+      mockRetrieveMemoryRecords.mockResolvedValue({
+        memoryRecordSummaries: [
+          { content: { text: 'User likes dark mode' }, score: 0.9 },
+          { content: { text: 'User timezone is US/Pacific' }, score: 0.8 },
+        ],
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': { topK: 5 } } },
+      })
+      const agent = createMockAgent()
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(mockRetrieveMemoryRecords).toHaveBeenCalledWith({
+        memoryId: 'mem-1',
+        namespace: '/facts/{actorId}/',
+        searchCriteria: { searchQuery: 'hello', topK: 5 },
+      })
+      expect(agent.systemPrompt).toContain('<agentcore_memory>')
+      expect(agent.systemPrompt).toContain('User likes dark mode')
+    })
+
+    it('strips stale memory block before re-injecting', async () => {
+      mockRetrieveMemoryRecords.mockResolvedValue({
+        memoryRecordSummaries: [{ content: { text: 'New fact' }, score: 0.9 }],
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      agent.systemPrompt = 'Base prompt\n\n<agentcore_memory>\nOld data\n</agentcore_memory>'
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(agent.systemPrompt).not.toContain('Old data')
+      expect(agent.systemPrompt).toContain('New fact')
+      expect(agent.systemPrompt).toContain('Base prompt')
+    })
+
+    it('skips injection when zero records returned', async () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(agent.systemPrompt).toBe('You are a helpful assistant.')
+    })
+
+    it('uses generic query on fresh session with no messages', async () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {}, '/preferences/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      agent.messages = []
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(mockRetrieveMemoryRecords).toHaveBeenCalledWith(
+        expect.objectContaining({
+          searchCriteria: expect.objectContaining({
+            searchQuery: expect.stringContaining('facts'),
+          }),
+        })
+      )
+    })
+
+    it('continues without injection on retrieval error', async () => {
+      mockRetrieveMemoryRecords.mockRejectedValue(new Error('API error'))
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      agent.systemPrompt = 'Base prompt\n\n<agentcore_memory>\nStale\n</agentcore_memory>'
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(agent.systemPrompt).not.toContain('agentcore_memory')
+      expect(agent.systemPrompt).toContain('Base prompt')
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Injection failed'), expect.any(Error))
+      warnSpy.mockRestore()
+    })
+
+    it('applies relevanceScore post-filter', async () => {
+      mockRetrieveMemoryRecords.mockResolvedValue({
+        memoryRecordSummaries: [
+          { content: { text: 'High relevance' }, score: 0.9 },
+          { content: { text: 'Low relevance' }, score: 0.2 },
+        ],
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': { relevanceScore: 0.5 } } },
+      })
+      const agent = createMockAgent()
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(agent.systemPrompt).toContain('High relevance')
+      expect(agent.systemPrompt).not.toContain('Low relevance')
+    })
+
+    it('uses custom contextTag', async () => {
+      mockRetrieveMemoryRecords.mockResolvedValue({
+        memoryRecordSummaries: [{ content: { text: 'Fact' }, score: 0.9 }],
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} }, contextTag: 'custom_memory' },
+      })
+      const agent = createMockAgent()
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(agent.systemPrompt).toContain('<custom_memory>')
+      expect(agent.systemPrompt).toContain('</custom_memory>')
+    })
+
+    it('uses custom formatMemories override', async () => {
+      mockRetrieveMemoryRecords.mockResolvedValue({
+        memoryRecordSummaries: [{ content: { text: 'Fact' }, score: 0.9 }],
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: {
+          namespaces: { '/facts/{actorId}/': {} },
+          formatMemories: () => '<custom>Custom format</custom>',
+        },
+      })
+      const agent = createMockAgent()
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(agent.systemPrompt).toContain('<custom>Custom format</custom>')
+    })
+
+    it('handles undefined systemPrompt', async () => {
+      mockRetrieveMemoryRecords.mockResolvedValue({
+        memoryRecordSummaries: [{ content: { text: 'Fact' }, score: 0.9 }],
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      agent.systemPrompt = undefined
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(typeof agent.systemPrompt).toBe('string')
+      expect(agent.systemPrompt).toContain('<agentcore_memory>')
+    })
+
+    it('handles SystemContentBlock[] systemPrompt', async () => {
+      mockRetrieveMemoryRecords.mockResolvedValue({
+        memoryRecordSummaries: [{ content: { text: 'Fact from array' }, score: 0.9 }],
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/facts/{actorId}/': {} } },
+      })
+      const agent = createMockAgent()
+      agent.systemPrompt = [{ type: 'textBlock', text: 'Base instructions' }, { type: 'cachePointBlock' }] as any
+      agent.messages = [createMessage('user', 'hello')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(Array.isArray(agent.systemPrompt)).toBe(true)
+      const blocks = agent.systemPrompt as any[]
+      expect(blocks[0].text).toBe('Base instructions')
+      expect(blocks[1].type).toBe('cachePointBlock')
+      const memoryBlock = blocks.find((b: any) => b.text?.includes('agentcore_memory'))
+      expect(memoryBlock).toBeDefined()
+      expect(memoryBlock.text).toContain('Fact from array')
+    })
+  })
+
+  describe('extraction pipeline', () => {
+    it('buffers messages from MessageAddedEvent', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      const msg = createMessage('assistant', 'Hello!')
+      await agent.fireHooks('MessageAddedEvent', { agent, message: msg })
+
+      expect((plugin as any).buffer).toHaveLength(1)
+    })
+
+    it('flushes buffer on AfterInvocationEvent', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'Hi') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'Hello!') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).toHaveBeenCalledTimes(2)
+      expect((plugin as any).buffer).toHaveLength(0)
+    })
+
+    it('applies messageFilter before buffering', async () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: { messageFilter: (msg: any) => msg.role !== 'user' },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'Hi') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'Hello!') })
+
+      expect((plugin as any).buffer).toHaveLength(1)
+    })
+
+    it('sends correct payload to createEvent', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'Hello!') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memoryId: 'mem-1',
+          actorId: 'user-1',
+          sessionId: 'session-1',
+          payload: [{ conversational: { role: 'ASSISTANT', content: { text: 'Hello!' } } }],
+          clientToken: expect.any(String),
+        })
+      )
+    })
+
+    it('includes metadata from metadataProvider', async () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: true,
+        metadataProvider: () => ({ source: { stringValue: 'test' } }),
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'Hello!') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: { source: { stringValue: 'test' } } })
+      )
+    })
+
+    it('retries failed events once then drops', async () => {
+      let callCount = 0
+      mockCreateEvent.mockImplementation(() => {
+        callCount++
+        if (callCount <= 2) return Promise.reject(new Error('throttled'))
+        return Promise.resolve({})
+      })
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'msg1') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).toHaveBeenCalledTimes(2)
+      warnSpy.mockRestore()
+    })
+
+    it('does not throw from hooks on extraction error', async () => {
+      mockCreateEvent.mockRejectedValue(new Error('API error'))
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'msg') })
+      await expect(agent.fireHooks('AfterInvocationEvent', { agent })).resolves.toBeUndefined()
+
+      warnSpy.mockRestore()
+    })
+
+    it('flushes early when batchSize reached', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: { batchSize: 2 } })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'msg1') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'msg2') })
+
+      await vi.advanceTimersByTimeAsync(10)
+      expect(mockCreateEvent).toHaveBeenCalledTimes(2)
+    })
+
+    it('guards against concurrent flushes', async () => {
+      let resolveFirst!: () => void
+      const firstCallPromise = new Promise<void>((resolve) => {
+        resolveFirst = resolve
+      })
+      mockCreateEvent.mockImplementationOnce(() => firstCallPromise.then(() => ({})))
+      mockCreateEvent.mockResolvedValue({})
+
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      ;(plugin as any).buffer = [createMessage('assistant', 'msg1')]
+
+      const flush1 = (plugin as any).flushBuffer()
+      ;(plugin as any).buffer = [createMessage('assistant', 'msg2')]
+      const flush2 = (plugin as any).flushBuffer()
+
+      resolveFirst()
+      await flush1
+      await flush2
+
+      expect(mockCreateEvent).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('withActor', () => {
+    it('returns new uninitialized instance with overridden actorId', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const cloned = plugin.withActor('actor-2')
+      expect((cloned as any).originalConfig.actorId).toBe('actor-2')
+      expect((cloned as any).initialized).toBe(false)
+    })
+
+    it('shares MemoryClient instance', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const cloned = plugin.withActor('actor-2')
+      expect((cloned as any).client).toBe((plugin as any).client)
+    })
+
+    it('has independent buffer', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const cloned = plugin.withActor('actor-2')
+      expect((cloned as any).buffer).not.toBe((plugin as any).buffer)
+    })
+  })
+
+  describe('withMetadataProvider', () => {
+    it('returns new instance with overridden metadataProvider', () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const fn = () => ({ key: { stringValue: 'val' } })
+      const cloned = plugin.withMetadataProvider(fn)
+      expect((cloned as any).originalConfig.metadataProvider).toBe(fn)
+      expect((cloned as any).initialized).toBe(false)
+    })
+  })
+})

--- a/src/memory/integrations/strands/__tests__/plugin.test.ts
+++ b/src/memory/integrations/strands/__tests__/plugin.test.ts
@@ -786,4 +786,86 @@ describe('AgentCoreMemory', () => {
       expect(mockCreateEvent).not.toHaveBeenCalled()
     })
   })
+
+  describe('observability', () => {
+    it('onDroppedEvents fires with retry-failed when both initial + retry fail', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const dropped: any[] = []
+      mockCreateEvent.mockRejectedValue(new Error('boom'))
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: { onDroppedEvents: (info) => dropped.push(info) },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'hi') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(
+        dropped.some((d) => d.reason === 'retry-failed' && d.count === 1 && typeof d.clientToken === 'string')
+      ).toBe(true)
+      warnSpy.mockRestore()
+    })
+
+    it('onDroppedEvents fires with timeout when flushTimeoutMs trips', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const dropped: any[] = []
+      // first call hangs, second (retry) resolves so final state is not drop
+      let calls = 0
+      mockCreateEvent.mockImplementation(() => {
+        calls++
+        if (calls === 1) return new Promise(() => {}) // hang
+        return Promise.resolve({})
+      })
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: { flushTimeoutMs: 50, onDroppedEvents: (info) => dropped.push(info) },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'hi') })
+
+      const afterInvoke = agent.fireHooks('AfterInvocationEvent', { agent })
+      await vi.advanceTimersByTimeAsync(200)
+      await afterInvoke
+
+      expect(dropped.some((d) => d.reason === 'timeout')).toBe(true)
+      warnSpy.mockRestore()
+    })
+
+    it('post-shutdown MessageAddedEvent warns once and notifies via onDroppedEvents', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const dropped: any[] = []
+
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        extraction: { onDroppedEvents: (info) => dropped.push(info) },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await plugin.shutdown()
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'late-1') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'late-2') })
+
+      const postShutdownDrops = dropped.filter((d) => d.reason === 'post-shutdown')
+      expect(postShutdownDrops).toHaveLength(2)
+      // warn is one-shot — only the first drop produces a console.warn
+      const dropWarns = warnSpy.mock.calls.filter((c) => String(c[0]).includes('after shutdown()'))
+      expect(dropWarns).toHaveLength(1)
+      warnSpy.mockRestore()
+    })
+
+    it('shutdown() no-ops when extraction is disabled (R2-A1 + R2-A3 regression)', async () => {
+      const plugin = new AgentCoreMemory({
+        ...BASE_CONFIG,
+        injection: { namespaces: { '/x': {} } },
+      })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+      await expect(plugin.shutdown()).resolves.toBeUndefined()
+    })
+  })
 })

--- a/src/memory/integrations/strands/__tests__/plugin.test.ts
+++ b/src/memory/integrations/strands/__tests__/plugin.test.ts
@@ -884,5 +884,73 @@ describe('AgentCoreMemory', () => {
       plugin.initAgent(agent as any)
       await expect(plugin.shutdown()).resolves.toBeUndefined()
     })
+
+    it('tool-use-only messages are skipped from extraction (jariy17 finding 2)', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      const toolUseOnly = {
+        role: 'assistant',
+        content: [{ type: 'toolUseBlock', name: 'search', toolUseId: 't1', input: { q: 'test' } }],
+      }
+      await agent.fireHooks('MessageAddedEvent', { agent, message: toolUseOnly })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).not.toHaveBeenCalled()
+    })
+
+    it('reasoning-only messages are skipped from extraction (jariy17 finding 2)', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      const reasoningOnly = {
+        role: 'assistant',
+        content: [{ type: 'reasoningBlock', text: 'Let me think about this carefully...' }],
+      }
+      await agent.fireHooks('MessageAddedEvent', { agent, message: reasoningOnly })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).not.toHaveBeenCalled()
+    })
+
+    it('mixed message lands with only the text content (jariy17 finding 2)', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      const mixed = {
+        role: 'assistant',
+        content: [
+          { type: 'textBlock', text: 'here is my answer' },
+          { type: 'toolUseBlock', name: 'search', toolUseId: 't1', input: { q: 'test' } },
+          { type: 'reasoningBlock', text: 'internal chain of thought' },
+        ],
+      }
+      await agent.fireHooks('MessageAddedEvent', { agent, message: mixed })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).toHaveBeenCalledTimes(1)
+      const sentText = mockCreateEvent.mock.calls[0][0].payload[0].conversational.content.text
+      expect(sentText).toBe('here is my answer')
+      expect(sentText).not.toContain('tool_use')
+      expect(sentText).not.toContain('chain of thought')
+    })
+
+    it('empty-content messages are skipped (jariy17 finding 3)', async () => {
+      const plugin = new AgentCoreMemory({ ...BASE_CONFIG, extraction: true })
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      const empty = { role: 'user', content: [] }
+      const imageOnly = { role: 'user', content: [{ type: 'imageBlock' }] }
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: empty })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: imageOnly })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      expect(mockCreateEvent).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/memory/integrations/strands/__tests__/search-memory-tool.test.ts
+++ b/src/memory/integrations/strands/__tests__/search-memory-tool.test.ts
@@ -14,7 +14,7 @@ const mockRetrieveMemoryRecords = vi.fn()
 
 const mockClient = {
   retrieveMemoryRecords: mockRetrieveMemoryRecords,
-} as unknown as import('../../../../client.js').MemoryClient
+} as unknown as import('../../../client.js').MemoryClient
 
 const baseConfig = {
   memoryId: 'mem-123',

--- a/src/memory/integrations/strands/__tests__/search-memory-tool.test.ts
+++ b/src/memory/integrations/strands/__tests__/search-memory-tool.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createSearchMemoryTool } from '../search-memory-tool.js'
+
+vi.mock('@strands-agents/sdk', () => ({
+  tool: vi.fn((config) => ({
+    name: config.name,
+    description: config.description,
+    inputSchema: config.inputSchema,
+    callback: config.callback,
+  })),
+}))
+
+const mockRetrieveMemoryRecords = vi.fn()
+
+const mockClient = {
+  retrieveMemoryRecords: mockRetrieveMemoryRecords,
+} as unknown as import('../../../../client.js').MemoryClient
+
+const baseConfig = {
+  memoryId: 'mem-123',
+  namespaces: {
+    'user/facts': { topK: 3 },
+    'user/preferences': { topK: 5 },
+  },
+}
+
+describe('createSearchMemoryTool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('has correct name and description', () => {
+    const t = createSearchMemoryTool(mockClient, baseConfig)
+    expect(t.name).toBe('search_memory')
+    expect(t.description).toContain('Search long-term memory')
+  })
+
+  it('searches all namespaces when no namespace specified', async () => {
+    mockRetrieveMemoryRecords.mockResolvedValue({ memoryRecordSummaries: [] })
+
+    const t = createSearchMemoryTool(mockClient, baseConfig)
+    await (t as any).callback({ query: 'dark mode' })
+
+    expect(mockRetrieveMemoryRecords).toHaveBeenCalledTimes(2)
+    expect(mockRetrieveMemoryRecords).toHaveBeenCalledWith(expect.objectContaining({ namespace: 'user/facts' }))
+    expect(mockRetrieveMemoryRecords).toHaveBeenCalledWith(expect.objectContaining({ namespace: 'user/preferences' }))
+  })
+
+  it('searches specific namespace when specified', async () => {
+    mockRetrieveMemoryRecords.mockResolvedValue({ memoryRecordSummaries: [] })
+
+    const t = createSearchMemoryTool(mockClient, baseConfig)
+    await (t as any).callback({ query: 'timezone', namespace: 'user/facts' })
+
+    expect(mockRetrieveMemoryRecords).toHaveBeenCalledTimes(1)
+    expect(mockRetrieveMemoryRecords).toHaveBeenCalledWith(expect.objectContaining({ namespace: 'user/facts' }))
+  })
+
+  it('returns error for unknown namespace', async () => {
+    const t = createSearchMemoryTool(mockClient, baseConfig)
+    const result = await (t as any).callback({ query: 'test', namespace: 'unknown/ns' })
+
+    expect(result).toContain('Error: unknown namespace "unknown/ns"')
+    expect(result).toContain('user/facts')
+    expect(result).toContain('user/preferences')
+    expect(mockRetrieveMemoryRecords).not.toHaveBeenCalled()
+  })
+
+  it('formats results with namespace labels', async () => {
+    mockRetrieveMemoryRecords.mockImplementation(({ namespace }: { namespace: string }) => {
+      if (namespace === 'user/facts') {
+        return Promise.resolve({
+          memoryRecordSummaries: [
+            { memoryRecordId: 'r1', content: { text: 'User prefers dark mode' }, score: 0.9 },
+            { memoryRecordId: 'r2', content: { text: 'User timezone is US/Pacific' }, score: 0.8 },
+          ],
+        })
+      }
+      return Promise.resolve({
+        memoryRecordSummaries: [{ memoryRecordId: 'r3', content: { text: 'Likes concise responses' }, score: 0.7 }],
+      })
+    })
+
+    const t = createSearchMemoryTool(mockClient, baseConfig)
+    const result = await (t as any).callback({ query: 'preferences' })
+
+    expect(result).toContain('[facts]')
+    expect(result).toContain('- User prefers dark mode')
+    expect(result).toContain('- User timezone is US/Pacific')
+    expect(result).toContain('[preferences]')
+    expect(result).toContain('- Likes concise responses')
+  })
+
+  it("returns 'No relevant memories found.' when no results", async () => {
+    mockRetrieveMemoryRecords.mockResolvedValue({ memoryRecordSummaries: [] })
+
+    const t = createSearchMemoryTool(mockClient, baseConfig)
+    const result = await (t as any).callback({ query: 'something obscure' })
+
+    expect(result).toBe('No relevant memories found.')
+  })
+
+  it('handles retrieval errors gracefully via Promise.allSettled', async () => {
+    mockRetrieveMemoryRecords.mockImplementation(({ namespace }: { namespace: string }) => {
+      if (namespace === 'user/facts') {
+        return Promise.reject(new Error('network error'))
+      }
+      return Promise.resolve({
+        memoryRecordSummaries: [{ memoryRecordId: 'r1', content: { text: 'Likes concise responses' }, score: 0.9 }],
+      })
+    })
+
+    const t = createSearchMemoryTool(mockClient, baseConfig)
+    const result = await (t as any).callback({ query: 'preferences' })
+
+    expect(result).toContain('[preferences]')
+    expect(result).toContain('- Likes concise responses')
+    expect(result).not.toContain('[facts]')
+  })
+
+  it('applies relevanceScore filter when configured', async () => {
+    const configWithThreshold = {
+      memoryId: 'mem-123',
+      namespaces: {
+        'user/facts': { topK: 5, relevanceScore: 0.8 },
+      },
+    }
+
+    mockRetrieveMemoryRecords.mockResolvedValue({
+      memoryRecordSummaries: [
+        { memoryRecordId: 'r1', content: { text: 'High relevance' }, score: 0.95 },
+        { memoryRecordId: 'r2', content: { text: 'Below threshold' }, score: 0.5 },
+        { memoryRecordId: 'r3', content: { text: 'Exactly at threshold' }, score: 0.8 },
+      ],
+    })
+
+    const t = createSearchMemoryTool(mockClient, configWithThreshold)
+    const result = await (t as any).callback({ query: 'test' })
+
+    expect(result).toContain('High relevance')
+    expect(result).toContain('Exactly at threshold')
+    expect(result).not.toContain('Below threshold')
+  })
+
+  it('passes correct topK from config to API', async () => {
+    const configWithTopK = {
+      memoryId: 'mem-456',
+      namespaces: {
+        'user/facts': { topK: 10 },
+      },
+    }
+
+    mockRetrieveMemoryRecords.mockResolvedValue({ memoryRecordSummaries: [] })
+
+    const t = createSearchMemoryTool(mockClient, configWithTopK)
+    await (t as any).callback({ query: 'test' })
+
+    expect(mockRetrieveMemoryRecords).toHaveBeenCalledWith({
+      memoryId: 'mem-456',
+      namespace: 'user/facts',
+      searchCriteria: { searchQuery: 'test', topK: 10 },
+    })
+  })
+})

--- a/src/memory/integrations/strands/batcher.ts
+++ b/src/memory/integrations/strands/batcher.ts
@@ -1,0 +1,235 @@
+/// <reference types="node" />
+
+/**
+ * Generic async batcher with size + time triggers, idempotent single-retry,
+ * per-send timeout, bounded drain loop, and graceful shutdown.
+ *
+ * Internal to the memory plugin today. If a second consumer needs this pattern
+ * (telemetry, OTEL, identity events), promote to a public export — the API is
+ * intentionally generic so that promotion is a one-line index.ts change.
+ */
+
+export type BatchDropReason = 'retry-failed' | 'max-drain-iterations' | 'post-shutdown' | 'timeout'
+
+export interface BatchDropInfo {
+  reason: BatchDropReason
+  count: number
+  /** Caller-defined identifier for the dropped item. Useful for log correlation. */
+  key?: string
+  cause?: unknown
+}
+
+export interface AsyncBatcherConfig<T> {
+  /** Buffered item count that triggers an immediate flush. Must be a positive integer. */
+  batchSize: number
+  /** Maximum time (ms) an item sits in the buffer before being flushed. Must be non-negative. */
+  batchTimeoutMs: number
+  /** Per-send timeout (ms). Items exceeding this are rejected; one retry is attempted. */
+  sendTimeoutMs: number
+  /** Upper bound on flush passes per drain. Guards against pathological producers. */
+  maxDrainIterations: number
+  /**
+   * Sends one item. Wrapped in `Promise.resolve().then(...)` internally, so a
+   * synchronous throw becomes a rejected promise rather than escaping the
+   * batcher's `Promise.allSettled` isolation.
+   */
+  send: (item: T) => Promise<unknown>
+  /** Optional structured drop callback. Errors thrown inside are caught and logged. */
+  onDropped?: (info: BatchDropInfo) => void
+  /**
+   * Returns a stable identifier for an item, used for drop logging. If omitted,
+   * dropped events log without a key.
+   */
+  keyOf?: (item: T) => string
+  /** Prefix for `console.warn` messages. Defaults to `[batcher]`. */
+  logPrefix?: string
+}
+
+export class AsyncBatcher<T> {
+  private readonly config: AsyncBatcherConfig<T>
+  private readonly logPrefix: string
+  private buffer: T[] = []
+  private flushTimer?: ReturnType<typeof globalThis.setTimeout> | undefined
+  private pendingFlush: Promise<void> | null = null
+  private shuttingDown = false
+  private postShutdownDropWarned = false
+
+  constructor(config: AsyncBatcherConfig<T>) {
+    this.config = config
+    this.logPrefix = config.logPrefix ?? '[batcher]'
+  }
+
+  get size(): number {
+    return this.buffer.length
+  }
+
+  add(item: T): void {
+    if (this.shuttingDown) {
+      if (!this.postShutdownDropWarned) {
+        this.postShutdownDropWarned = true
+        console.warn(`${this.logPrefix} Dropping item received after shutdown()`)
+      }
+      this.notifyDropped({ reason: 'post-shutdown', count: 1, ...this.keyFor(item) })
+      return
+    }
+
+    this.buffer.push(item)
+
+    if (this.buffer.length >= this.config.batchSize) {
+      void this.drainUntilEmpty()
+      return
+    }
+
+    if (!this.flushTimer && this.buffer.length === 1) {
+      this.flushTimer = globalThis.setTimeout(() => {
+        void this.drainUntilEmpty()
+      }, this.config.batchTimeoutMs)
+    }
+  }
+
+  /**
+   * Force an immediate flush of the buffer and wait for completion. Loops
+   * until the buffer is empty or {@link AsyncBatcherConfig.maxDrainIterations}
+   * is reached.
+   */
+  async flush(): Promise<void> {
+    this.clearFlushTimer()
+    await this.drainUntilEmpty()
+  }
+
+  /**
+   * Stop accepting new items, cancel pending timers, and await the final
+   * flush. After shutdown the batcher is inert — subsequent `add` calls are
+   * dropped via {@link BatchDropInfo} with reason `'post-shutdown'`.
+   */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+    this.clearFlushTimer()
+    await this.drainUntilEmpty()
+  }
+
+  /**
+   * Drain the buffer across multiple flush passes. Each pass takes a snapshot
+   * of the current buffer; any items that arrive during the pass (from
+   * concurrent `add()` calls) are picked up on the next iteration. Bounded by
+   * `maxDrainIterations` to guard against pathological producers.
+   */
+  private async drainUntilEmpty(): Promise<void> {
+    if (this.pendingFlush) {
+      await this.pendingFlush
+      return
+    }
+
+    const run = async (): Promise<void> => {
+      const maxIter = this.config.maxDrainIterations
+      for (let i = 0; i < maxIter && this.buffer.length > 0; i++) {
+        await this.flushOnce()
+      }
+      if (this.buffer.length > 0) {
+        const stranded = this.buffer.length
+        console.warn(
+          `${this.logPrefix} flush reached maxDrainIterations=${maxIter} with ${stranded} item(s) still buffered`
+        )
+        this.notifyDropped({ reason: 'max-drain-iterations', count: stranded })
+      }
+    }
+
+    this.pendingFlush = run().finally(() => {
+      this.pendingFlush = null
+    })
+    await this.pendingFlush
+  }
+
+  private async flushOnce(): Promise<void> {
+    if (this.buffer.length === 0) return
+
+    const toFlush = [...this.buffer]
+    this.buffer = []
+    this.clearFlushTimer()
+
+    const results = await Promise.allSettled(toFlush.map((item) => this.sendWithTimeout(item)))
+
+    const failed: number[] = []
+    for (let i = 0; i < results.length; i++) {
+      if (results[i]!.status === 'rejected') failed.push(i)
+    }
+    if (failed.length === 0) return
+
+    const retryResults = await Promise.allSettled(failed.map((i) => this.sendWithTimeout(toFlush[i]!)))
+    const failedDetails: Array<{ key?: string; reason: unknown }> = []
+    for (let j = 0; j < retryResults.length; j++) {
+      const r = retryResults[j]!
+      if (r.status === 'rejected') {
+        const item = toFlush[failed[j]!]!
+        failedDetails.push({ ...this.keyFor(item), reason: r.reason })
+      }
+    }
+    if (failedDetails.length === 0) return
+
+    for (const detail of failedDetails) {
+      const keyPart = detail.key !== undefined ? ` (key=${detail.key})` : ''
+      console.warn(`${this.logPrefix} Dropping item after retry${keyPart}:`, detail.reason)
+      this.notifyDropped({
+        reason: 'retry-failed',
+        count: 1,
+        ...(detail.key !== undefined ? { key: detail.key } : {}),
+        cause: detail.reason,
+      })
+    }
+    console.warn(`${this.logPrefix} Dropped ${failedDetails.length} item(s) after retry`)
+  }
+
+  /**
+   * Wraps the user-supplied `send` in `Promise.resolve().then(...)` so a
+   * synchronous throw becomes a rejected promise (preserves `Promise.allSettled`
+   * isolation), and races it against `sendTimeoutMs`.
+   */
+  private sendWithTimeout(item: T): Promise<unknown> {
+    const timeoutMs = this.config.sendTimeoutMs
+    const call = Promise.resolve().then(() => this.config.send(item))
+
+    let timer: ReturnType<typeof globalThis.setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = globalThis.setTimeout(() => {
+        const keyInfo = this.keyFor(item)
+        const keyPart = keyInfo.key !== undefined ? ` (key=${keyInfo.key})` : ''
+        const msg = `${this.logPrefix} send timed out after ${timeoutMs}ms${keyPart}`
+        console.warn(msg)
+        this.notifyDropped({
+          reason: 'timeout',
+          count: 1,
+          ...(keyInfo.key !== undefined ? { key: keyInfo.key } : {}),
+          cause: new Error(msg),
+        })
+        reject(new Error(msg))
+      }, timeoutMs)
+    })
+
+    return Promise.race([call, timeout]).finally(() => {
+      if (timer) globalThis.clearTimeout(timer)
+    })
+  }
+
+  private notifyDropped(info: BatchDropInfo): void {
+    const cb = this.config.onDropped
+    if (!cb) return
+    try {
+      cb(info)
+    } catch (err) {
+      console.warn(`${this.logPrefix} onDropped callback threw:`, err)
+    }
+  }
+
+  private keyFor(item: T): { key?: string } {
+    if (!this.config.keyOf) return {}
+    const key = this.config.keyOf(item)
+    return key !== undefined ? { key } : {}
+  }
+
+  private clearFlushTimer(): void {
+    if (this.flushTimer) {
+      globalThis.clearTimeout(this.flushTimer)
+      this.flushTimer = undefined
+    }
+  }
+}

--- a/src/memory/integrations/strands/format.ts
+++ b/src/memory/integrations/strands/format.ts
@@ -1,0 +1,135 @@
+import type { Message, SystemPrompt, SystemContentBlock, ContentBlock, ToolResultContent } from '@strands-agents/sdk'
+import type { MemoryRecordGroup } from './types.js'
+
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function deriveLabel(namespacePath: string): string {
+  const segments = namespacePath.split('/').filter((s) => s.length > 0 && !s.startsWith('{'))
+  if (segments.length > 0) {
+    return segments[segments.length - 1]!
+  }
+  const stripped = namespacePath.replace(/\{[^}]*\}/g, '').replace(/\//g, '')
+  return stripped || 'memory'
+}
+
+export function formatMemoryBlock(groups: MemoryRecordGroup[], contextTag: string): string {
+  const totalRecords = groups.reduce((sum, g) => sum + g.records.length, 0)
+  if (totalRecords === 0) return ''
+
+  const sections = groups
+    .filter((g) => g.records.length > 0)
+    .map((g) => {
+      const lines = g.records.map((r) => `- ${r.content}`)
+      return `[${g.label}]\n${lines.join('\n')}`
+    })
+
+  return `<${contextTag}>\nThe following are relevant memories about the user:\n\n${sections.join('\n\n')}\n</${contextTag}>`
+}
+
+export function truncateToCharBudget(groups: MemoryRecordGroup[], maxChars: number): MemoryRecordGroup[] {
+  const flat = groups.flatMap((g, groupIndex) => g.records.map((r) => ({ record: r, groupIndex })))
+
+  flat.sort((a, b) => (b.record.score ?? 0) - (a.record.score ?? 0))
+
+  let budget = maxChars
+  const surviving = new Map<number, typeof flat>()
+
+  for (const entry of flat) {
+    if (budget <= 0) break
+    const cost = entry.record.content.length
+    if (cost > budget) break
+    budget -= cost
+
+    const list = surviving.get(entry.groupIndex)
+    if (list) {
+      list.push(entry)
+    } else {
+      surviving.set(entry.groupIndex, [entry])
+    }
+  }
+
+  return groups
+    .map((g, i) => {
+      const kept = surviving.get(i)
+      if (!kept) return null
+      return {
+        namespace: g.namespace,
+        label: g.label,
+        records: kept.map((e) => e.record),
+      }
+    })
+    .filter((g): g is MemoryRecordGroup => g !== null)
+}
+
+export function stripMemoryBlock(prompt: SystemPrompt | undefined, tag: string): SystemPrompt | undefined {
+  if (prompt === undefined) return undefined
+
+  const escaped = escapeRegex(tag)
+  const regex = new RegExp(`<${escaped}>[\\s\\S]*?</${escaped}>`, 'g')
+
+  if (typeof prompt === 'string') {
+    return prompt.replace(regex, '')
+  }
+
+  const result: SystemContentBlock[] = []
+  for (const block of prompt) {
+    if (block.type === 'textBlock') {
+      const stripped = block.text.replace(regex, '')
+      if (!stripped.trim()) continue
+      result.push({ ...block, text: stripped } as SystemContentBlock)
+    } else {
+      result.push(block)
+    }
+  }
+  return result
+}
+
+export function appendMemoryBlock(prompt: SystemPrompt | undefined, block: string): SystemPrompt {
+  if (prompt === undefined) return block
+  if (typeof prompt === 'string') return `${prompt}\n\n${block}`
+  return [...prompt, { type: 'textBlock' as const, text: block } as SystemContentBlock]
+}
+
+export function extractText(message: Message): string {
+  const parts: string[] = []
+
+  for (const block of message.content) {
+    const text = extractContentBlockText(block)
+    if (text) parts.push(text)
+  }
+
+  return parts.join('\n').trim()
+}
+
+function extractContentBlockText(block: ContentBlock): string | undefined {
+  switch (block.type) {
+    case 'textBlock':
+      return block.text
+    case 'toolUseBlock':
+      return `[tool_use: ${block.name}(${JSON.stringify(block.input)})]`
+    case 'toolResultBlock':
+      return extractToolResultText(block.content)
+    case 'reasoningBlock':
+      return block.text ?? undefined
+    default:
+      return undefined
+  }
+}
+
+function extractToolResultText(content: ToolResultContent[]): string | undefined {
+  const parts: string[] = []
+  for (const item of content) {
+    if (item.type === 'textBlock') {
+      parts.push(item.text)
+    } else if (item.type === 'jsonBlock') {
+      parts.push(JSON.stringify(item.json))
+    }
+  }
+  return parts.length > 0 ? parts.join('\n') : undefined
+}
+
+export function mapRole(message: Message): 'USER' | 'ASSISTANT' {
+  return message.role === 'user' ? 'USER' : 'ASSISTANT'
+}

--- a/src/memory/integrations/strands/format.ts
+++ b/src/memory/integrations/strands/format.ts
@@ -1,4 +1,4 @@
-import type { Message, SystemPrompt, SystemContentBlock, ContentBlock, ToolResultContent } from '@strands-agents/sdk'
+import type { Message, SystemPrompt, SystemContentBlock, ContentBlock } from '@strands-agents/sdk'
 import type { MemoryRecordGroup } from './types.js'
 
 export function escapeRegex(str: string): string {
@@ -105,31 +105,17 @@ export function extractText(message: Message): string {
   return parts.join('\n').trim()
 }
 
+// Tool-use, tool-result, and reasoning blocks are agent internals, not user
+// content — excluded from LTM extraction by default so the memory store stays
+// focused on conversational content. Customers who need to persist agent
+// internals can override this via a custom messageFilter on ExtractionConfig.
 function extractContentBlockText(block: ContentBlock): string | undefined {
   switch (block.type) {
     case 'textBlock':
       return block.text
-    case 'toolUseBlock':
-      return `[tool_use: ${block.name}(${JSON.stringify(block.input)})]`
-    case 'toolResultBlock':
-      return extractToolResultText(block.content)
-    case 'reasoningBlock':
-      return block.text ?? undefined
     default:
       return undefined
   }
-}
-
-function extractToolResultText(content: ToolResultContent[]): string | undefined {
-  const parts: string[] = []
-  for (const item of content) {
-    if (item.type === 'textBlock') {
-      parts.push(item.text)
-    } else if (item.type === 'jsonBlock') {
-      parts.push(JSON.stringify(item.json))
-    }
-  }
-  return parts.length > 0 ? parts.join('\n') : undefined
 }
 
 export function mapRole(message: Message): 'USER' | 'ASSISTANT' {

--- a/src/memory/integrations/strands/format.ts
+++ b/src/memory/integrations/strands/format.ts
@@ -39,7 +39,7 @@ export function truncateToCharBudget(groups: MemoryRecordGroup[], maxChars: numb
   for (const entry of flat) {
     if (budget <= 0) break
     const cost = entry.record.content.length
-    if (cost > budget) break
+    if (cost > budget) continue
     budget -= cost
 
     const list = surviving.get(entry.groupIndex)
@@ -67,7 +67,9 @@ export function stripMemoryBlock(prompt: SystemPrompt | undefined, tag: string):
   if (prompt === undefined) return undefined
 
   const escaped = escapeRegex(tag)
-  const regex = new RegExp(`<${escaped}>[\\s\\S]*?</${escaped}>`, 'g')
+  // Consume the `\n\n` separator that `appendMemoryBlock` prepends, plus any
+  // accumulated leading whitespace, so repeated strip/append cycles don't leak.
+  const regex = new RegExp(`\\n*<${escaped}>[\\s\\S]*?</${escaped}>\\n*`, 'g')
 
   if (typeof prompt === 'string') {
     return prompt.replace(regex, '')

--- a/src/memory/integrations/strands/index.ts
+++ b/src/memory/integrations/strands/index.ts
@@ -1,5 +1,6 @@
 export { AgentCoreMemory } from './plugin.js'
 export { createSearchMemoryTool } from './search-memory-tool.js'
+export type { SearchMemoryInput, SearchMemoryTool } from './search-memory-tool.js'
 export type {
   AgentCoreMemoryConfig,
   ExtractionConfig,

--- a/src/memory/integrations/strands/index.ts
+++ b/src/memory/integrations/strands/index.ts
@@ -1,0 +1,13 @@
+export { AgentCoreMemory } from './plugin.js'
+export { createSearchMemoryTool } from './search-memory-tool.js'
+export type {
+  AgentCoreMemoryConfig,
+  ExtractionConfig,
+  InjectionConfig,
+  NamespaceConfig,
+  MemoryRecordGroup,
+  MemoryRecord,
+  ResolvedExtractionConfig,
+  MetadataProviderFn,
+} from './types.js'
+export { resolveExtractionConfig } from './types.js'

--- a/src/memory/integrations/strands/plugin.ts
+++ b/src/memory/integrations/strands/plugin.ts
@@ -24,6 +24,13 @@ import {
   mapRole,
 } from './format.js'
 import { createSearchMemoryTool } from './search-memory-tool.js'
+import { AsyncBatcher } from './batcher.js'
+import type { BatchDropInfo } from './batcher.js'
+
+interface BufferedMessage {
+  message: Message
+  clientToken: string
+}
 
 interface AgentWithSystemPrompt {
   systemPrompt?: SystemPrompt | undefined
@@ -48,11 +55,7 @@ export class AgentCoreMemory implements Plugin {
   private readonly resolvedNamespaces: Record<string, NamespaceConfig>
   private agent!: AgentWithSystemPrompt
   private initialized = false
-  private buffer: Array<{ message: Message; clientToken: string }> = []
-  private flushTimer?: ReturnType<typeof globalThis.setTimeout> | undefined
-  private pendingFlush: Promise<void> | null = null
-  private shuttingDown = false
-  private postShutdownDropWarned = false
+  private batcher: AsyncBatcher<BufferedMessage> | null = null
   private searchMemoryTool?: Tool
   private tokenCounter = 0
 
@@ -75,6 +78,19 @@ export class AgentCoreMemory implements Plugin {
       this.searchMemoryTool = createSearchMemoryTool(this.client, {
         memoryId: config.memoryId,
         namespaces: this.resolvedNamespaces,
+      })
+    }
+
+    if (this.extractionConfig) {
+      this.batcher = new AsyncBatcher<BufferedMessage>({
+        batchSize: this.extractionConfig.batchSize,
+        batchTimeoutMs: this.extractionConfig.batchTimeoutMs,
+        sendTimeoutMs: this.extractionConfig.flushTimeoutMs,
+        maxDrainIterations: this.extractionConfig.maxDrainIterations,
+        send: (entry: BufferedMessage): Promise<unknown> => this.sendOne(entry.message, entry.clientToken),
+        onDropped: (info: BatchDropInfo): void => this.handleBatcherDrop(info),
+        keyOf: (entry: BufferedMessage): string => entry.clientToken,
+        logPrefix: '[agentcore-memory]',
       })
     }
 
@@ -221,18 +237,18 @@ export class AgentCoreMemory implements Plugin {
     try {
       const message = event.message
       if (!this.shouldBuffer(message)) return
-      this.bufferMessage(message)
+      this.batcher!.add({ message, clientToken: this.generateClientToken() })
     } catch (err) {
       console.warn('[agentcore-memory] Error buffering message:', err)
     }
   }
 
   private async handleAfterInvocation(): Promise<void> {
-    this.clearFlushTimer()
+    if (!this.batcher) return
     if (this.extractionConfig!.fireAndForget) {
-      void this.drainUntilEmpty()
+      void this.batcher.flush()
     } else {
-      await this.drainUntilEmpty()
+      await this.batcher.flush()
     }
   }
 
@@ -243,9 +259,8 @@ export class AgentCoreMemory implements Plugin {
    * is reached.
    */
   async flush(): Promise<void> {
-    if (!this.extractionConfig) return
-    this.clearFlushTimer()
-    await this.drainUntilEmpty()
+    if (!this.batcher) return
+    await this.batcher.flush()
   }
 
   /**
@@ -253,22 +268,12 @@ export class AgentCoreMemory implements Plugin {
    * final flush. After shutdown the plugin is inert — subsequent events are ignored.
    */
   async shutdown(): Promise<void> {
-    this.shuttingDown = true
-    this.clearFlushTimer()
-    if (!this.extractionConfig) return
-    await this.drainUntilEmpty()
+    if (!this.batcher) return
+    await this.batcher.shutdown()
   }
 
   private shouldBuffer(message: Message): boolean {
     if (!this.extractionConfig) return false
-    if (this.shuttingDown) {
-      if (!this.postShutdownDropWarned) {
-        this.postShutdownDropWarned = true
-        console.warn('[agentcore-memory] Dropping message received after shutdown()')
-      }
-      this.notifyDropped({ reason: 'post-shutdown', count: 1 })
-      return false
-    }
     const role = message.role
     if (role !== 'user' && role !== 'assistant') return false
     // Skip messages with no extractable text (image-only, tool-use-only,
@@ -277,144 +282,46 @@ export class AgentCoreMemory implements Plugin {
     return this.extractionConfig.messageFilter(message)
   }
 
-  private notifyDropped(info: DroppedEventInfo): void {
+  /**
+   * Translates the batcher's generic {@link BatchDropInfo} into the plugin's
+   * customer-facing {@link DroppedEventInfo} (which uses `clientToken` instead
+   * of the generic `key`). Errors thrown in the customer callback are swallowed
+   * with a warning so the plugin never crashes the agent.
+   */
+  private handleBatcherDrop(info: BatchDropInfo): void {
     const cb = this.extractionConfig?.onDroppedEvents
     if (!cb) return
+    const dropInfo: DroppedEventInfo = {
+      reason: info.reason,
+      count: info.count,
+      ...(info.key !== undefined ? { clientToken: info.key } : {}),
+      ...(info.cause !== undefined ? { cause: info.cause } : {}),
+    }
     try {
-      cb(info)
+      cb(dropInfo)
     } catch (err) {
       console.warn('[agentcore-memory] onDroppedEvents callback threw:', err)
     }
   }
 
-  private bufferMessage(message: Message): void {
-    const clientToken = this.generateClientToken()
-    this.buffer.push({ message, clientToken })
-
-    if (this.buffer.length >= this.extractionConfig!.batchSize) {
-      void this.drainUntilEmpty()
-      return
-    }
-
-    if (!this.flushTimer && this.buffer.length === 1) {
-      this.flushTimer = globalThis.setTimeout(() => {
-        void this.drainUntilEmpty()
-      }, this.extractionConfig!.batchTimeoutMs)
-    }
-  }
-
-  /**
-   * Drain the buffer across multiple flush passes. Each pass takes a snapshot
-   * of the current buffer; any messages that arrive during the pass (from
-   * concurrent MessageAddedEvent callbacks) are picked up on the next iteration.
-   * Bounded by {@link ResolvedExtractionConfig.maxDrainIterations} to guard against
-   * pathological producers.
-   */
-  private async drainUntilEmpty(): Promise<void> {
-    if (this.pendingFlush) {
-      await this.pendingFlush
-      return
-    }
-
-    const run = async (): Promise<void> => {
-      const maxIter = this.extractionConfig!.maxDrainIterations
-      for (let i = 0; i < maxIter && this.buffer.length > 0; i++) {
-        await this.flushBuffer()
-      }
-      if (this.buffer.length > 0) {
-        const stranded = this.buffer.length
-        console.warn(
-          `[agentcore-memory] flush reached maxDrainIterations=${this.extractionConfig!.maxDrainIterations} with ${stranded} message(s) still buffered`
-        )
-        this.notifyDropped({ reason: 'max-drain-iterations', count: stranded })
-      }
-    }
-
-    this.pendingFlush = run().finally(() => {
-      this.pendingFlush = null
-    })
-    await this.pendingFlush
-  }
-
-  private async flushBuffer(): Promise<void> {
-    if (this.buffer.length === 0) return
-
-    const toFlush = [...this.buffer]
-    this.buffer = []
-    this.clearFlushTimer()
-
-    const results = await Promise.allSettled(
-      toFlush.map((entry) => this.createEventFromMessage(entry.message, entry.clientToken))
-    )
-
-    const failed: number[] = []
-    for (let i = 0; i < results.length; i++) {
-      if (results[i]!.status === 'rejected') failed.push(i)
-    }
-
-    if (failed.length === 0) return
-
-    const retryResults = await Promise.allSettled(
-      failed.map((i) => this.createEventFromMessage(toFlush[i]!.message, toFlush[i]!.clientToken))
-    )
-    const failedDetails: Array<{ token: string; reason: unknown }> = []
-    for (let j = 0; j < retryResults.length; j++) {
-      const r = retryResults[j]!
-      if (r.status === 'rejected') {
-        failedDetails.push({ token: toFlush[failed[j]!]!.clientToken, reason: r.reason })
-      }
-    }
-    if (failedDetails.length === 0) return
-
-    for (const detail of failedDetails) {
-      console.warn(`[agentcore-memory] Dropping event after retry (clientToken=${detail.token}):`, detail.reason)
-      this.notifyDropped({ reason: 'retry-failed', count: 1, clientToken: detail.token, cause: detail.reason })
-    }
-    console.warn(`[agentcore-memory] Dropped ${failedDetails.length} event(s) after retry`)
-  }
-
-  /**
-   * Wraps each createEvent call in a Promise.race against flushTimeoutMs so a
-   * hung remote can't stall agent.invoke() indefinitely. The body of the call is
-   * wrapped in Promise.resolve().then(...) so a synchronous throw (e.g. from a
-   * user-supplied metadataProvider) becomes a rejected promise instead of
-   * escaping Promise.allSettled's isolation.
-   */
-  private createEventFromMessage(message: Message, clientToken: string): Promise<unknown> {
-    const timeoutMs = this.extractionConfig!.flushTimeoutMs
-    const call = Promise.resolve().then(() => {
-      const text = extractText(message)
-      const metadata = this.originalConfig.metadataProvider?.(message)
-      return this.client.createEvent({
-        memoryId: this.originalConfig.memoryId,
-        actorId: this.originalConfig.actorId,
-        sessionId: this.originalConfig.sessionId,
-        eventTimestamp: new Date(),
-        clientToken,
-        payload: [
-          {
-            conversational: {
-              role: mapRole(message),
-              content: { text },
-            },
+  private sendOne(message: Message, clientToken: string): Promise<unknown> {
+    const text = extractText(message)
+    const metadata = this.originalConfig.metadataProvider?.(message)
+    return this.client.createEvent({
+      memoryId: this.originalConfig.memoryId,
+      actorId: this.originalConfig.actorId,
+      sessionId: this.originalConfig.sessionId,
+      eventTimestamp: new Date(),
+      clientToken,
+      payload: [
+        {
+          conversational: {
+            role: mapRole(message),
+            content: { text },
           },
-        ],
-        ...(metadata && { metadata }),
-      })
-    })
-
-    let timer: ReturnType<typeof globalThis.setTimeout> | undefined
-    const timeout = new Promise<never>((_, reject) => {
-      timer = globalThis.setTimeout(() => {
-        const msg = `[agentcore-memory] createEvent timed out after ${timeoutMs}ms (clientToken=${clientToken}); retry will use same token`
-        console.warn(msg)
-        this.notifyDropped({ reason: 'timeout', count: 1, clientToken, cause: new Error(msg) })
-        reject(new Error(msg))
-      }, timeoutMs)
-    })
-
-    return Promise.race([call, timeout]).finally(() => {
-      if (timer) globalThis.clearTimeout(timer)
+        },
+      ],
+      ...(metadata && { metadata }),
     })
   }
 
@@ -422,12 +329,5 @@ export class AgentCoreMemory implements Plugin {
     const { sessionId, actorId } = this.originalConfig
     const counter = this.tokenCounter++
     return `${sessionId}-${actorId}-${Date.now()}-${counter}-${Math.random().toString(36).slice(2, 10)}`
-  }
-
-  private clearFlushTimer(): void {
-    if (this.flushTimer) {
-      globalThis.clearTimeout(this.flushTimer)
-      this.flushTimer = undefined
-    }
   }
 }

--- a/src/memory/integrations/strands/plugin.ts
+++ b/src/memory/integrations/strands/plugin.ts
@@ -6,6 +6,7 @@ import type { LocalAgent, Message, SystemPrompt } from '@strands-agents/sdk'
 import { MemoryClient } from '../../client.js'
 import type {
   AgentCoreMemoryConfig,
+  DroppedEventInfo,
   InjectionConfig,
   MemoryRecordGroup,
   MemoryRecord,
@@ -43,6 +44,7 @@ export class AgentCoreMemory implements Plugin {
   private flushTimer?: ReturnType<typeof globalThis.setTimeout> | undefined
   private pendingFlush: Promise<void> | null = null
   private shuttingDown = false
+  private postShutdownDropWarned = false
   private searchMemoryTool?: Tool
   private tokenCounter = 0
 
@@ -241,10 +243,27 @@ export class AgentCoreMemory implements Plugin {
 
   private shouldBuffer(message: Message): boolean {
     if (!this.extractionConfig) return false
-    if (this.shuttingDown) return false
+    if (this.shuttingDown) {
+      if (!this.postShutdownDropWarned) {
+        this.postShutdownDropWarned = true
+        console.warn('[agentcore-memory] Dropping message received after shutdown()')
+      }
+      this.notifyDropped({ reason: 'post-shutdown', count: 1 })
+      return false
+    }
     const role = message.role
     if (role !== 'user' && role !== 'assistant') return false
     return this.extractionConfig.messageFilter(message)
+  }
+
+  private notifyDropped(info: DroppedEventInfo): void {
+    const cb = this.extractionConfig?.onDroppedEvents
+    if (!cb) return
+    try {
+      cb(info)
+    } catch (err) {
+      console.warn('[agentcore-memory] onDroppedEvents callback threw:', err)
+    }
   }
 
   private bufferMessage(message: Message): void {
@@ -282,9 +301,11 @@ export class AgentCoreMemory implements Plugin {
         await this.flushBuffer()
       }
       if (this.buffer.length > 0) {
+        const stranded = this.buffer.length
         console.warn(
-          `[agentcore-memory] flush reached maxDrainIterations=${this.extractionConfig!.maxDrainIterations} with ${this.buffer.length} message(s) still buffered`
+          `[agentcore-memory] flush reached maxDrainIterations=${this.extractionConfig!.maxDrainIterations} with ${stranded} message(s) still buffered`
         )
+        this.notifyDropped({ reason: 'max-drain-iterations', count: stranded })
       }
     }
 
@@ -326,6 +347,7 @@ export class AgentCoreMemory implements Plugin {
 
     for (const detail of failedDetails) {
       console.warn(`[agentcore-memory] Dropping event after retry (clientToken=${detail.token}):`, detail.reason)
+      this.notifyDropped({ reason: 'retry-failed', count: 1, clientToken: detail.token, cause: detail.reason })
     }
     console.warn(`[agentcore-memory] Dropped ${failedDetails.length} event(s) after retry`)
   }
@@ -362,10 +384,12 @@ export class AgentCoreMemory implements Plugin {
 
     let timer: ReturnType<typeof globalThis.setTimeout> | undefined
     const timeout = new Promise<never>((_, reject) => {
-      timer = globalThis.setTimeout(
-        () => reject(new Error(`[agentcore-memory] createEvent timed out after ${timeoutMs}ms`)),
-        timeoutMs
-      )
+      timer = globalThis.setTimeout(() => {
+        const msg = `[agentcore-memory] createEvent timed out after ${timeoutMs}ms (clientToken=${clientToken}); retry will use same token`
+        console.warn(msg)
+        this.notifyDropped({ reason: 'timeout', count: 1, clientToken, cause: new Error(msg) })
+        reject(new Error(msg))
+      }, timeoutMs)
     })
 
     return Promise.race([call, timeout]).finally(() => {

--- a/src/memory/integrations/strands/plugin.ts
+++ b/src/memory/integrations/strands/plugin.ts
@@ -271,6 +271,9 @@ export class AgentCoreMemory implements Plugin {
     }
     const role = message.role
     if (role !== 'user' && role !== 'assistant') return false
+    // Skip messages with no extractable text (image-only, tool-use-only,
+    // reasoning-only). Prevents wasted createEvent calls with text: "".
+    if (!extractText(message)) return false
     return this.extractionConfig.messageFilter(message)
   }
 

--- a/src/memory/integrations/strands/plugin.ts
+++ b/src/memory/integrations/strands/plugin.ts
@@ -1,0 +1,293 @@
+/// <reference types="node" />
+
+import type { Plugin, Tool } from '@strands-agents/sdk'
+import { BeforeInvocationEvent, MessageAddedEvent, AfterInvocationEvent } from '@strands-agents/sdk'
+import type { LocalAgent, Message, SystemPrompt } from '@strands-agents/sdk'
+import { MemoryClient } from '../../client.js'
+import type {
+  AgentCoreMemoryConfig,
+  InjectionConfig,
+  MemoryRecordGroup,
+  MemoryRecord,
+  ResolvedExtractionConfig,
+} from './types.js'
+import { resolveExtractionConfig } from './types.js'
+import {
+  deriveLabel,
+  formatMemoryBlock,
+  truncateToCharBudget,
+  stripMemoryBlock,
+  appendMemoryBlock,
+  extractText,
+  mapRole,
+} from './format.js'
+import { createSearchMemoryTool } from './search-memory-tool.js'
+
+interface AgentWithSystemPrompt {
+  systemPrompt?: SystemPrompt | undefined
+  messages: Message[]
+}
+
+export class AgentCoreMemory implements Plugin {
+  readonly name = 'agentcore-memory'
+
+  private readonly client: MemoryClient
+  private readonly originalConfig: AgentCoreMemoryConfig
+  private readonly extractionConfig: ResolvedExtractionConfig | null
+  private readonly injectionConfig: InjectionConfig | null
+  private agent!: AgentWithSystemPrompt
+  private initialized = false
+  private buffer: Message[] = []
+  private flushTimer?: ReturnType<typeof globalThis.setTimeout> | undefined
+  private flushing = false
+  private searchMemoryTool?: Tool
+
+  constructor(config: AgentCoreMemoryConfig) {
+    this.originalConfig = config
+    this.extractionConfig = resolveExtractionConfig(config.extraction)
+    this.injectionConfig = config.injection ?? null
+
+    if (config.memoryClient instanceof MemoryClient) {
+      this.client = config.memoryClient as unknown as MemoryClient
+    } else {
+      this.client = new MemoryClient(config.memoryClient)
+    }
+
+    if (this.injectionConfig?.searchTool) {
+      this.searchMemoryTool = createSearchMemoryTool(this.client, {
+        memoryId: config.memoryId,
+        namespaces: this.injectionConfig.namespaces,
+      })
+    }
+
+    if (this.injectionConfig && this.injectionConfig.automatic === false && !this.injectionConfig.searchTool) {
+      console.warn(
+        '[agentcore-memory] injection configured with automatic: false and searchTool: false — injection will do nothing'
+      )
+    }
+  }
+
+  initAgent(agent: LocalAgent): void {
+    if (this.initialized) {
+      throw new Error(
+        'AgentCoreMemory plugin already initialized. Use withActor() or withMetadataProvider() to create a new instance for a different agent.'
+      )
+    }
+    this.initialized = true
+    this.agent = agent as unknown as AgentWithSystemPrompt
+
+    if (this.injectionConfig && this.injectionConfig.automatic !== false) {
+      agent.addHook(BeforeInvocationEvent, () => this.handleBeforeInvocation())
+    }
+
+    if (this.extractionConfig) {
+      agent.addHook(MessageAddedEvent, (e) => this.handleMessageAdded(e))
+      agent.addHook(AfterInvocationEvent, () => this.handleAfterInvocation())
+    }
+  }
+
+  getTools(): Tool[] {
+    if (this.searchMemoryTool) {
+      return [this.searchMemoryTool]
+    }
+    return []
+  }
+
+  withActor(actorId: string): AgentCoreMemory {
+    return AgentCoreMemory.cloneWithConfig(this, { ...this.originalConfig, actorId })
+  }
+
+  withMetadataProvider(fn: (message: Message) => Record<string, { stringValue: string }>): AgentCoreMemory {
+    return AgentCoreMemory.cloneWithConfig(this, { ...this.originalConfig, metadataProvider: fn })
+  }
+
+  private static cloneWithConfig(source: AgentCoreMemory, config: AgentCoreMemoryConfig): AgentCoreMemory {
+    const instance = new AgentCoreMemory(config)
+    Object.defineProperty(instance, 'client', { value: source.client })
+    return instance
+  }
+
+  private async handleBeforeInvocation(): Promise<void> {
+    try {
+      await this.retrieveAndInject()
+    } catch (err) {
+      const tag = this.injectionConfig!.contextTag ?? 'agentcore_memory'
+      this.agent.systemPrompt = stripMemoryBlock(this.agent.systemPrompt, tag)
+      console.warn('[agentcore-memory] Injection failed, continuing without memory context:', err)
+    }
+  }
+
+  private async retrieveAndInject(): Promise<void> {
+    const config = this.injectionConfig!
+    const tag = config.contextTag ?? 'agentcore_memory'
+
+    this.agent.systemPrompt = stripMemoryBlock(this.agent.systemPrompt, tag)
+
+    const query = this.getSearchQuery()
+    const namespaceEntries = Object.entries(config.namespaces)
+
+    const results = await Promise.all(
+      namespaceEntries.map(async ([ns, nsConfig]) => {
+        const response = await this.client.retrieveMemoryRecords({
+          memoryId: this.originalConfig.memoryId,
+          namespace: ns,
+          searchCriteria: {
+            searchQuery: query,
+            topK: nsConfig.topK ?? 5,
+          },
+        })
+
+        let records: MemoryRecord[] = (response.memoryRecordSummaries ?? []).map((r) => {
+          const record: MemoryRecord = {
+            content: (r.content as { text?: string })?.text ?? '',
+          }
+          if (r.score !== undefined) record.score = r.score
+          if (r.createdAt !== undefined) record.createdAt = r.createdAt
+          return record
+        })
+
+        if (nsConfig.relevanceScore !== undefined) {
+          records = records.filter((r) => (r.score ?? 0) >= nsConfig.relevanceScore!)
+        }
+
+        return {
+          namespace: ns,
+          label: deriveLabel(ns),
+          records,
+        } satisfies MemoryRecordGroup
+      })
+    )
+
+    const groups = results.filter((g) => g.records.length > 0)
+    if (groups.length === 0) return
+
+    const maxChars = config.maxInjectionChars ?? 8000
+    const truncated = truncateToCharBudget(groups, maxChars)
+
+    const formatter = config.formatMemories ?? ((g: MemoryRecordGroup[]): string => formatMemoryBlock(g, tag))
+    const block = formatter(truncated)
+
+    if (!block) return
+
+    this.agent.systemPrompt = appendMemoryBlock(this.agent.systemPrompt, block)
+  }
+
+  private getSearchQuery(): string {
+    const messages = this.agent.messages
+    const lastMsg = messages.length > 0 ? messages[messages.length - 1] : undefined
+    if (!lastMsg) {
+      return this.buildGenericQuery()
+    }
+    const text = extractText(lastMsg)
+    return text || this.buildGenericQuery()
+  }
+
+  private buildGenericQuery(): string {
+    if (!this.injectionConfig) return 'user context'
+    const labels = Object.keys(this.injectionConfig.namespaces).map(deriveLabel)
+    return `Retrieve relevant context about: ${labels.join(', ')}`
+  }
+
+  private handleMessageAdded(event: MessageAddedEvent): void {
+    try {
+      const message = event.message
+      if (!this.shouldBuffer(message)) return
+      this.bufferMessage(message)
+    } catch (err) {
+      console.warn('[agentcore-memory] Error buffering message:', err)
+    }
+  }
+
+  private async handleAfterInvocation(): Promise<void> {
+    try {
+      this.clearFlushTimer()
+      if (this.extractionConfig!.fireAndForget) {
+        this.flushBuffer().catch((err) => console.warn('[agentcore-memory] Background flush failed:', err))
+      } else {
+        await this.flushBuffer()
+      }
+    } catch (err) {
+      console.warn('[agentcore-memory] Extraction flush failed:', err)
+    }
+  }
+
+  private shouldBuffer(message: Message): boolean {
+    if (!this.extractionConfig) return false
+    return this.extractionConfig.messageFilter(message)
+  }
+
+  private bufferMessage(message: Message): void {
+    this.buffer.push(message)
+
+    if (this.buffer.length >= this.extractionConfig!.batchSize) {
+      this.flushBuffer().catch((err) => console.warn('[agentcore-memory] Early flush failed:', err))
+      return
+    }
+
+    if (!this.flushTimer && this.buffer.length === 1) {
+      this.flushTimer = globalThis.setTimeout(() => {
+        this.flushBuffer().catch((err) => console.warn('[agentcore-memory] Timer flush failed:', err))
+      }, this.extractionConfig!.batchTimeoutMs)
+    }
+  }
+
+  private async flushBuffer(): Promise<void> {
+    if (this.flushing) return
+    if (this.buffer.length === 0) return
+
+    this.flushing = true
+    const toFlush = [...this.buffer]
+    this.buffer = []
+    this.clearFlushTimer()
+
+    try {
+      const results = await Promise.allSettled(toFlush.map((msg, i) => this.createEventFromMessage(msg, i)))
+
+      const failed = results.map((r, i) => (r.status === 'rejected' ? i : null)).filter((i): i is number => i !== null)
+
+      if (failed.length > 0) {
+        const retryResults = await Promise.allSettled(failed.map((i) => this.createEventFromMessage(toFlush[i]!, i)))
+        const stillFailed = retryResults.filter((r) => r.status === 'rejected').length
+        if (stillFailed > 0) {
+          console.warn(`[agentcore-memory] Dropped ${stillFailed} events after retry`)
+        }
+      }
+    } finally {
+      this.flushing = false
+    }
+  }
+
+  private createEventFromMessage(message: Message, index: number): Promise<unknown> {
+    const text = extractText(message)
+    const metadata = this.originalConfig.metadataProvider?.(message)
+
+    return this.client.createEvent({
+      memoryId: this.originalConfig.memoryId,
+      actorId: this.originalConfig.actorId,
+      sessionId: this.originalConfig.sessionId,
+      eventTimestamp: new Date(),
+      clientToken: this.generateClientToken(index),
+      payload: [
+        {
+          conversational: {
+            role: mapRole(message),
+            content: { text },
+          },
+        },
+      ],
+      ...(metadata && { metadata }),
+    })
+  }
+
+  private generateClientToken(index: number): string {
+    const { sessionId, actorId } = this.originalConfig
+    return `${sessionId}-${actorId}-${Date.now()}-${index}`
+  }
+
+  private clearFlushTimer(): void {
+    if (this.flushTimer) {
+      globalThis.clearTimeout(this.flushTimer)
+      this.flushTimer = undefined
+    }
+  }
+}

--- a/src/memory/integrations/strands/plugin.ts
+++ b/src/memory/integrations/strands/plugin.ts
@@ -30,6 +30,14 @@ interface AgentWithSystemPrompt {
   messages: Message[]
 }
 
+// Tracks which AgentCoreMemory instance owns which Agent. Prevents two plugins
+// from both hooking the same agent — that path silently duplicates every
+// extracted event under two actorIds, doubling cost + confusing LTM. A customer
+// who wants multi-actor should use withActor() / withMetadataProvider() forks
+// on separate agents, or construct two plugins on separate agents with distinct
+// contextTags. This guard makes the failure loud instead of silent.
+const AGENT_REGISTRY = new WeakMap<object, AgentCoreMemory>()
+
 export class AgentCoreMemory implements Plugin {
   readonly name = 'agentcore-memory'
 
@@ -83,6 +91,16 @@ export class AgentCoreMemory implements Plugin {
         'AgentCoreMemory plugin already initialized. Use withActor() or withMetadataProvider() to create a new instance for a different agent.'
       )
     }
+    const existing = AGENT_REGISTRY.get(agent as unknown as object)
+    if (existing) {
+      throw new Error(
+        'AgentCoreMemory: another AgentCoreMemory plugin is already registered on this agent. ' +
+          'Registering two plugins on the same agent silently duplicates every extracted event. ' +
+          'If you need multi-actor memory, use separate Agent instances with one plugin each, or ' +
+          'use plugin.withActor() to fork actors within a single agent.'
+      )
+    }
+    AGENT_REGISTRY.set(agent as unknown as object, this)
     this.initialized = true
     this.agent = agent as unknown as AgentWithSystemPrompt
 

--- a/src/memory/integrations/strands/plugin.ts
+++ b/src/memory/integrations/strands/plugin.ts
@@ -10,8 +10,9 @@ import type {
   MemoryRecordGroup,
   MemoryRecord,
   ResolvedExtractionConfig,
+  NamespaceConfig,
 } from './types.js'
-import { resolveExtractionConfig } from './types.js'
+import { resolveExtractionConfig, resolveNamespaces } from './types.js'
 import {
   deriveLabel,
   formatMemoryBlock,
@@ -35,12 +36,16 @@ export class AgentCoreMemory implements Plugin {
   private readonly originalConfig: AgentCoreMemoryConfig
   private readonly extractionConfig: ResolvedExtractionConfig | null
   private readonly injectionConfig: InjectionConfig | null
+  private readonly resolvedNamespaces: Record<string, NamespaceConfig>
   private agent!: AgentWithSystemPrompt
   private initialized = false
-  private buffer: Message[] = []
+  private buffer: Array<{ message: Message; clientToken: string }> = []
   private flushTimer?: ReturnType<typeof globalThis.setTimeout> | undefined
   private flushing = false
+  private pendingFlush: Promise<void> | null = null
+  private shuttingDown = false
   private searchMemoryTool?: Tool
+  private tokenCounter = 0
 
   constructor(config: AgentCoreMemoryConfig) {
     this.originalConfig = config
@@ -53,10 +58,14 @@ export class AgentCoreMemory implements Plugin {
       this.client = new MemoryClient(config.memoryClient)
     }
 
+    this.resolvedNamespaces = this.injectionConfig
+      ? resolveNamespaces(this.injectionConfig.namespaces, config.actorId, config.sessionId)
+      : {}
+
     if (this.injectionConfig?.searchTool) {
       this.searchMemoryTool = createSearchMemoryTool(this.client, {
         memoryId: config.memoryId,
-        namespaces: this.injectionConfig.namespaces,
+        namespaces: this.resolvedNamespaces,
       })
     }
 
@@ -102,9 +111,7 @@ export class AgentCoreMemory implements Plugin {
   }
 
   private static cloneWithConfig(source: AgentCoreMemory, config: AgentCoreMemoryConfig): AgentCoreMemory {
-    const instance = new AgentCoreMemory(config)
-    Object.defineProperty(instance, 'client', { value: source.client })
-    return instance
+    return new AgentCoreMemory({ ...config, memoryClient: source.client })
   }
 
   private async handleBeforeInvocation(): Promise<void> {
@@ -124,13 +131,16 @@ export class AgentCoreMemory implements Plugin {
     this.agent.systemPrompt = stripMemoryBlock(this.agent.systemPrompt, tag)
 
     const query = this.getSearchQuery()
-    const namespaceEntries = Object.entries(config.namespaces)
+    const templateKeys = Object.keys(config.namespaces)
+    const resolvedKeys = Object.keys(this.resolvedNamespaces)
 
     const results = await Promise.all(
-      namespaceEntries.map(async ([ns, nsConfig]) => {
+      templateKeys.map(async (templateNs, idx) => {
+        const apiNamespace = resolvedKeys[idx]!
+        const nsConfig = config.namespaces[templateNs]!
         const response = await this.client.retrieveMemoryRecords({
           memoryId: this.originalConfig.memoryId,
-          namespace: ns,
+          namespace: apiNamespace,
           searchCriteria: {
             searchQuery: query,
             topK: nsConfig.topK ?? 5,
@@ -151,8 +161,8 @@ export class AgentCoreMemory implements Plugin {
         }
 
         return {
-          namespace: ns,
-          label: deriveLabel(ns),
+          namespace: apiNamespace,
+          label: deriveLabel(templateNs),
           records,
         } satisfies MemoryRecordGroup
       })
@@ -202,33 +212,90 @@ export class AgentCoreMemory implements Plugin {
     try {
       this.clearFlushTimer()
       if (this.extractionConfig!.fireAndForget) {
-        this.flushBuffer().catch((err) => console.warn('[agentcore-memory] Background flush failed:', err))
+        this.drainUntilEmpty().catch((err) => console.warn('[agentcore-memory] Background flush failed:', err))
       } else {
-        await this.flushBuffer()
+        await this.drainUntilEmpty()
       }
     } catch (err) {
       console.warn('[agentcore-memory] Extraction flush failed:', err)
     }
   }
 
+  /**
+   * Force an immediate flush of any buffered events and wait for completion.
+   * Safe to call from user code when the agent terminates or a checkpoint is needed.
+   * Loops until the buffer is empty or {@link ResolvedExtractionConfig.maxDrainIterations}
+   * is reached.
+   */
+  async flush(): Promise<void> {
+    if (!this.extractionConfig) return
+    this.clearFlushTimer()
+    await this.drainUntilEmpty()
+  }
+
+  /**
+   * Stop accepting new buffered messages, cancel pending timers, and await the
+   * final flush. After shutdown the plugin is inert — subsequent events are ignored.
+   */
+  async shutdown(): Promise<void> {
+    this.shuttingDown = true
+    this.clearFlushTimer()
+    await this.drainUntilEmpty()
+  }
+
   private shouldBuffer(message: Message): boolean {
     if (!this.extractionConfig) return false
+    if (this.shuttingDown) return false
+    const role = message.role
+    if (role !== 'user' && role !== 'assistant') return false
     return this.extractionConfig.messageFilter(message)
   }
 
   private bufferMessage(message: Message): void {
-    this.buffer.push(message)
+    const clientToken = this.generateClientToken()
+    this.buffer.push({ message, clientToken })
 
     if (this.buffer.length >= this.extractionConfig!.batchSize) {
-      this.flushBuffer().catch((err) => console.warn('[agentcore-memory] Early flush failed:', err))
+      this.drainUntilEmpty().catch((err) => console.warn('[agentcore-memory] Early flush failed:', err))
       return
     }
 
     if (!this.flushTimer && this.buffer.length === 1) {
       this.flushTimer = globalThis.setTimeout(() => {
-        this.flushBuffer().catch((err) => console.warn('[agentcore-memory] Timer flush failed:', err))
+        this.drainUntilEmpty().catch((err) => console.warn('[agentcore-memory] Timer flush failed:', err))
       }, this.extractionConfig!.batchTimeoutMs)
     }
+  }
+
+  /**
+   * Drain the buffer across multiple flush passes. Each pass takes a snapshot
+   * of the current buffer; any messages that arrive during the pass (from
+   * concurrent MessageAddedEvent callbacks) are picked up on the next iteration.
+   * Bounded by {@link ResolvedExtractionConfig.maxDrainIterations} to guard against
+   * pathological producers.
+   */
+  private async drainUntilEmpty(): Promise<void> {
+    if (this.pendingFlush) {
+      await this.pendingFlush
+      return
+    }
+
+    const run = async (): Promise<void> => {
+      const maxIter = this.extractionConfig!.maxDrainIterations
+      for (let i = 0; i < maxIter && this.buffer.length > 0; i++) {
+        await this.flushBuffer()
+      }
+      if (this.buffer.length > 0) {
+        console.warn(
+          `[agentcore-memory] flush reached maxDrainIterations=${this.extractionConfig!.maxDrainIterations} with ${this.buffer.length} message(s) still buffered`
+        )
+      }
+    }
+
+    this.pendingFlush = run().finally(() => {
+      this.pendingFlush = null
+    })
+    await this.pendingFlush
   }
 
   private async flushBuffer(): Promise<void> {
@@ -241,15 +308,31 @@ export class AgentCoreMemory implements Plugin {
     this.clearFlushTimer()
 
     try {
-      const results = await Promise.allSettled(toFlush.map((msg, i) => this.createEventFromMessage(msg, i)))
+      const results = await Promise.allSettled(
+        toFlush.map((entry) => this.createEventFromMessage(entry.message, entry.clientToken))
+      )
 
-      const failed = results.map((r, i) => (r.status === 'rejected' ? i : null)).filter((i): i is number => i !== null)
+      const failed: number[] = []
+      for (let i = 0; i < results.length; i++) {
+        if (results[i]!.status === 'rejected') failed.push(i)
+      }
 
       if (failed.length > 0) {
-        const retryResults = await Promise.allSettled(failed.map((i) => this.createEventFromMessage(toFlush[i]!, i)))
-        const stillFailed = retryResults.filter((r) => r.status === 'rejected').length
-        if (stillFailed > 0) {
-          console.warn(`[agentcore-memory] Dropped ${stillFailed} events after retry`)
+        const retryResults = await Promise.allSettled(
+          failed.map((i) => this.createEventFromMessage(toFlush[i]!.message, toFlush[i]!.clientToken))
+        )
+        const failedDetails: Array<{ token: string; reason: unknown }> = []
+        for (let j = 0; j < retryResults.length; j++) {
+          const r = retryResults[j]!
+          if (r.status === 'rejected') {
+            failedDetails.push({ token: toFlush[failed[j]!]!.clientToken, reason: r.reason })
+          }
+        }
+        if (failedDetails.length > 0) {
+          for (const detail of failedDetails) {
+            console.warn(`[agentcore-memory] Dropping event after retry (clientToken=${detail.token}):`, detail.reason)
+          }
+          console.warn(`[agentcore-memory] Dropped ${failedDetails.length} event(s) after retry`)
         }
       }
     } finally {
@@ -257,31 +340,53 @@ export class AgentCoreMemory implements Plugin {
     }
   }
 
-  private createEventFromMessage(message: Message, index: number): Promise<unknown> {
-    const text = extractText(message)
-    const metadata = this.originalConfig.metadataProvider?.(message)
-
-    return this.client.createEvent({
-      memoryId: this.originalConfig.memoryId,
-      actorId: this.originalConfig.actorId,
-      sessionId: this.originalConfig.sessionId,
-      eventTimestamp: new Date(),
-      clientToken: this.generateClientToken(index),
-      payload: [
-        {
-          conversational: {
-            role: mapRole(message),
-            content: { text },
+  /**
+   * Wraps each createEvent call in a Promise.race against flushTimeoutMs so a
+   * hung remote can't stall agent.invoke() indefinitely. The body of the call is
+   * wrapped in Promise.resolve().then(...) so a synchronous throw (e.g. from a
+   * user-supplied metadataProvider) becomes a rejected promise instead of
+   * escaping Promise.allSettled's isolation.
+   */
+  private createEventFromMessage(message: Message, clientToken: string): Promise<unknown> {
+    const timeoutMs = this.extractionConfig!.flushTimeoutMs
+    const call = Promise.resolve().then(() => {
+      const text = extractText(message)
+      const metadata = this.originalConfig.metadataProvider?.(message)
+      return this.client.createEvent({
+        memoryId: this.originalConfig.memoryId,
+        actorId: this.originalConfig.actorId,
+        sessionId: this.originalConfig.sessionId,
+        eventTimestamp: new Date(),
+        clientToken,
+        payload: [
+          {
+            conversational: {
+              role: mapRole(message),
+              content: { text },
+            },
           },
-        },
-      ],
-      ...(metadata && { metadata }),
+        ],
+        ...(metadata && { metadata }),
+      })
+    })
+
+    let timer: ReturnType<typeof globalThis.setTimeout> | undefined
+    const timeout = new Promise<never>((_, reject) => {
+      timer = globalThis.setTimeout(
+        () => reject(new Error(`[agentcore-memory] createEvent timed out after ${timeoutMs}ms`)),
+        timeoutMs
+      )
+    })
+
+    return Promise.race([call, timeout]).finally(() => {
+      if (timer) globalThis.clearTimeout(timer)
     })
   }
 
-  private generateClientToken(index: number): string {
+  private generateClientToken(): string {
     const { sessionId, actorId } = this.originalConfig
-    return `${sessionId}-${actorId}-${Date.now()}-${index}`
+    const counter = this.tokenCounter++
+    return `${sessionId}-${actorId}-${Date.now()}-${counter}-${Math.random().toString(36).slice(2, 10)}`
   }
 
   private clearFlushTimer(): void {

--- a/src/memory/integrations/strands/plugin.ts
+++ b/src/memory/integrations/strands/plugin.ts
@@ -41,7 +41,6 @@ export class AgentCoreMemory implements Plugin {
   private initialized = false
   private buffer: Array<{ message: Message; clientToken: string }> = []
   private flushTimer?: ReturnType<typeof globalThis.setTimeout> | undefined
-  private flushing = false
   private pendingFlush: Promise<void> | null = null
   private shuttingDown = false
   private searchMemoryTool?: Tool
@@ -209,15 +208,11 @@ export class AgentCoreMemory implements Plugin {
   }
 
   private async handleAfterInvocation(): Promise<void> {
-    try {
-      this.clearFlushTimer()
-      if (this.extractionConfig!.fireAndForget) {
-        this.drainUntilEmpty().catch((err) => console.warn('[agentcore-memory] Background flush failed:', err))
-      } else {
-        await this.drainUntilEmpty()
-      }
-    } catch (err) {
-      console.warn('[agentcore-memory] Extraction flush failed:', err)
+    this.clearFlushTimer()
+    if (this.extractionConfig!.fireAndForget) {
+      void this.drainUntilEmpty()
+    } else {
+      await this.drainUntilEmpty()
     }
   }
 
@@ -240,6 +235,7 @@ export class AgentCoreMemory implements Plugin {
   async shutdown(): Promise<void> {
     this.shuttingDown = true
     this.clearFlushTimer()
+    if (!this.extractionConfig) return
     await this.drainUntilEmpty()
   }
 
@@ -256,13 +252,13 @@ export class AgentCoreMemory implements Plugin {
     this.buffer.push({ message, clientToken })
 
     if (this.buffer.length >= this.extractionConfig!.batchSize) {
-      this.drainUntilEmpty().catch((err) => console.warn('[agentcore-memory] Early flush failed:', err))
+      void this.drainUntilEmpty()
       return
     }
 
     if (!this.flushTimer && this.buffer.length === 1) {
       this.flushTimer = globalThis.setTimeout(() => {
-        this.drainUntilEmpty().catch((err) => console.warn('[agentcore-memory] Timer flush failed:', err))
+        void this.drainUntilEmpty()
       }, this.extractionConfig!.batchTimeoutMs)
     }
   }
@@ -299,45 +295,39 @@ export class AgentCoreMemory implements Plugin {
   }
 
   private async flushBuffer(): Promise<void> {
-    if (this.flushing) return
     if (this.buffer.length === 0) return
 
-    this.flushing = true
     const toFlush = [...this.buffer]
     this.buffer = []
     this.clearFlushTimer()
 
-    try {
-      const results = await Promise.allSettled(
-        toFlush.map((entry) => this.createEventFromMessage(entry.message, entry.clientToken))
-      )
+    const results = await Promise.allSettled(
+      toFlush.map((entry) => this.createEventFromMessage(entry.message, entry.clientToken))
+    )
 
-      const failed: number[] = []
-      for (let i = 0; i < results.length; i++) {
-        if (results[i]!.status === 'rejected') failed.push(i)
-      }
-
-      if (failed.length > 0) {
-        const retryResults = await Promise.allSettled(
-          failed.map((i) => this.createEventFromMessage(toFlush[i]!.message, toFlush[i]!.clientToken))
-        )
-        const failedDetails: Array<{ token: string; reason: unknown }> = []
-        for (let j = 0; j < retryResults.length; j++) {
-          const r = retryResults[j]!
-          if (r.status === 'rejected') {
-            failedDetails.push({ token: toFlush[failed[j]!]!.clientToken, reason: r.reason })
-          }
-        }
-        if (failedDetails.length > 0) {
-          for (const detail of failedDetails) {
-            console.warn(`[agentcore-memory] Dropping event after retry (clientToken=${detail.token}):`, detail.reason)
-          }
-          console.warn(`[agentcore-memory] Dropped ${failedDetails.length} event(s) after retry`)
-        }
-      }
-    } finally {
-      this.flushing = false
+    const failed: number[] = []
+    for (let i = 0; i < results.length; i++) {
+      if (results[i]!.status === 'rejected') failed.push(i)
     }
+
+    if (failed.length === 0) return
+
+    const retryResults = await Promise.allSettled(
+      failed.map((i) => this.createEventFromMessage(toFlush[i]!.message, toFlush[i]!.clientToken))
+    )
+    const failedDetails: Array<{ token: string; reason: unknown }> = []
+    for (let j = 0; j < retryResults.length; j++) {
+      const r = retryResults[j]!
+      if (r.status === 'rejected') {
+        failedDetails.push({ token: toFlush[failed[j]!]!.clientToken, reason: r.reason })
+      }
+    }
+    if (failedDetails.length === 0) return
+
+    for (const detail of failedDetails) {
+      console.warn(`[agentcore-memory] Dropping event after retry (clientToken=${detail.token}):`, detail.reason)
+    }
+    console.warn(`[agentcore-memory] Dropped ${failedDetails.length} event(s) after retry`)
   }
 
   /**

--- a/src/memory/integrations/strands/search-memory-tool.ts
+++ b/src/memory/integrations/strands/search-memory-tool.ts
@@ -47,9 +47,16 @@ export function createSearchMemoryTool(
       )
 
       const sections: string[] = []
+      const errors: string[] = []
 
-      for (const settled of retrievals) {
-        if (settled.status === 'rejected') continue
+      for (let i = 0; i < retrievals.length; i++) {
+        const settled = retrievals[i]!
+        if (settled.status === 'rejected') {
+          const ns = namespacesToSearch[i]
+          console.warn(`[agentcore-memory] search_memory retrieval failed for namespace ${ns}:`, settled.reason)
+          errors.push(`${ns}: ${settled.reason instanceof Error ? settled.reason.message : String(settled.reason)}`)
+          continue
+        }
 
         const { ns, records, nsConfig } = settled.value
 
@@ -65,7 +72,12 @@ export function createSearchMemoryTool(
         sections.push(`[${label}]\n${lines.join('\n')}`)
       }
 
-      if (sections.length === 0) return 'No relevant memories found.'
+      if (sections.length === 0) {
+        if (errors.length > 0) {
+          return `Memory search failed for all requested namespaces:\n${errors.map((e) => `- ${e}`).join('\n')}`
+        }
+        return 'No relevant memories found.'
+      }
 
       return sections.join('\n\n')
     },

--- a/src/memory/integrations/strands/search-memory-tool.ts
+++ b/src/memory/integrations/strands/search-memory-tool.ts
@@ -1,4 +1,5 @@
 import { tool } from '@strands-agents/sdk'
+import type { InvokableTool } from '@strands-agents/sdk'
 import { z } from 'zod'
 import type { MemoryClient } from '../../client.js'
 import type { NamespaceConfig } from './types.js'
@@ -8,22 +9,26 @@ function namespaceLabel(ns: string): string {
   return parts[parts.length - 1] ?? ns
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
+const searchMemoryInputSchema = z.object({
+  query: z.string().describe('What to search for in memory'),
+  namespace: z
+    .string()
+    .optional()
+    .describe('Specific namespace to search. If omitted, searches all configured namespaces.'),
+})
+
+export type SearchMemoryInput = z.infer<typeof searchMemoryInputSchema>
+export type SearchMemoryTool = InvokableTool<SearchMemoryInput, string>
+
 export function createSearchMemoryTool(
   client: MemoryClient,
   config: { memoryId: string; namespaces: Record<string, NamespaceConfig> }
-) {
+): SearchMemoryTool {
   return tool({
     name: 'search_memory',
     description:
       'Search long-term memory for relevant user context, preferences, or past interactions. Use this when you need to recall information from previous conversations.',
-    inputSchema: z.object({
-      query: z.string().describe('What to search for in memory'),
-      namespace: z
-        .string()
-        .optional()
-        .describe('Specific namespace to search. If omitted, searches all configured namespaces.'),
-    }),
+    inputSchema: searchMemoryInputSchema,
     callback: async ({ query, namespace }) => {
       const namespacesToSearch: string[] = namespace ? [namespace] : Object.keys(config.namespaces)
 

--- a/src/memory/integrations/strands/search-memory-tool.ts
+++ b/src/memory/integrations/strands/search-memory-tool.ts
@@ -1,0 +1,73 @@
+import { tool } from '@strands-agents/sdk'
+import { z } from 'zod'
+import type { MemoryClient } from '../../client.js'
+import type { NamespaceConfig } from './types.js'
+
+function namespaceLabel(ns: string): string {
+  const parts = ns.split('/').filter((p) => p.length > 0 && !p.startsWith('{'))
+  return parts[parts.length - 1] ?? ns
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, @typescript-eslint/explicit-module-boundary-types
+export function createSearchMemoryTool(
+  client: MemoryClient,
+  config: { memoryId: string; namespaces: Record<string, NamespaceConfig> }
+) {
+  return tool({
+    name: 'search_memory',
+    description:
+      'Search long-term memory for relevant user context, preferences, or past interactions. Use this when you need to recall information from previous conversations.',
+    inputSchema: z.object({
+      query: z.string().describe('What to search for in memory'),
+      namespace: z
+        .string()
+        .optional()
+        .describe('Specific namespace to search. If omitted, searches all configured namespaces.'),
+    }),
+    callback: async ({ query, namespace }) => {
+      const namespacesToSearch: string[] = namespace ? [namespace] : Object.keys(config.namespaces)
+
+      if (namespace !== undefined && !(namespace in config.namespaces)) {
+        return `Error: unknown namespace "${namespace}". Configured namespaces: ${Object.keys(config.namespaces).join(', ')}`
+      }
+
+      const retrievals = await Promise.allSettled(
+        namespacesToSearch.map(async (ns) => {
+          const nsConfig = config.namespaces[ns] ?? {}
+          const result = await client.retrieveMemoryRecords({
+            memoryId: config.memoryId,
+            namespace: ns,
+            searchCriteria: {
+              searchQuery: query,
+              topK: nsConfig.topK ?? 5,
+            },
+          })
+          return { ns, records: result.memoryRecordSummaries ?? [], nsConfig }
+        })
+      )
+
+      const sections: string[] = []
+
+      for (const settled of retrievals) {
+        if (settled.status === 'rejected') continue
+
+        const { ns, records, nsConfig } = settled.value
+
+        const filtered =
+          nsConfig.relevanceScore !== undefined
+            ? records.filter((r) => (r.score ?? 0) >= nsConfig.relevanceScore!)
+            : records
+
+        if (filtered.length === 0) continue
+
+        const label = namespaceLabel(ns)
+        const lines = filtered.map((r) => `- ${r.content?.text ?? ''}`)
+        sections.push(`[${label}]\n${lines.join('\n')}`)
+      }
+
+      if (sections.length === 0) return 'No relevant memories found.'
+
+      return sections.join('\n\n')
+    },
+  })
+}

--- a/src/memory/integrations/strands/types.ts
+++ b/src/memory/integrations/strands/types.ts
@@ -1,5 +1,6 @@
 import type { Message, SystemPrompt } from '@strands-agents/sdk'
 import type { MemoryClientConfig } from '../../types.js'
+import type { MemoryClient } from '../../client.js'
 
 export interface NamespaceConfig {
   topK?: number
@@ -11,6 +12,8 @@ export interface ExtractionConfig {
   batchTimeoutMs?: number
   messageFilter?: (message: Message) => boolean
   fireAndForget?: boolean
+  flushTimeoutMs?: number
+  maxDrainIterations?: number
 }
 
 export interface InjectionConfig {
@@ -29,7 +32,7 @@ export interface AgentCoreMemoryConfig {
   extraction?: boolean | ExtractionConfig
   injection?: InjectionConfig
   metadataProvider?: (message: Message) => Record<string, { stringValue: string }>
-  memoryClient?: MemoryClientConfig
+  memoryClient?: MemoryClientConfig | MemoryClient
 }
 
 export interface MemoryRecordGroup {
@@ -49,6 +52,8 @@ export interface ResolvedExtractionConfig {
   batchTimeoutMs: number
   messageFilter: (message: Message) => boolean
   fireAndForget: boolean
+  flushTimeoutMs: number
+  maxDrainIterations: number
 }
 
 export type MetadataProviderFn = (message: Message) => Record<string, { stringValue: string }>
@@ -58,6 +63,8 @@ const DEFAULT_EXTRACTION: ResolvedExtractionConfig = {
   batchTimeoutMs: 5000,
   messageFilter: () => true,
   fireAndForget: false,
+  flushTimeoutMs: 10000,
+  maxDrainIterations: 10,
 }
 
 export function resolveExtractionConfig(
@@ -69,12 +76,45 @@ export function resolveExtractionConfig(
   if (config === true) {
     return { ...DEFAULT_EXTRACTION }
   }
+  if (config.batchSize !== undefined && (!Number.isFinite(config.batchSize) || config.batchSize < 1)) {
+    throw new TypeError(`extraction.batchSize must be a positive integer, got ${config.batchSize}`)
+  }
+  if (config.batchTimeoutMs !== undefined && (!Number.isFinite(config.batchTimeoutMs) || config.batchTimeoutMs < 0)) {
+    throw new TypeError(`extraction.batchTimeoutMs must be a non-negative number, got ${config.batchTimeoutMs}`)
+  }
+  if (config.flushTimeoutMs !== undefined && (!Number.isFinite(config.flushTimeoutMs) || config.flushTimeoutMs < 1)) {
+    throw new TypeError(`extraction.flushTimeoutMs must be a positive number, got ${config.flushTimeoutMs}`)
+  }
+  if (
+    config.maxDrainIterations !== undefined &&
+    (!Number.isInteger(config.maxDrainIterations) || config.maxDrainIterations < 1)
+  ) {
+    throw new TypeError(`extraction.maxDrainIterations must be a positive integer, got ${config.maxDrainIterations}`)
+  }
   return {
     batchSize: config.batchSize ?? DEFAULT_EXTRACTION.batchSize,
     batchTimeoutMs: config.batchTimeoutMs ?? DEFAULT_EXTRACTION.batchTimeoutMs,
     messageFilter: config.messageFilter ?? DEFAULT_EXTRACTION.messageFilter,
     fireAndForget: config.fireAndForget ?? DEFAULT_EXTRACTION.fireAndForget,
+    flushTimeoutMs: config.flushTimeoutMs ?? DEFAULT_EXTRACTION.flushTimeoutMs,
+    maxDrainIterations: config.maxDrainIterations ?? DEFAULT_EXTRACTION.maxDrainIterations,
   }
+}
+
+export function resolveNamespaceTemplate(ns: string, actorId: string, sessionId: string): string {
+  return ns.replace(/\{actorId\}/g, actorId).replace(/\{sessionId\}/g, sessionId)
+}
+
+export function resolveNamespaces(
+  namespaces: Record<string, NamespaceConfig>,
+  actorId: string,
+  sessionId: string
+): Record<string, NamespaceConfig> {
+  const resolved: Record<string, NamespaceConfig> = {}
+  for (const [ns, cfg] of Object.entries(namespaces)) {
+    resolved[resolveNamespaceTemplate(ns, actorId, sessionId)] = cfg
+  }
+  return resolved
 }
 
 export type { SystemPrompt }

--- a/src/memory/integrations/strands/types.ts
+++ b/src/memory/integrations/strands/types.ts
@@ -7,6 +7,15 @@ export interface NamespaceConfig {
   relevanceScore?: number
 }
 
+export type DroppedEventReason = 'retry-failed' | 'max-drain-iterations' | 'post-shutdown' | 'timeout'
+
+export interface DroppedEventInfo {
+  reason: DroppedEventReason
+  count: number
+  clientToken?: string | undefined
+  cause?: unknown
+}
+
 export interface ExtractionConfig {
   batchSize?: number
   batchTimeoutMs?: number
@@ -14,6 +23,12 @@ export interface ExtractionConfig {
   fireAndForget?: boolean
   flushTimeoutMs?: number
   maxDrainIterations?: number
+  /**
+   * Callback fired whenever extraction drops one or more events. Gives
+   * customers a structured hook for alerting / metrics that `console.warn`
+   * alone doesn't provide. Called synchronously; keep the handler fast.
+   */
+  onDroppedEvents?: (info: DroppedEventInfo) => void
 }
 
 export interface InjectionConfig {
@@ -54,6 +69,7 @@ export interface ResolvedExtractionConfig {
   fireAndForget: boolean
   flushTimeoutMs: number
   maxDrainIterations: number
+  onDroppedEvents: ((info: DroppedEventInfo) => void) | undefined
 }
 
 export type MetadataProviderFn = (message: Message) => Record<string, { stringValue: string }>
@@ -65,6 +81,7 @@ const DEFAULT_EXTRACTION: ResolvedExtractionConfig = {
   fireAndForget: false,
   flushTimeoutMs: 10000,
   maxDrainIterations: 10,
+  onDroppedEvents: undefined,
 }
 
 function isNonNegative(n: number): boolean {
@@ -102,6 +119,7 @@ export function resolveExtractionConfig(
     fireAndForget: config.fireAndForget ?? DEFAULT_EXTRACTION.fireAndForget,
     flushTimeoutMs: config.flushTimeoutMs ?? DEFAULT_EXTRACTION.flushTimeoutMs,
     maxDrainIterations: config.maxDrainIterations ?? DEFAULT_EXTRACTION.maxDrainIterations,
+    onDroppedEvents: config.onDroppedEvents ?? DEFAULT_EXTRACTION.onDroppedEvents,
   })
 }
 

--- a/src/memory/integrations/strands/types.ts
+++ b/src/memory/integrations/strands/types.ts
@@ -17,11 +17,45 @@ export interface DroppedEventInfo {
 }
 
 export interface ExtractionConfig {
+  /**
+   * Number of buffered messages that triggers an automatic flush.
+   *
+   * Note: this controls *when* the buffer drains, not how many messages are
+   * sent per API call. The service's `createEvent` accepts one event at a
+   * time, so each buffered message becomes one `createEvent` call regardless
+   * of `batchSize`. Lower values reduce buffering latency and memory; higher
+   * values reduce flush overhead at the cost of holding messages in memory
+   * longer.
+   *
+   * Default: 10. Must be a positive integer.
+   */
   batchSize?: number
+  /**
+   * Maximum time (in milliseconds) a message can sit in the buffer before
+   * being flushed. Resets each time the buffer drains.
+   *
+   * Default: 5000. Must be non-negative and finite.
+   */
   batchTimeoutMs?: number
   messageFilter?: (message: Message) => boolean
   fireAndForget?: boolean
+  /**
+   * Per-event timeout (in milliseconds) for `createEvent` requests. If the
+   * service doesn't respond within this window, the request is rejected and
+   * the retry uses the same `clientToken` for idempotency.
+   *
+   * Default: 10000. Must be a positive finite number.
+   */
   flushTimeoutMs?: number
+  /**
+   * Upper bound on the number of flush passes performed in a single drain.
+   * Guards against pathological producers that keep adding messages while
+   * the buffer is being drained. Any messages still buffered after the cap
+   * is reached are reported via `onDroppedEvents` with reason
+   * `'max-drain-iterations'`.
+   *
+   * Default: 10. Must be a positive integer.
+   */
   maxDrainIterations?: number
   /**
    * Callback fired whenever extraction drops one or more events. Gives

--- a/src/memory/integrations/strands/types.ts
+++ b/src/memory/integrations/strands/types.ts
@@ -67,6 +67,10 @@ const DEFAULT_EXTRACTION: ResolvedExtractionConfig = {
   maxDrainIterations: 10,
 }
 
+function isNonNegative(n: number): boolean {
+  return Number.isFinite(n) && n >= 0 && !Object.is(n, -0)
+}
+
 export function resolveExtractionConfig(
   config: boolean | ExtractionConfig | undefined
 ): ResolvedExtractionConfig | null {
@@ -74,16 +78,16 @@ export function resolveExtractionConfig(
     return null
   }
   if (config === true) {
-    return { ...DEFAULT_EXTRACTION }
+    return Object.freeze({ ...DEFAULT_EXTRACTION })
   }
-  if (config.batchSize !== undefined && (!Number.isFinite(config.batchSize) || config.batchSize < 1)) {
+  if (config.batchSize !== undefined && (!Number.isInteger(config.batchSize) || config.batchSize < 1)) {
     throw new TypeError(`extraction.batchSize must be a positive integer, got ${config.batchSize}`)
   }
-  if (config.batchTimeoutMs !== undefined && (!Number.isFinite(config.batchTimeoutMs) || config.batchTimeoutMs < 0)) {
-    throw new TypeError(`extraction.batchTimeoutMs must be a non-negative number, got ${config.batchTimeoutMs}`)
+  if (config.batchTimeoutMs !== undefined && !isNonNegative(config.batchTimeoutMs)) {
+    throw new TypeError(`extraction.batchTimeoutMs must be a non-negative finite number, got ${config.batchTimeoutMs}`)
   }
-  if (config.flushTimeoutMs !== undefined && (!Number.isFinite(config.flushTimeoutMs) || config.flushTimeoutMs < 1)) {
-    throw new TypeError(`extraction.flushTimeoutMs must be a positive number, got ${config.flushTimeoutMs}`)
+  if (config.flushTimeoutMs !== undefined && (!isNonNegative(config.flushTimeoutMs) || config.flushTimeoutMs < 1)) {
+    throw new TypeError(`extraction.flushTimeoutMs must be a positive finite number, got ${config.flushTimeoutMs}`)
   }
   if (
     config.maxDrainIterations !== undefined &&
@@ -91,14 +95,14 @@ export function resolveExtractionConfig(
   ) {
     throw new TypeError(`extraction.maxDrainIterations must be a positive integer, got ${config.maxDrainIterations}`)
   }
-  return {
+  return Object.freeze({
     batchSize: config.batchSize ?? DEFAULT_EXTRACTION.batchSize,
     batchTimeoutMs: config.batchTimeoutMs ?? DEFAULT_EXTRACTION.batchTimeoutMs,
     messageFilter: config.messageFilter ?? DEFAULT_EXTRACTION.messageFilter,
     fireAndForget: config.fireAndForget ?? DEFAULT_EXTRACTION.fireAndForget,
     flushTimeoutMs: config.flushTimeoutMs ?? DEFAULT_EXTRACTION.flushTimeoutMs,
     maxDrainIterations: config.maxDrainIterations ?? DEFAULT_EXTRACTION.maxDrainIterations,
-  }
+  })
 }
 
 export function resolveNamespaceTemplate(ns: string, actorId: string, sessionId: string): string {

--- a/src/memory/integrations/strands/types.ts
+++ b/src/memory/integrations/strands/types.ts
@@ -1,0 +1,80 @@
+import type { Message, SystemPrompt } from '@strands-agents/sdk'
+import type { MemoryClientConfig } from '../../types.js'
+
+export interface NamespaceConfig {
+  topK?: number
+  relevanceScore?: number
+}
+
+export interface ExtractionConfig {
+  batchSize?: number
+  batchTimeoutMs?: number
+  messageFilter?: (message: Message) => boolean
+  fireAndForget?: boolean
+}
+
+export interface InjectionConfig {
+  namespaces: Record<string, NamespaceConfig>
+  automatic?: boolean
+  searchTool?: boolean
+  maxInjectionChars?: number
+  contextTag?: string
+  formatMemories?: (records: MemoryRecordGroup[]) => string
+}
+
+export interface AgentCoreMemoryConfig {
+  memoryId: string
+  actorId: string
+  sessionId: string
+  extraction?: boolean | ExtractionConfig
+  injection?: InjectionConfig
+  metadataProvider?: (message: Message) => Record<string, { stringValue: string }>
+  memoryClient?: MemoryClientConfig
+}
+
+export interface MemoryRecordGroup {
+  namespace: string
+  label: string
+  records: MemoryRecord[]
+}
+
+export interface MemoryRecord {
+  content: string
+  score?: number
+  createdAt?: Date
+}
+
+export interface ResolvedExtractionConfig {
+  batchSize: number
+  batchTimeoutMs: number
+  messageFilter: (message: Message) => boolean
+  fireAndForget: boolean
+}
+
+export type MetadataProviderFn = (message: Message) => Record<string, { stringValue: string }>
+
+const DEFAULT_EXTRACTION: ResolvedExtractionConfig = {
+  batchSize: 10,
+  batchTimeoutMs: 5000,
+  messageFilter: () => true,
+  fireAndForget: false,
+}
+
+export function resolveExtractionConfig(
+  config: boolean | ExtractionConfig | undefined
+): ResolvedExtractionConfig | null {
+  if (config === undefined || config === false) {
+    return null
+  }
+  if (config === true) {
+    return { ...DEFAULT_EXTRACTION }
+  }
+  return {
+    batchSize: config.batchSize ?? DEFAULT_EXTRACTION.batchSize,
+    batchTimeoutMs: config.batchTimeoutMs ?? DEFAULT_EXTRACTION.batchTimeoutMs,
+    messageFilter: config.messageFilter ?? DEFAULT_EXTRACTION.messageFilter,
+    fireAndForget: config.fireAndForget ?? DEFAULT_EXTRACTION.fireAndForget,
+  }
+}
+
+export type { SystemPrompt }

--- a/tests_integ/memory-strands.test.ts
+++ b/tests_integ/memory-strands.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Integration tests for AgentCoreMemory plugin.
+ *
+ * Tests the plugin's extraction and injection pipelines against real
+ * AgentCore Memory APIs. Uses direct hook invocation rather than a full
+ * Strands Agent to isolate the plugin logic from model dependencies.
+ *
+ * Requires:
+ * - AWS credentials configured (SDK credential chain)
+ * - AWS_REGION env var (defaults to us-west-2)
+ * - IAM perms: bedrock-agentcore:{Create,Get,Delete}Memory, CreateEvent,
+ *   ListEvents, RetrieveMemoryRecords
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { MemoryClient } from '../src/memory/client.js'
+import { AgentCoreMemory } from '../src/memory/integrations/strands/plugin.js'
+import { createSearchMemoryTool } from '../src/memory/integrations/strands/search-memory-tool.js'
+
+const REGION = process.env.AWS_REGION || 'us-west-2'
+const RUN_ID = Date.now()
+const createdMemoryIds = new Set<string>()
+
+function createMockAgent(systemPrompt?: string) {
+  const hooks: Array<{ eventName: string; callback: (event: any) => any }> = []
+  return {
+    systemPrompt: systemPrompt ?? 'You are a helpful assistant.',
+    messages: [] as any[],
+    addHook: (eventType: any, callback: any) => {
+      hooks.push({ eventName: eventType.name, callback })
+      return () => {}
+    },
+    _hooks: hooks,
+    async fireHooks(eventName: string, event: any) {
+      for (const h of hooks.filter((h) => h.eventName === eventName)) {
+        await h.callback(event)
+      }
+    },
+  }
+}
+
+function createMessage(role: 'user' | 'assistant', text: string): any {
+  return { role, content: [{ type: 'textBlock', text }] }
+}
+
+describe('AgentCoreMemory Integration Tests', () => {
+  let client: MemoryClient
+  let memoryId: string
+
+  beforeAll(async () => {
+    client = new MemoryClient({ region: REGION })
+
+    const name = `test_mem_strands_${RUN_ID}`
+    const result = await client.createMemoryAndWait(
+      { name, eventExpiryDuration: 30 },
+      { maxWaitSeconds: 600, pollIntervalMs: 5_000 }
+    )
+    memoryId = result.memory!.id!
+    createdMemoryIds.add(memoryId)
+  }, 720_000)
+
+  afterAll(async () => {
+    await Promise.allSettled(Array.from(createdMemoryIds).map((id) => client.deleteMemory({ memoryId: id })))
+  })
+
+  describe('extraction pipeline', () => {
+    it('stores conversation messages as events via createEvent', async () => {
+      const actorId = `actor-extract-${RUN_ID}`
+      const sessionId = `session-extract-${RUN_ID}`
+
+      const plugin = new AgentCoreMemory({
+        memoryId,
+        actorId,
+        sessionId,
+        extraction: true,
+      })
+
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      const userMsg = createMessage('user', 'I prefer dark mode and concise responses')
+      const assistantMsg = createMessage('assistant', 'Got it! I will remember your preferences.')
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: userMsg })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: assistantMsg })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      const events = await client.listEvents({
+        memoryId,
+        actorId,
+        sessionId,
+        includePayloads: true,
+      })
+
+      expect(events.events).toBeDefined()
+      expect(events.events!.length).toBeGreaterThanOrEqual(2)
+
+      const payloads = events.events!.flatMap((e) =>
+        (e.payload ?? []).filter((p: any) => p.conversational).map((p: any) => p.conversational)
+      )
+      const texts = payloads.map((p: any) => p.content?.text)
+      expect(texts).toContain('I prefer dark mode and concise responses')
+      expect(texts).toContain('Got it! I will remember your preferences.')
+    }, 60_000)
+
+    it('applies messageFilter to skip filtered messages', async () => {
+      const actorId = `actor-filter-${RUN_ID}`
+      const sessionId = `session-filter-${RUN_ID}`
+
+      const plugin = new AgentCoreMemory({
+        memoryId,
+        actorId,
+        sessionId,
+        extraction: {
+          messageFilter: (msg: any) => msg.role !== 'user',
+        },
+      })
+
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('user', 'skip this') })
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'keep this') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      const events = await client.listEvents({
+        memoryId,
+        actorId,
+        sessionId,
+        includePayloads: true,
+      })
+
+      expect(events.events).toBeDefined()
+      expect(events.events!.length).toBe(1)
+
+      const text = (events.events![0]!.payload![0] as any).conversational?.content?.text
+      expect(text).toBe('keep this')
+    }, 60_000)
+
+    it('includes custom metadata on events', async () => {
+      const actorId = `actor-meta-${RUN_ID}`
+      const sessionId = `session-meta-${RUN_ID}`
+
+      const plugin = new AgentCoreMemory({
+        memoryId,
+        actorId,
+        sessionId,
+        extraction: true,
+        metadataProvider: () => ({
+          source: { stringValue: 'integ-test' },
+        }),
+      })
+
+      const agent = createMockAgent()
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('MessageAddedEvent', { agent, message: createMessage('assistant', 'with metadata') })
+      await agent.fireHooks('AfterInvocationEvent', { agent })
+
+      const events = await client.listEvents({
+        memoryId,
+        actorId,
+        sessionId,
+        includePayloads: true,
+      })
+
+      expect(events.events).toBeDefined()
+      expect(events.events!.length).toBeGreaterThanOrEqual(1)
+      const meta = events.events![0]!.metadata
+      expect(meta).toBeDefined()
+      expect((meta as any).source?.stringValue).toBe('integ-test')
+    }, 60_000)
+  })
+
+  describe('injection pipeline', () => {
+    it('retrieves memory records and injects into system prompt', async () => {
+      const actorId = `actor-inject-${RUN_ID}`
+      const sessionId = `session-inject-${RUN_ID}`
+
+      await client.createEvent({
+        memoryId,
+        actorId,
+        sessionId,
+        eventTimestamp: new Date(),
+        payload: [
+          {
+            conversational: {
+              role: 'USER',
+              content: { text: 'I always want dark mode enabled' },
+            },
+          },
+        ],
+      })
+
+      await client.createEvent({
+        memoryId,
+        actorId,
+        sessionId,
+        eventTimestamp: new Date(Date.now() + 1000),
+        payload: [
+          {
+            conversational: {
+              role: 'ASSISTANT',
+              content: { text: 'Noted, I will remember your dark mode preference.' },
+            },
+          },
+        ],
+      })
+
+      const hasMemories = await client.waitForMemories({
+        memoryId,
+        namespace: '/',
+        testQuery: 'dark mode',
+        maxWaitSeconds: 180,
+        pollIntervalMs: 10_000,
+      })
+
+      if (!hasMemories) {
+        console.warn('No LTM records generated in time — skipping injection assertion')
+        return
+      }
+
+      const plugin = new AgentCoreMemory({
+        memoryId,
+        actorId,
+        sessionId: `session-inject-read-${RUN_ID}`,
+        injection: {
+          namespaces: { '/': { topK: 5 } },
+        },
+      })
+
+      const agent = createMockAgent('You are a helpful assistant.')
+      agent.messages = [createMessage('user', 'what are my preferences?')]
+      plugin.initAgent(agent as any)
+
+      await agent.fireHooks('BeforeInvocationEvent', { agent })
+
+      expect(typeof agent.systemPrompt).toBe('string')
+      expect(agent.systemPrompt as string).toContain('<agentcore_memory>')
+    }, 300_000)
+  })
+
+  describe('search_memory tool', () => {
+    it('retrieves results via tool callback', async () => {
+      const actorId = `actor-tool-${RUN_ID}`
+      const sessionId = `session-tool-${RUN_ID}`
+
+      await client.createEvent({
+        memoryId,
+        actorId,
+        sessionId,
+        eventTimestamp: new Date(),
+        payload: [
+          {
+            conversational: {
+              role: 'USER',
+              content: { text: 'My timezone is US/Pacific and I work in engineering' },
+            },
+          },
+        ],
+      })
+
+      const hasMemories = await client.waitForMemories({
+        memoryId,
+        namespace: '/',
+        testQuery: 'timezone engineering',
+        maxWaitSeconds: 180,
+        pollIntervalMs: 10_000,
+      })
+
+      if (!hasMemories) {
+        console.warn('No LTM records generated in time — skipping tool assertion')
+        return
+      }
+
+      const searchTool = createSearchMemoryTool(client, {
+        memoryId,
+        namespaces: { '/': { topK: 5 } },
+      })
+
+      const result = await (searchTool as any).callback({ query: 'timezone' })
+      expect(typeof result).toBe('string')
+      expect(result.length).toBeGreaterThan(0)
+    }, 300_000)
+  })
+})


### PR DESCRIPTION
## Description

Implements the `AgentCoreMemory` plugin for the Strands TypeScript SDK, providing LTM extraction (store conversation messages as memory events) and LTM injection (retrieve insights into the agent's system prompt). This is the TypeScript equivalent of the Python SDK's memory integration, designed from the ground up to avoid the accumulation bug documented in [#420](https://github.com/aws/bedrock-agentcore-sdk-python/issues/420).

### What's included

- **`AgentCoreMemory`** — Strands Plugin (SDK >=0.7.0) with:
  - **Extraction pipeline**: `MessageAddedEvent` → buffer messages → batched flush via `createEvent()` with `Promise.allSettled` + `clientToken` idempotent retries
  - **Injection pipeline**: `BeforeInvocationEvent` → strip stale `<agentcore_memory>` sentinel → retrieve fresh LTM per namespace in parallel → format → inject into `systemPrompt`
  - **`search_memory` tool**: opt-in via `searchTool: true`, registered through `getTools()`
  - **Multi-agent helpers**: `withActor(actorId)`, `withMetadataProvider(fn)`
  - **Lifecycle APIs**: `flush()` and `shutdown()` for graceful drains
  - **Template placeholders**: `{actorId}` / `{sessionId}` resolved at construct time
  - **Constructor validation**: fail-fast on invalid extraction config (batchSize, batchTimeoutMs, flushTimeoutMs, maxDrainIterations)
  - **`onDroppedEvents` callback**: structured drop notifications for retry-failed / timeout / post-shutdown / max-drain-iterations
  - **`AsyncBatcher` utility** (internal): generic buffer/batch/retry/timeout/drain pipeline extracted from the plugin
- **`createSearchMemoryTool`** — standalone tool factory for advanced composability
- **143 unit tests** + integration test scaffold
- **Export path**: `bedrock-agentcore/experimental/memory/strands`

### Key design decisions

- **Extraction and injection are decoupled** — customers opt into each independently
- **Ephemeral system prompt injection** — strip and re-inject each turn, never mutate persisted messages (fixes the Python SDK's O(N×K) accumulation bug)
- **Batching on by default** — `batchSize: 10`, `batchTimeoutMs: 5000ms`. Note: `batchSize` controls *when* the buffer drains, not how many messages are sent per API call — `createEvent` is one-call-per-message regardless of `batchSize` (documented in TSDoc).
- **`extraction:` / `injection:` naming** — replaces `storeMessages:` / `injectContext:` per team review
- **`automatic` + `searchTool` booleans** — replaces `mode: 'tool'` per team review
- **Plugin interface (SDK >=0.7.0)** — uses `initAgent()` + `getTools()`, one-line registration via `plugins: [memoryPlugin]`
- **Idempotent retries** — `clientToken` is generated once at buffer time and reused across the initial send and the retry, guaranteeing the service deduplicates correctly
- **Tool-use / reasoning blocks excluded from LTM** — only `textBlock` content reaches the memory store; agent internals don't pollute. Customers who need them can override via `messageFilter`.

### API shape

```typescript
import { AgentCoreMemory } from 'bedrock-agentcore/experimental/memory/strands'

const memoryPlugin = new AgentCoreMemory({
  memoryId: 'mem-1',
  actorId: 'user-1',
  sessionId: 'session-1',
  extraction: true,  // or { batchSize: 20, messageFilter: (msg) => ... }
  injection: {
    namespaces: {
      '/users/{actorId}/facts': { topK: 5 },
      '/users/{actorId}/preferences': { topK: 3 },
    },
    searchTool: true,
  },
})

const agent = new Agent({
  model,
  plugins: [memoryPlugin],
})
```

## Strands v2 compatibility

This plugin is the v1 user-facing surface. When Strands v2 ships its `MemoryManager` primitive, an `AgentCoreKnowledgeStore` (implementing the `KnowledgeStore` interface) will be added alongside this plugin — both surfaces will be supported, no breaking changes to existing users. The internal `AsyncBatcher` utility was designed to be promotable to a public export if a second consumer (telemetry, identity events, etc.) emerges.

## Related Issues

Design doc: https://quip-amazon.com/odNFAWZ9XaS9
Bug-bash test plan: https://quip-amazon.com/liRSADYLxnPv

## Type of Change

New feature

## Testing

### Unit tests (541 / 541 pass)
- `npm run check` passes (lint, format, type-check, build, tests)
- Plugin class: 36 tests covering hook registration, injection pipeline, extraction pipeline, error handling, multi-agent helpers
- Format utilities: 44 tests covering all edge cases (regex escaping, SystemContentBlock[] handling, truncation, etc.)
- Search tool: 9 tests covering namespace search, filtering, error resilience
- **`AsyncBatcher`**: 15 tests covering size/time triggers, retry idempotency, timeout, drain dedup, maxDrainIterations cap, shutdown, callback error isolation
- **Regression suite (`_verify_concerns.test.ts`)**: 17 tests proving each previously-addressed PR review concern is still fixed (clientToken stability, template resolution, validation throws, lifecycle APIs, content-block filtering)

### E2E testing (deployed agent)
Deployed a real TypeScript agent to AgentCore with the plugin and verified:
- **Extraction** — messages stored as events, processed into LTM facts by the service
- **Injection** — cross-session recall of user facts (name, job, preferences) via system prompt injection
- **search_memory tool** — agent autonomously searched memory to find "TypeScript over Python" preference
- **STM (SessionManager + S3)** — conversation history persisted to S3 via Strands SessionManager, restored on next turn
- **Cross-session LTM** — brand new session recalled facts from prior sessions

Test project: `~/workplace/cli-typescript/memorytest/`

- [x] I ran `npm run check`

## Review feedback addressed

This PR has been through three rounds of review. Status of each comment:

**jariy17's evaluation (43-test edge-case + performance audit):**
- ✅ Finding 1 — namespace `{actorId}` / `{sessionId}` template resolution (now resolved at construct time)
- ✅ Finding 2 — tool-use / reasoning blocks pollute LTM (now excluded from `extractText`)
- ✅ Finding 3 — empty messages cause wasted `createEvent` calls (now skipped at buffer time via `shouldBuffer`)
- ✅ Finding 4 — `flush()` / `shutdown()` lifecycle APIs missing (now public methods)
- ✅ Performance note — `batchSize` semantics clarified in TSDoc on `ExtractionConfig`

**jesseturner21's inline review:**
- ✅ `clientToken` regenerated on retry (now generated once at buffer time and stored alongside the message)
- ✅ `memoryClient` type should be `MemoryClientConfig | MemoryClient` (done; `cloneWithConfig` no longer uses `Object.defineProperty`)

**Hweinstock's inline review:**
- ✅ Decouple batching from session manager — `AsyncBatcher<T>` extracted into `batcher.ts` (internal), 15 unit tests
- ✅ Explicit return type for `createSearchMemoryTool` — now `SearchMemoryTool = InvokableTool<SearchMemoryInput, string>`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

**Note:** `@strands-agents/sdk` peer dependency bumped from `>=0.1.0` to `>=0.7.0` for the Plugin interface. Existing browser/code-interpreter integrations use `tool()` which exists in both versions, so this is backward compatible for those subpaths.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
