### PR TITLE
fix(sse): remove content-length: 0 header before streaming responses

### DIFF
--- a/src/runtime/__tests__/app.test.ts
+++ b/src/runtime/__tests__/app.test.ts
@@ -376,6 +376,8 @@ describe('BedrockAgentCoreApp', () => {
       }
       const mockReply = {
         sse: mockSSE,
+        raw: { removeHeader: vi.fn() },
+        removeHeader: vi.fn(),
         status: vi.fn().mockReturnThis(),
         send: vi.fn(),
       }
@@ -420,6 +422,8 @@ describe('BedrockAgentCoreApp', () => {
 
       const mockReply = {
         sse: mockSSE,
+        raw: { removeHeader: vi.fn() },
+        removeHeader: vi.fn(),
         status: vi.fn().mockReturnThis(),
         send: vi.fn(),
       }
@@ -469,6 +473,8 @@ describe('BedrockAgentCoreApp', () => {
 
       const mockReply = {
         sse: mockSSE,
+        raw: { removeHeader: vi.fn() },
+        removeHeader: vi.fn(),
         status: vi.fn().mockReturnThis(),
         send: vi.fn(),
       }
@@ -517,7 +523,8 @@ describe('BedrockAgentCoreApp', () => {
 
       const mockReply = {
         sse: mockSSE,
-        raw: { headersSent: true },
+        raw: { headersSent: true, removeHeader: vi.fn() },
+        removeHeader: vi.fn(),
         status: vi.fn().mockReturnThis(),
         send: vi.fn(),
       }
@@ -1195,7 +1202,8 @@ describe('BedrockAgentCoreApp', () => {
 
       const mockReply = {
         sse: mockSSE,
-        raw: { headersSent: true },
+        raw: { headersSent: true, removeHeader: vi.fn() },
+        removeHeader: vi.fn(),
         status: vi.fn().mockReturnThis(),
         send: vi.fn(),
       }

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -450,6 +450,12 @@ export class BedrockAgentCoreApp<TSchema extends z.ZodSchema = z.ZodSchema<unkno
    */
   private async _handleStreamingResponse(reply: FastifyReply, generator: AsyncGenerator<SSESource>): Promise<void> {
     try {
+      // Fastify sets content-length: 0 when payload is null/undefined, and
+      // @fastify/sse copies it to reply.raw before writeHead(200), causing
+      // HTTP clients to treat the streaming body as empty.
+      reply.raw.removeHeader('content-length')
+      reply.removeHeader('content-length')
+
       await reply.sse.keepAlive()
       // Stream data chunks
       for await (const chunk of generator) {


### PR DESCRIPTION
## Summary

- Fixes SSE streaming responses including `Content-Length: 0`, which causes HTTP clients (`fetch`, `curl`) to interpret the response body as empty even though SSE data chunks are written afterward
- Removes the `content-length` header from both `reply` and `reply.raw` in `_handleStreamingResponse` before streaming begins, so HTTP falls back to `Transfer-Encoding: chunked`
- Updates 5 streaming test mocks to include the new `removeHeader` calls

Closes #143

## Root Cause

1. Fastify sets `content-length: 0` when payload is `null`/`undefined` ([fastify reply.js#L628](https://github.com/fastify/fastify/blob/v5.8.5/lib/reply.js#L628))
2. `@fastify/sse`'s `sendHeaders()` copies ALL Fastify headers — including `content-length: 0` — to `reply.raw` before `writeHead(200)` ([sse index.js#L190-L199](https://github.com/fastify/sse/blob/v0.4.0/index.js#L190-L199))
3. Clients see `Content-Length: 0` and treat the body as empty

## Test plan

- [x] All 379 unit tests pass
- [x] Type-check, lint, and format checks pass
- [x] E2E verified: `curl -v` against a streaming handler now shows `Transfer-Encoding: chunked` (not `Content-Length: 0`) and all SSE `data:` frames are received