### PR TITLE
fix(runtime): read PORT from environment instead of hardcoding 8080

### DIFF
--- a/src/runtime/__tests__/app.test.ts
+++ b/src/runtime/__tests__/app.test.ts
@@ -151,6 +151,75 @@ describe('BedrockAgentCoreApp', () => {
     })
   })
 
+  describe('run', () => {
+    it('defaults to port 8080 and host 0.0.0.0', async () => {
+      const handler: InvocationHandler = async (_request, _context) => 'test response'
+      const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
+      const mockApp = app['_app'] as any
+
+      delete process.env.PORT
+      app.run()
+
+      await vi.waitFor(() => {
+        expect(mockApp.listen).toHaveBeenCalledWith({ port: 8080, host: '0.0.0.0' })
+      })
+    })
+
+    it('reads PORT from environment variable', async () => {
+      const handler: InvocationHandler = async (_request, _context) => 'test response'
+      const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
+      const mockApp = app['_app'] as any
+
+      process.env.PORT = '3000'
+      app.run()
+
+      await vi.waitFor(() => {
+        expect(mockApp.listen).toHaveBeenCalledWith({ port: 3000, host: '0.0.0.0' })
+      })
+
+      delete process.env.PORT
+    })
+
+    it('accepts port option that overrides env var', async () => {
+      const handler: InvocationHandler = async (_request, _context) => 'test response'
+      const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
+      const mockApp = app['_app'] as any
+
+      process.env.PORT = '3000'
+      app.run({ port: 9090 })
+
+      await vi.waitFor(() => {
+        expect(mockApp.listen).toHaveBeenCalledWith({ port: 9090, host: '0.0.0.0' })
+      })
+
+      delete process.env.PORT
+    })
+
+    it('accepts host option', async () => {
+      const handler: InvocationHandler = async (_request, _context) => 'test response'
+      const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
+      const mockApp = app['_app'] as any
+
+      app.run({ host: '127.0.0.1' })
+
+      await vi.waitFor(() => {
+        expect(mockApp.listen).toHaveBeenCalledWith({ port: 8080, host: '127.0.0.1' })
+      })
+    })
+
+    it('accepts both port and host options', async () => {
+      const handler: InvocationHandler = async (_request, _context) => 'test response'
+      const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
+      const mockApp = app['_app'] as any
+
+      app.run({ port: 4000, host: '127.0.0.1' })
+
+      await vi.waitFor(() => {
+        expect(mockApp.listen).toHaveBeenCalledWith({ port: 4000, host: '127.0.0.1' })
+      })
+    })
+  })
+
   describe('routes setup', () => {
     it('registers GET /ping route', () => {
       const handler: InvocationHandler = async (_request, _context) => 'test response'

--- a/src/runtime/__tests__/app.test.ts
+++ b/src/runtime/__tests__/app.test.ts
@@ -157,7 +157,6 @@ describe('BedrockAgentCoreApp', () => {
       const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
       const mockApp = app['_app'] as any
 
-      delete process.env.PORT
       app.run()
 
       await vi.waitFor(() => {
@@ -165,34 +164,16 @@ describe('BedrockAgentCoreApp', () => {
       })
     })
 
-    it('reads PORT from environment variable', async () => {
+    it('accepts port option', async () => {
       const handler: InvocationHandler = async (_request, _context) => 'test response'
       const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
       const mockApp = app['_app'] as any
 
-      process.env.PORT = '3000'
-      app.run()
-
-      await vi.waitFor(() => {
-        expect(mockApp.listen).toHaveBeenCalledWith({ port: 3000, host: '0.0.0.0' })
-      })
-
-      delete process.env.PORT
-    })
-
-    it('accepts port option that overrides env var', async () => {
-      const handler: InvocationHandler = async (_request, _context) => 'test response'
-      const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
-      const mockApp = app['_app'] as any
-
-      process.env.PORT = '3000'
       app.run({ port: 9090 })
 
       await vi.waitFor(() => {
         expect(mockApp.listen).toHaveBeenCalledWith({ port: 9090, host: '0.0.0.0' })
       })
-
-      delete process.env.PORT
     })
 
     it('accepts host option', async () => {

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -98,10 +98,10 @@ export class BedrockAgentCoreApp<TSchema extends z.ZodSchema = z.ZodSchema<unkno
   }
 
   /**
-   * Starts the Fastify server on port 8080.
+   * Starts the Fastify server on the port specified by the PORT environment variable (default: 8080).
    */
   run(): void {
-    const PORT = 8080
+    const PORT = parseInt(process.env.PORT || '8080', 10)
 
     // Wait for Fastify to be ready (all plugins registered), setup routes, and start the server
     Promise.resolve(this._registerPlugins())

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -101,11 +101,11 @@ export class BedrockAgentCoreApp<TSchema extends z.ZodSchema = z.ZodSchema<unkno
    * Starts the Fastify server.
    *
    * @param options - Optional server options
-   * @param options.port - Port to serve on. Defaults to the PORT environment variable, or 8080.
-   * @param options.host - Host to bind to. Defaults to '0.0.0.0'.
+   * @param options.port - Port to serve on, defaults to 8080.
+   * @param options.host - Host to bind to, defaults to '0.0.0.0'.
    */
   run(options?: { port?: number; host?: string }): void {
-    const PORT = options?.port ?? parseInt(process.env.PORT || '8080', 10)
+    const PORT = options?.port ?? 8080
     const HOST = options?.host ?? '0.0.0.0'
 
     // Wait for Fastify to be ready (all plugins registered), setup routes, and start the server

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -98,17 +98,22 @@ export class BedrockAgentCoreApp<TSchema extends z.ZodSchema = z.ZodSchema<unkno
   }
 
   /**
-   * Starts the Fastify server on the port specified by the PORT environment variable (default: 8080).
+   * Starts the Fastify server.
+   *
+   * @param options - Optional server options
+   * @param options.port - Port to serve on. Defaults to the PORT environment variable, or 8080.
+   * @param options.host - Host to bind to. Defaults to '0.0.0.0'.
    */
-  run(): void {
-    const PORT = parseInt(process.env.PORT || '8080', 10)
+  run(options?: { port?: number; host?: string }): void {
+    const PORT = options?.port ?? parseInt(process.env.PORT || '8080', 10)
+    const HOST = options?.host ?? '0.0.0.0'
 
     // Wait for Fastify to be ready (all plugins registered), setup routes, and start the server
     Promise.resolve(this._registerPlugins())
       .then(() => {
         this._setupContentTypeParsers()
         this._setupRoutes()
-        return this._app.listen({ port: PORT, host: '0.0.0.0' })
+        return this._app.listen({ port: PORT, host: HOST })
       })
       .then(() => {
         this._app.log.info(`Server listening on port ${PORT}`)


### PR DESCRIPTION
## Summary

- `BedrockAgentCoreApp.run()` now accepts optional `{ port, host }` options, matching the Python SDK's API
- Port defaults to `8080`, host defaults to `'0.0.0.0'`

Fixes #147

## Examples

```typescript
// Default: port 8080, host 0.0.0.0
app.run()

// Custom port
app.run({ port: 3000 })

// Custom host
app.run({ host: '127.0.0.1' })

// Both
app.run({ port: 3000, host: '127.0.0.1' })
```

## Test plan

- [x] Added 4 unit tests covering: default port/host, custom port, custom host, combined options
- [x] All 383 unit tests passing
- [x] Build passes