### PR TITLE
chore: replace PAT token with GitHub App token

### DIFF
--- a/.github/workflows/agent-restricted.yml
+++ b/.github/workflows/agent-restricted.yml
@@ -66,6 +66,13 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Run Strands Agent
         uses: ./
         with:
@@ -78,6 +85,6 @@ jobs:
           agent_runner: ${{ inputs.agent_runner }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: 'us-west-2'
-          pat_token: ${{ secrets.PAT_TOKEN }}
+          pat_token: ${{ steps.app-token.outputs.token }}
         env:
           STRANDS_TOOLS_DIRECTORY: "true"


### PR DESCRIPTION
## Summary
- Replace `secrets.PAT_TOKEN` in `agent-restricted.yml` with a short-lived GitHub App token
- Uses `actions/create-github-app-token@v1` with the `agentcore-devx-automation` app (ID: 3637953)

## Setup Required
Before merging, add the following to this repo:
- **Variable** `APP_ID` = `3637953`
- **Secret** `APP_PRIVATE_KEY` = RSA private key from Secrets Manager

## Secrets to Delete After Verification
- `PAT_TOKEN`

## Test plan
- [ ] Add APP_ID variable and APP_PRIVATE_KEY secret to repo
- [ ] Merge PR
- [ ] Trigger `agent-restricted` workflow manually and confirm it succeeds
- [ ] Delete old PAT secret