### PR TITLE
ci: add Claude Code /security-review workflow on PRs

### DIFF
--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -1,0 +1,365 @@
+name: Claude Security Review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description:
+          'PR number to review (note: workflow_dispatch will NOT post inline comments — the action only attaches the
+          inline-comment MCP server on PR-context events. Use this only for end-to-end smoke-testing the prompt
+          plumbing.)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  pull-requests: write
+  issues: write
+  contents: read
+
+concurrency:
+  # Don't cancel-in-progress: a cancelled run that has already started its labels/checkout
+  # but not the actual review still triggers always() steps and ends up posting a misleading
+  # "no findings" summary (since the inline-comment buffer is empty when the analysis step
+  # was skipped due to cancellation). Letting both runs complete is the safer default.
+  group: pr-security-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    # On 'labeled' events, only proceed when the label is exactly 'safe-to-review'.
+    # Other labels (e.g. size/m) are filtered out so we don't spawn API calls.
+    if: |
+      github.event_name != 'pull_request_target' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'safe-to-review'
+    outputs:
+      authorized: ${{ steps.auth.outputs.authorized || steps.dispatch-auth.outputs.authorized }}
+    steps:
+      - name: Check authorization
+        id: auth
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // pull_request_target opened/reopened/synchronize: gate on the PR author
+            //   (auto-runs on maintainer-authored PRs; community PRs need the label path below).
+            // pull_request_target labeled (safe-to-review): gate on the labeler (sender)
+            //   so a maintainer applying the label authorizes the run on a community PR.
+            const isLabel = context.payload.action === 'labeled';
+            const user = isLabel
+              ? context.payload.sender.login
+              : context.payload.pull_request.user.login;
+            const reason = isLabel ? `labeler ${user}` : `PR author ${user}`;
+            try {
+              await github.rest.teams.getMembershipForUserInOrg({
+                org: context.repo.owner,
+                team_slug: 'agentcore-cli-devs',
+                username: user,
+              });
+              console.log(`${reason} is a member of agentcore-cli-devs`);
+              core.setOutput('authorized', 'true');
+            } catch (teamError) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: user,
+                });
+                const hasWriteAccess = ['write', 'admin'].includes(data.permission);
+                if (hasWriteAccess) {
+                  console.log(`${reason} has write access (${data.permission})`);
+                  core.setOutput('authorized', 'true');
+                } else {
+                  console.log(`${reason} does not have write access (${data.permission}) — skipping review`);
+                  core.setOutput('authorized', 'false');
+                }
+              } catch (collabError) {
+                console.log(`${reason} authorization check failed (${collabError.status}) — skipping review`);
+                core.setOutput('authorized', 'false');
+              }
+            }
+
+      - name: Auto-authorize workflow_dispatch
+        id: dispatch-auth
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "authorized=true" >> "$GITHUB_OUTPUT"
+
+  security-review:
+    needs: authorize
+    if: needs.authorize.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      AWS_REGION: us-west-2
+    steps:
+      # Generate the GitHub App token first so every subsequent github-script step can
+      # use it. The default GITHUB_TOKEN is read-only on pull_request_target /
+      # pull_request_review events from forks, which makes label/comment writes 403.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER_INPUT: ${{ inputs.pr_number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const num =
+              context.eventName === 'workflow_dispatch'
+                ? parseInt(process.env.PR_NUMBER_INPUT, 10)
+                : context.payload.pull_request.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: num,
+            });
+            core.setOutput('number', num);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('base_ref', pr.base.ref);
+
+      - name: Add claude-security-reviewing label
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'claude-security-reviewing',
+              });
+            } catch (e) {
+              if (e.status === 404) {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'claude-security-reviewing',
+                  color: 'D73A4A',
+                  description: 'Claude Code /security-review in progress',
+                });
+              }
+            }
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: ['claude-security-reviewing'],
+            });
+
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          # The bundled /security-review skill runs `git diff origin/HEAD...` so we need
+          # the base branch locally too. fetch-depth: 0 grabs the full history.
+          fetch-depth: 0
+
+      - name: Prepare base ref for /security-review skill
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: |
+          set -euo pipefail
+          # The bundled /security-review skill's SessionStart hook runs
+          # `git diff --name-only origin/HEAD...` as its first command. Two
+          # things have to be true for that to succeed:
+          #   1. origin/HEAD has to be a valid ref. actions/checkout doesn't
+          #      set up the remote's symbolic HEAD, so we point it at the PR's
+          #      base branch.
+          #   2. The PR head and origin/<base> have to share a merge base in
+          #      the local clone. actions/checkout@v6 with `ref: <head_sha>`
+          #      fetches the head's history but on fork PRs may NOT fetch
+          #      origin/<base> into the clone — leaving `git diff origin/HEAD...`
+          #      to fail with "no merge base", which silently bombs the skill
+          #      (num_turns=0, model never invoked) and would otherwise look
+          #      like a clean review with zero findings.
+          # Fetching origin/<base> explicitly closes that gap.
+          git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          git remote set-head origin "$BASE_REF"
+          git symbolic-ref refs/remotes/origin/HEAD
+
+          # Sanity: ensure the merge base actually resolves before we hand off
+          # to the skill. If it doesn't, fail loudly here rather than letting
+          # the skill silently bail.
+          if ! git merge-base "origin/$BASE_REF" HEAD >/dev/null; then
+            echo "::error::No merge base between HEAD and origin/$BASE_REF — /security-review cannot compute a diff."
+            exit 1
+          fi
+          echo "Merge base: $(git merge-base "origin/$BASE_REF" HEAD)"
+          echo "Files changed: $(git diff --name-only "origin/$BASE_REF...HEAD" | wc -l)"
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN }}
+          aws-region: us-west-2
+
+      - name: Run Claude Code security review
+        id: review
+        uses: anthropics/claude-code-action@v1
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          use_bedrock: 'true'
+          # The Claude Code SDK that ships with the action has /security-review bundled
+          # as a slash command. Invoking it directly lets the skill drive its own
+          # `git diff origin/HEAD...`, sub-task fan-out, and false-positive filtering
+          # without us re-implementing any of that. We append a short tail telling the
+          # action to use the inline-comment MCP tool for findings.
+          prompt: |
+            /security-review
+
+            For each finding, call mcp__github_inline_comment__create_inline_comment with
+            { path, line, body } pointing at the exact file and line in the diff. Do NOT
+            post a single summary comment listing all findings — the workflow handles a
+            top-level summary after this run completes. If there are no findings, exit
+            without calling any tool.
+          show_full_output: 'true'
+          # Allow-listing this MCP tool name is what tells the action to register the
+          # github_inline_comment MCP server. See anthropics/claude-code-action
+          # src/mcp/install-mcp-server.ts.
+          claude_args: >-
+            --model us.anthropic.claude-opus-4-7 --max-turns 30 --allowedTools
+            mcp__github_inline_comment__create_inline_comment
+
+      - name: Verify model actually ran
+        id: model-ran
+        # The action exits 0 even when the model was never invoked (e.g. a
+        # SessionStart hook errored before the first turn). Treating that as
+        # success would let the workflow falsely report "no high-confidence
+        # findings" — that's exactly what happened on PR #1474, where the
+        # `/security-review` skill's first `git diff origin/HEAD...` hit a
+        # "no merge base" error, the SDK still returned `subtype: success`
+        # with `num_turns: 0` and zero tokens, and the buffer was empty.
+        #
+        # The action writes its full SDK transcript to
+        # ${RUNNER_TEMP}/claude-execution-output.json. We pull the final
+        # result envelope and require that the model actually took turns and
+        # spent tokens. If it didn't, mark the run as not-actually-completed
+        # so the summary comment uses the failure branch instead of pretending
+        # there were no findings.
+        if: steps.review.conclusion == 'success' || steps.review.conclusion == 'failure'
+        env:
+          # The action exposes its full SDK transcript path as the
+          # `execution_file` step output (a JSON array of stream events; the
+          # final element is the result envelope). We fall back to the known
+          # path under RUNNER_TEMP if for some reason the output is missing.
+          OUTPUT_JSON:
+            ${{ steps.review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
+        run: |
+          set -euo pipefail
+          if [ ! -s "$OUTPUT_JSON" ]; then
+            echo "::warning::No claude-execution-output.json found at $OUTPUT_JSON; cannot verify the model ran."
+            echo "ran=unknown" >> "$GITHUB_OUTPUT"
+            echo "num_turns=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          NUM_TURNS=$(jq -r '.[-1].num_turns // 0' "$OUTPUT_JSON")
+          IS_ERROR=$(jq -r '.[-1].is_error // false' "$OUTPUT_JSON")
+          OUTPUT_TOKENS=$(jq -r '.[-1].usage.output_tokens // 0' "$OUTPUT_JSON")
+          echo "num_turns=$NUM_TURNS, is_error=$IS_ERROR, output_tokens=$OUTPUT_TOKENS"
+          echo "num_turns=$NUM_TURNS" >> "$GITHUB_OUTPUT"
+          if [ "$IS_ERROR" = "true" ] || [ "$NUM_TURNS" = "0" ] || [ "$OUTPUT_TOKENS" = "0" ]; then
+            echo "::error::Claude Code SDK reported success but the model never ran productively (num_turns=$NUM_TURNS, output_tokens=$OUTPUT_TOKENS, is_error=$IS_ERROR). The /security-review skill likely bailed before analysis (e.g. SessionStart hook error). Refusing to report 'no findings'."
+            echo "ran=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "ran=true" >> "$GITHUB_OUTPUT"
+
+      - name: Count buffered findings
+        id: findings
+        # Only count if the review step actually ran (success or failure - both produce
+        # a meaningful buffer state). Skip on cancellation/skip so we don't lie about
+        # "no findings" when Bedrock was never invoked.
+        if: steps.review.conclusion == 'success' || steps.review.conclusion == 'failure'
+        run: |
+          set -euo pipefail
+          BUFFER=/tmp/inline-comments-buffer.jsonl
+          if [ -s "$BUFFER" ]; then
+            COUNT=$(wc -l < "$BUFFER" | tr -d ' ')
+          else
+            COUNT=0
+          fi
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Buffered findings: $COUNT"
+
+      - name: Post security review summary comment
+        # Always post some kind of summary so the PR shows the run happened, but branch on
+        # the review step's conclusion so a cancelled/skipped run doesn't get reported as
+        # "no findings".
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          FINDING_COUNT: ${{ steps.findings.outputs.count }}
+          REVIEW_CONCLUSION: ${{ steps.review.conclusion }}
+          MODEL_RAN: ${{ steps.model-ran.outputs.ran }}
+          NUM_TURNS: ${{ steps.model-ran.outputs.num_turns }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const count = parseInt(process.env.FINDING_COUNT || '0', 10);
+            const conclusion = process.env.REVIEW_CONCLUSION || 'skipped';
+            const modelRan = process.env.MODEL_RAN || 'unknown';
+            const numTurns = process.env.NUM_TURNS || '0';
+            const runUrl = process.env.RUN_URL;
+
+            let body;
+            if (modelRan !== 'true') {
+              // Two cases land here, both unsafe to report as "no findings":
+              //   - 'false': SDK exited 0 but transcript shows the model never ran productively
+              //     (e.g. /security-review's SessionStart hook errored before the first turn).
+              //   - 'unknown': claude-execution-output.json was missing, so we couldn't verify
+              //     the model ran at all. Treat as not-verified rather than silently green.
+              body = `**Claude Security Review:** the review did not actually analyze this PR (model took ${numTurns} turn${numTurns === '1' ? '' : 's'} — the skill likely failed during setup). See the [run](${runUrl}) for details; a later push or re-run is needed for a real review.`;
+            } else if (conclusion === 'success') {
+              body =
+                count > 0
+                  ? `**Claude Security Review:** posted ${count} inline finding${count === 1 ? '' : 's'} on this PR. ([run](${runUrl}))`
+                  : `**Claude Security Review:** no high-confidence findings. ([run](${runUrl}))`;
+            } else if (conclusion === 'failure') {
+              body = `**Claude Security Review:** the review run failed before completing. See the [run](${runUrl}) for details.`;
+            } else {
+              // cancelled / skipped — analysis didn't run, do NOT claim "no findings"
+              body = `**Claude Security Review:** the review run was ${conclusion} before the analysis could complete (likely superseded or interrupted). See the [run](${runUrl}); a later run on this PR will replace this status.`;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+      - name: Remove claude-security-reviewing label
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: 'claude-security-reviewing',
+              });
+            } catch (error) {
+              console.log('Label removal failed (may not exist):', error.message);
+            }

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -1,15 +1,26 @@
 name: Claude Security Review
 
+# This workflow inlines the security-review prompt rather than calling the
+# bundled /security-review slash command. The bundled skill silently bombs
+# whenever the runner's clone gets shallowed mid-run (claude-code-action's
+# restoreConfigFromBase does this on every PR by design — see
+# https://github.com/anthropics/claude-code-action/blob/v1/src/github/operations/restore-config.ts),
+# because its first action is `git diff origin/HEAD...` and a shallow clone
+# has no merge base. Computing the diff ourselves before the action starts
+# eliminates that whole class of failure.
+
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
+    # Only review PRs targeting our long-lived release branch. PRs into
+    # short-lived feature branches don't need a security gate — they get
+    # reviewed when those features are merged into main.
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       pr_number:
-        description:
-          'PR number to review (note: workflow_dispatch will NOT post inline comments — the action only attaches the
-          inline-comment MCP server on PR-context events. Use this only for end-to-end smoke-testing the prompt
-          plumbing.)'
+        description: PR number to review (workflow_dispatch will NOT post inline comments — use only for prompt smoke tests)
         required: true
         type: string
 
@@ -45,10 +56,6 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            // pull_request_target opened/reopened/synchronize: gate on the PR author
-            //   (auto-runs on maintainer-authored PRs; community PRs need the label path below).
-            // pull_request_target labeled (safe-to-review): gate on the labeler (sender)
-            //   so a maintainer applying the label authorizes the run on a community PR.
             const isLabel = context.payload.action === 'labeled';
             const user = isLabel
               ? context.payload.sender.login
@@ -60,35 +67,25 @@ jobs:
                 team_slug: 'agentcore-cli-devs',
                 username: user,
               });
-              console.log(`${reason} is a member of agentcore-cli-devs`);
               core.setOutput('authorized', 'true');
-            } catch (teamError) {
+            } catch {
               try {
                 const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   username: user,
                 });
-                const hasWriteAccess = ['write', 'admin'].includes(data.permission);
-                if (hasWriteAccess) {
-                  console.log(`${reason} has write access (${data.permission})`);
-                  core.setOutput('authorized', 'true');
-                } else {
-                  console.log(`${reason} does not have write access (${data.permission}) — skipping review`);
-                  core.setOutput('authorized', 'false');
-                }
-              } catch (collabError) {
-                console.log(`${reason} authorization check failed (${collabError.status}) — skipping review`);
+                core.setOutput('authorized', ['write', 'admin'].includes(data.permission) ? 'true' : 'false');
+              } catch {
                 core.setOutput('authorized', 'false');
               }
             }
-
       - name: Auto-authorize workflow_dispatch
         id: dispatch-auth
         if: github.event_name == 'workflow_dispatch'
         run: echo "authorized=true" >> "$GITHUB_OUTPUT"
 
-  security-review:
+  review:
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: ubuntu-latest
@@ -96,9 +93,6 @@ jobs:
     env:
       AWS_REGION: us-west-2
     steps:
-      # Generate the GitHub App token first so every subsequent github-script step can
-      # use it. The default GITHUB_TOKEN is read-only on pull_request_target /
-      # pull_request_review events from forks, which makes label/comment writes 403.
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -106,7 +100,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Resolve PR number
+      - name: Resolve PR
         id: pr
         uses: actions/github-script@v9
         env:
@@ -114,10 +108,9 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const num =
-              context.eventName === 'workflow_dispatch'
-                ? parseInt(process.env.PR_NUMBER_INPUT, 10)
-                : context.payload.pull_request.number;
+            const num = context.eventName === 'workflow_dispatch'
+              ? parseInt(process.env.PR_NUMBER_INPUT, 10)
+              : context.payload.pull_request.number;
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -127,7 +120,7 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('base_ref', pr.base.ref);
 
-      - name: Add claude-security-reviewing label
+      - name: Add reviewing label
         uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -148,7 +141,7 @@ jobs:
                   repo: context.repo.repo,
                   name: 'claude-security-reviewing',
                   color: 'D73A4A',
-                  description: 'Claude Code /security-review in progress',
+                  description: 'Claude Code security review in progress',
                 });
               }
             }
@@ -163,104 +156,247 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
-          # The bundled /security-review skill runs `git diff origin/HEAD...` so we need
-          # the base branch locally too. fetch-depth: 0 grabs the full history.
           fetch-depth: 0
 
-      - name: Prepare base ref for /security-review skill
+      - name: Compute diff
+        id: diff
         env:
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
           set -euo pipefail
-          # The bundled /security-review skill's SessionStart hook runs
-          # `git diff --name-only origin/HEAD...` as its first command. Two
-          # things have to be true for that to succeed:
-          #   1. origin/HEAD has to be a valid ref. actions/checkout doesn't
-          #      set up the remote's symbolic HEAD, so we point it at the PR's
-          #      base branch.
-          #   2. The PR head and origin/<base> have to share a merge base in
-          #      the local clone. actions/checkout@v6 with `ref: <head_sha>`
-          #      fetches the head's history but on fork PRs may NOT fetch
-          #      origin/<base> into the clone — leaving `git diff origin/HEAD...`
-          #      to fail with "no merge base", which silently bombs the skill
-          #      (num_turns=0, model never invoked) and would otherwise look
-          #      like a clean review with zero findings.
-          # Fetching origin/<base> explicitly closes that gap.
+          # Compute the diff *before* claude-code-action shallows the repo.
+          # The action's restoreConfigFromBase() runs `git fetch --depth=1`
+          # against the base branch on startup, which strips history and
+          # would break any base-vs-head diff after that point. Doing it
+          # here means the model gets a frozen artifact that can't be
+          # invalidated by anything the action does later.
           git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
-          git remote set-head origin "$BASE_REF"
-          git symbolic-ref refs/remotes/origin/HEAD
+          git diff "origin/$BASE_REF...HEAD" > /tmp/pr.diff
+          BYTES=$(wc -c < /tmp/pr.diff)
+          FILES=$(git diff --name-only "origin/$BASE_REF...HEAD" | wc -l | tr -d ' ')
+          echo "bytes=$BYTES" >> "$GITHUB_OUTPUT"
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "Diff: $BYTES bytes across $FILES files"
 
-          # Sanity: ensure the merge base actually resolves before we hand off
-          # to the skill. If it doesn't, fail loudly here rather than letting
-          # the skill silently bail.
-          if ! git merge-base "origin/$BASE_REF" HEAD >/dev/null; then
-            echo "::error::No merge base between HEAD and origin/$BASE_REF — /security-review cannot compute a diff."
-            exit 1
-          fi
-          echo "Merge base: $(git merge-base "origin/$BASE_REF" HEAD)"
-          echo "Files changed: $(git diff --name-only "origin/$BASE_REF...HEAD" | wc -l)"
+      - name: Build prompt
+        if: steps.diff.outputs.bytes != '0'
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/prompt"
+          cat > "$RUNNER_TEMP/prompt/prompt.md" <<'PROMPT_EOF'
+          You are performing a HIGH-CONFIDENCE security code review of a pull
+          request. The complete diff is at `/tmp/pr.diff` — read it first
+          using the Read tool. That file is the ground truth for what the
+          PR changes; do not run `git diff` or any other git commands. To
+          understand context — callers of a changed function, existing
+          sanitization patterns, the project's threat model — use Grep,
+          Glob, and Read against the repository working tree. Do not use
+          Bash.
 
-      - name: Configure AWS credentials (OIDC)
+          # OBJECTIVE
+
+          Identify HIGH-CONFIDENCE security vulnerabilities newly introduced
+          by this PR that have real exploitation potential. This is NOT a
+          general code review. Focus ONLY on security implications added by
+          the PR. Do not comment on pre-existing issues.
+
+          # CRITICAL INSTRUCTIONS
+
+          1. MINIMIZE FALSE POSITIVES: Only flag issues where you are >80%
+             confident of actual exploitability.
+          2. AVOID NOISE: Skip theoretical issues, style concerns, or
+             low-impact findings.
+          3. FOCUS ON IMPACT: Prioritize vulnerabilities that lead to
+             unauthorized access, data breach, or system compromise.
+          4. DO NOT report any of:
+             - Denial of service / resource exhaustion / rate limiting
+             - Secrets at rest on disk (handled by other tooling)
+             - Memory consumption or CPU exhaustion
+
+          # CATEGORIES TO EXAMINE
+
+          **Input validation**: SQL injection, command injection, XXE,
+          template injection, NoSQL injection, path traversal.
+          **AuthN/AuthZ**: authentication bypass, privilege escalation,
+          session/JWT flaws, authorization-logic bypasses.
+          **Crypto & secrets**: hardcoded keys/passwords/tokens, weak
+          algorithms, improper key storage, weak randomness, certificate
+          validation bypass.
+          **Code execution**: deserialization RCE (pickle, YAML, etc.),
+          eval injection, XSS (reflected/stored/DOM) — only in unsafe paths
+          (see precedents).
+          **Data exposure**: sensitive logging, PII handling violations,
+          API leakage, debug-info exposure.
+
+          A finding can still be HIGH severity if only exploitable from the
+          local network.
+
+          # METHODOLOGY
+
+          Phase 1 — Repository context: identify existing security
+          libraries/frameworks, sanitization patterns, the project's threat
+          model. Use search tools.
+
+          Phase 2 — Comparative analysis: compare new changes against
+          established patterns; flag deviations and net-new attack surface.
+
+          Phase 3 — Vulnerability assessment: for each modified file,
+          trace user input → sensitive operations, look for unsafe privilege
+          boundary crossings, identify injection points.
+
+          # FALSE-POSITIVE FILTER (apply hard)
+
+          Read the code (Read/Grep/Glob); do not run commands to reproduce
+          or write files.
+
+          HARD EXCLUSIONS — drop any finding matching:
+          1. DoS / resource exhaustion.
+          2. Secrets/credentials on disk if otherwise secured.
+          3. Rate limiting or service overload.
+          4. Memory/CPU exhaustion.
+          5. Missing input validation on non-security-critical fields.
+          6. Input sanitization in GitHub Actions workflows unless clearly
+             triggerable via untrusted input.
+          7. Lack of hardening; only flag concrete vulns.
+          8. Theoretical race conditions or timing attacks.
+          9. Outdated third-party libraries (handled separately).
+          10. Memory-safety issues in memory-safe languages (Rust, Go,
+              JS/TS, Python).
+          11. Files that are unit tests or test-only.
+          12. Log spoofing — un-sanitized user input to logs is not a vuln.
+          13. SSRF that only controls the path (host/protocol control is
+              required).
+          14. User-controlled content in AI system prompts is not a vuln.
+          15. Regex injection.
+          16. Regex DoS.
+          17. Insecure documentation (.md and similar).
+          18. Lack of audit logs.
+
+          PRECEDENTS:
+          1. Plaintext-logging high-value secrets IS a vuln; logging URLs
+             is assumed safe.
+          2. UUIDs are unguessable and need no validation.
+          3. Env vars and CLI flags are trusted inputs.
+          4. Resource leaks (memory, fd) are not vulns.
+          5. Tabnabbing, XS-Leaks, prototype pollution, open redirects:
+             only with extremely high confidence.
+          6. React / Angular: do not report XSS in components or .tsx files
+             unless using `dangerouslySetInnerHTML`,
+             `bypassSecurityTrustHtml`, or equivalents.
+          7. GitHub Actions workflow vulns: only when a concrete attack
+             path through untrusted input exists.
+          8. Missing AuthN/AuthZ in client-side code is not a vuln —
+             validation is the server's job.
+          9. MEDIUM findings only when obvious and concrete.
+          10. .ipynb notebook vulns: only with a concrete attack path
+              through untrusted input.
+          11. Logging non-PII data is not a vuln. Only flag when the data
+              is secrets, passwords, or PII.
+          12. Command injection in shell scripts: only when there is a
+              concrete attack path through untrusted input.
+
+          For each surviving finding, score confidence 1–10:
+          - 1–3: low / likely noise — drop
+          - 4–6: medium — drop unless obvious and concrete
+          - 7–10: high — keep
+
+          # PROCESS
+
+          Run this in three steps, exactly:
+
+          1. Spawn a Task sub-agent to identify candidate vulnerabilities.
+             Pass the full instructions above (objective, categories,
+             methodology, hard exclusions, precedents). Have it return a
+             structured list of candidates with file/line/category/
+             description/exploit/fix.
+
+          2. For EACH candidate from step 1, spawn an independent Task
+             sub-agent IN PARALLEL to adversarially verify it. Each
+             verifier gets the full FALSE-POSITIVE FILTER above and is
+             told to default to "drop" if uncertain. Each returns a
+             confidence score 1–10.
+
+          3. Drop any finding with confidence < 8. For every finding that
+             survives, call:
+
+                 mcp__github_inline_comment__create_inline_comment
+
+             with `{ path, line, body }` pointing at the exact file and
+             line in the diff. The body should follow:
+
+                 **<Severity>: <Category>**
+                 <One-paragraph description of the issue and concrete
+                 exploit scenario.>
+                 **Recommendation:** <One-sentence fix.>
+
+             Do NOT post a single summary comment listing all findings —
+             the workflow handles a top-level summary after this run
+             completes. If zero findings survive Phase 3, exit without
+             calling any tool.
+
+          Begin.
+          PROMPT_EOF
+
+      - name: Configure AWS credentials
+        if: steps.diff.outputs.bytes != '0'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Run Claude Code security review
+      - name: Load prompt into env
+        id: load-prompt
+        if: steps.diff.outputs.bytes != '0'
+        # The action only accepts `prompt:` (a string), not a file path —
+        # passing prompt_file silently no-ops, leaves the action with no
+        # trigger, and skips the run with "No trigger found". Read the
+        # built prompt into an environment variable so we can pass it
+        # inline below. Using GITHUB_ENV with a randomized heredoc
+        # sentinel is the standard Actions idiom for multi-line values.
+        env:
+          PROMPT_FILE: ${{ runner.temp }}/prompt/prompt.md
+        run: |
+          set -euo pipefail
+          DELIM="EOF_$(uuidgen)"
+          {
+            echo "PROMPT_BODY<<$DELIM"
+            cat "$PROMPT_FILE"
+            echo "$DELIM"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Claude Code
         id: review
+        if: steps.diff.outputs.bytes != '0'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: 'true'
-          # The Claude Code SDK that ships with the action has /security-review bundled
-          # as a slash command. Invoking it directly lets the skill drive its own
-          # `git diff origin/HEAD...`, sub-task fan-out, and false-positive filtering
-          # without us re-implementing any of that. We append a short tail telling the
-          # action to use the inline-comment MCP tool for findings.
-          prompt: |
-            /security-review
-
-            For each finding, call mcp__github_inline_comment__create_inline_comment with
-            { path, line, body } pointing at the exact file and line in the diff. Do NOT
-            post a single summary comment listing all findings — the workflow handles a
-            top-level summary after this run completes. If there are no findings, exit
-            without calling any tool.
+          prompt: ${{ env.PROMPT_BODY }}
           show_full_output: 'true'
-          # Allow-listing this MCP tool name is what tells the action to register the
-          # github_inline_comment MCP server. See anthropics/claude-code-action
-          # src/mcp/install-mcp-server.ts.
+          # Read/Grep/Glob let the model explore the repo for context
+          # (existing sanitization patterns, threat model, callers of a
+          # changed function). Task is needed for the parallel verifier
+          # sub-agents in Phase 2. The github_inline_comment MCP tool is
+          # the output channel; allow-listing it is also what tells the
+          # action to attach the inline-comment MCP server. Bash is
+          # intentionally NOT allowed: the prompt forbids running
+          # commands, and keeping Bash off the list makes the diff at
+          # /tmp/pr.diff the only ground truth (no `git diff` re-runs
+          # against a possibly-shallow clone).
           claude_args: >-
-            --model us.anthropic.claude-opus-4-7 --max-turns 30 --allowedTools
-            mcp__github_inline_comment__create_inline_comment
+            --model us.anthropic.claude-opus-4-7 --max-turns 60 --allowedTools "Read Grep Glob Task
+            mcp__github_inline_comment__create_inline_comment"
 
-      - name: Verify model actually ran
+      - name: Verify model ran productively
         id: model-ran
-        # The action exits 0 even when the model was never invoked (e.g. a
-        # SessionStart hook errored before the first turn). Treating that as
-        # success would let the workflow falsely report "no high-confidence
-        # findings" — that's exactly what happened on PR #1474, where the
-        # `/security-review` skill's first `git diff origin/HEAD...` hit a
-        # "no merge base" error, the SDK still returned `subtype: success`
-        # with `num_turns: 0` and zero tokens, and the buffer was empty.
-        #
-        # The action writes its full SDK transcript to
-        # ${RUNNER_TEMP}/claude-execution-output.json. We pull the final
-        # result envelope and require that the model actually took turns and
-        # spent tokens. If it didn't, mark the run as not-actually-completed
-        # so the summary comment uses the failure branch instead of pretending
-        # there were no findings.
-        if: steps.review.conclusion == 'success' || steps.review.conclusion == 'failure'
+        if: steps.diff.outputs.bytes != '0' && (steps.review.conclusion == 'success' || steps.review.conclusion ==
+          'failure')
         env:
-          # The action exposes its full SDK transcript path as the
-          # `execution_file` step output (a JSON array of stream events; the
-          # final element is the result envelope). We fall back to the known
-          # path under RUNNER_TEMP if for some reason the output is missing.
-          OUTPUT_JSON:
-            ${{ steps.review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
+          OUTPUT_JSON: ${{ steps.review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
         run: |
           set -euo pipefail
           if [ ! -s "$OUTPUT_JSON" ]; then
-            echo "::warning::No claude-execution-output.json found at $OUTPUT_JSON; cannot verify the model ran."
+            echo "::warning::No execution transcript at $OUTPUT_JSON — cannot verify"
             echo "ran=unknown" >> "$GITHUB_OUTPUT"
             echo "num_turns=0" >> "$GITHUB_OUTPUT"
             exit 0
@@ -271,18 +407,19 @@ jobs:
           echo "num_turns=$NUM_TURNS, is_error=$IS_ERROR, output_tokens=$OUTPUT_TOKENS"
           echo "num_turns=$NUM_TURNS" >> "$GITHUB_OUTPUT"
           if [ "$IS_ERROR" = "true" ] || [ "$NUM_TURNS" = "0" ] || [ "$OUTPUT_TOKENS" = "0" ]; then
-            echo "::error::Claude Code SDK reported success but the model never ran productively (num_turns=$NUM_TURNS, output_tokens=$OUTPUT_TOKENS, is_error=$IS_ERROR). The /security-review skill likely bailed before analysis (e.g. SessionStart hook error). Refusing to report 'no findings'."
+            echo "::group::Last messages from SDK transcript"
+            jq -r '.[] | select(.type == "user" or .type == "system") | .message.content // .subtype' "$OUTPUT_JSON" | tail -40
+            echo "::endgroup::"
+            echo "::error::Model did not run productively (turns=$NUM_TURNS, output_tokens=$OUTPUT_TOKENS, is_error=$IS_ERROR)"
             echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           echo "ran=true" >> "$GITHUB_OUTPUT"
 
-      - name: Count buffered findings
+      - name: Count findings
         id: findings
-        # Only count if the review step actually ran (success or failure - both produce
-        # a meaningful buffer state). Skip on cancellation/skip so we don't lie about
-        # "no findings" when Bedrock was never invoked.
-        if: steps.review.conclusion == 'success' || steps.review.conclusion == 'failure'
+        if: steps.diff.outputs.bytes != '0' && (steps.review.conclusion == 'success' || steps.review.conclusion ==
+          'failure')
         run: |
           set -euo pipefail
           BUFFER=/tmp/inline-comments-buffer.jsonl
@@ -294,10 +431,7 @@ jobs:
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Buffered findings: $COUNT"
 
-      - name: Post security review summary comment
-        # Always post some kind of summary so the PR shows the run happened, but branch on
-        # the review step's conclusion so a cancelled/skipped run doesn't get reported as
-        # "no findings".
+      - name: Post summary
         if: always()
         uses: actions/github-script@v9
         env:
@@ -306,6 +440,8 @@ jobs:
           REVIEW_CONCLUSION: ${{ steps.review.conclusion }}
           MODEL_RAN: ${{ steps.model-ran.outputs.ran }}
           NUM_TURNS: ${{ steps.model-ran.outputs.num_turns }}
+          DIFF_BYTES: ${{ steps.diff.outputs.bytes }}
+          DIFF_FILES: ${{ steps.diff.outputs.files }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -316,25 +452,21 @@ jobs:
             const modelRan = process.env.MODEL_RAN || 'unknown';
             const numTurns = process.env.NUM_TURNS || '0';
             const runUrl = process.env.RUN_URL;
+            const diffBytes = parseInt(process.env.DIFF_BYTES || '0', 10);
 
             let body;
-            if (modelRan !== 'true') {
-              // Two cases land here, both unsafe to report as "no findings":
-              //   - 'false': SDK exited 0 but transcript shows the model never ran productively
-              //     (e.g. /security-review's SessionStart hook errored before the first turn).
-              //   - 'unknown': claude-execution-output.json was missing, so we couldn't verify
-              //     the model ran at all. Treat as not-verified rather than silently green.
-              body = `**Claude Security Review:** the review did not actually analyze this PR (model took ${numTurns} turn${numTurns === '1' ? '' : 's'} — the skill likely failed during setup). See the [run](${runUrl}) for details; a later push or re-run is needed for a real review.`;
+            if (diffBytes === 0) {
+              body = `**Claude Security Review:** PR has an empty diff against base — nothing to review. ([run](${runUrl}))`;
+            } else if (modelRan !== 'true') {
+              body = `**Claude Security Review:** the review did not analyze this PR (model took ${numTurns} turn${numTurns === '1' ? '' : 's'}). See the [run](${runUrl}) for details; a later push or re-run is needed.`;
             } else if (conclusion === 'success') {
-              body =
-                count > 0
-                  ? `**Claude Security Review:** posted ${count} inline finding${count === 1 ? '' : 's'} on this PR. ([run](${runUrl}))`
-                  : `**Claude Security Review:** no high-confidence findings. ([run](${runUrl}))`;
+              body = count > 0
+                ? `**Claude Security Review:** posted ${count} inline finding${count === 1 ? '' : 's'} on this PR. ([run](${runUrl}))`
+                : `**Claude Security Review:** no high-confidence findings. ([run](${runUrl}))`;
             } else if (conclusion === 'failure') {
               body = `**Claude Security Review:** the review run failed before completing. See the [run](${runUrl}) for details.`;
             } else {
-              // cancelled / skipped — analysis didn't run, do NOT claim "no findings"
-              body = `**Claude Security Review:** the review run was ${conclusion} before the analysis could complete (likely superseded or interrupted). See the [run](${runUrl}); a later run on this PR will replace this status.`;
+              body = `**Claude Security Review:** the review run was ${conclusion} before analysis could complete. See the [run](${runUrl}); a later run on this PR will replace this status.`;
             }
 
             await github.rest.issues.createComment({
@@ -344,7 +476,7 @@ jobs:
               body,
             });
 
-      - name: Remove claude-security-reviewing label
+      - name: Remove reviewing label
         if: always()
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -12,9 +12,9 @@ name: Claude Security Review
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
-    # Only review PRs targeting our long-lived release branch. PRs into
-    # short-lived feature branches don't need a security gate — they get
-    # reviewed when those features are merged into main.
+    # Only review PRs targeting our long-lived release branch. PRs
+    # into short-lived feature branches don't need a security gate — they
+    # get reviewed when those features are merged into main.
     branches:
       - main
   workflow_dispatch:
@@ -178,191 +178,12 @@ jobs:
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
           echo "Diff: $BYTES bytes across $FILES files"
 
-      - name: Build prompt
-        if: steps.diff.outputs.bytes != '0'
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/prompt"
-          cat > "$RUNNER_TEMP/prompt/prompt.md" <<'PROMPT_EOF'
-          You are performing a HIGH-CONFIDENCE security code review of a pull
-          request. The complete diff is at `/tmp/pr.diff` — read it first
-          using the Read tool. That file is the ground truth for what the
-          PR changes; do not run `git diff` or any other git commands. To
-          understand context — callers of a changed function, existing
-          sanitization patterns, the project's threat model — use Grep,
-          Glob, and Read against the repository working tree. Do not use
-          Bash.
-
-          # OBJECTIVE
-
-          Identify HIGH-CONFIDENCE security vulnerabilities newly introduced
-          by this PR that have real exploitation potential. This is NOT a
-          general code review. Focus ONLY on security implications added by
-          the PR. Do not comment on pre-existing issues.
-
-          # CRITICAL INSTRUCTIONS
-
-          1. MINIMIZE FALSE POSITIVES: Only flag issues where you are >80%
-             confident of actual exploitability.
-          2. AVOID NOISE: Skip theoretical issues, style concerns, or
-             low-impact findings.
-          3. FOCUS ON IMPACT: Prioritize vulnerabilities that lead to
-             unauthorized access, data breach, or system compromise.
-          4. DO NOT report any of:
-             - Denial of service / resource exhaustion / rate limiting
-             - Secrets at rest on disk (handled by other tooling)
-             - Memory consumption or CPU exhaustion
-
-          # CATEGORIES TO EXAMINE
-
-          **Input validation**: SQL injection, command injection, XXE,
-          template injection, NoSQL injection, path traversal.
-          **AuthN/AuthZ**: authentication bypass, privilege escalation,
-          session/JWT flaws, authorization-logic bypasses.
-          **Crypto & secrets**: hardcoded keys/passwords/tokens, weak
-          algorithms, improper key storage, weak randomness, certificate
-          validation bypass.
-          **Code execution**: deserialization RCE (pickle, YAML, etc.),
-          eval injection, XSS (reflected/stored/DOM) — only in unsafe paths
-          (see precedents).
-          **Data exposure**: sensitive logging, PII handling violations,
-          API leakage, debug-info exposure.
-
-          A finding can still be HIGH severity if only exploitable from the
-          local network.
-
-          # METHODOLOGY
-
-          Phase 1 — Repository context: identify existing security
-          libraries/frameworks, sanitization patterns, the project's threat
-          model. Use search tools.
-
-          Phase 2 — Comparative analysis: compare new changes against
-          established patterns; flag deviations and net-new attack surface.
-
-          Phase 3 — Vulnerability assessment: for each modified file,
-          trace user input → sensitive operations, look for unsafe privilege
-          boundary crossings, identify injection points.
-
-          # FALSE-POSITIVE FILTER (apply hard)
-
-          Read the code (Read/Grep/Glob); do not run commands to reproduce
-          or write files.
-
-          HARD EXCLUSIONS — drop any finding matching:
-          1. DoS / resource exhaustion.
-          2. Secrets/credentials on disk if otherwise secured.
-          3. Rate limiting or service overload.
-          4. Memory/CPU exhaustion.
-          5. Missing input validation on non-security-critical fields.
-          6. Input sanitization in GitHub Actions workflows unless clearly
-             triggerable via untrusted input.
-          7. Lack of hardening; only flag concrete vulns.
-          8. Theoretical race conditions or timing attacks.
-          9. Outdated third-party libraries (handled separately).
-          10. Memory-safety issues in memory-safe languages (Rust, Go,
-              JS/TS, Python).
-          11. Files that are unit tests or test-only.
-          12. Log spoofing — un-sanitized user input to logs is not a vuln.
-          13. SSRF that only controls the path (host/protocol control is
-              required).
-          14. User-controlled content in AI system prompts is not a vuln.
-          15. Regex injection.
-          16. Regex DoS.
-          17. Insecure documentation (.md and similar).
-          18. Lack of audit logs.
-
-          PRECEDENTS:
-          1. Plaintext-logging high-value secrets IS a vuln; logging URLs
-             is assumed safe.
-          2. UUIDs are unguessable and need no validation.
-          3. Env vars and CLI flags are trusted inputs.
-          4. Resource leaks (memory, fd) are not vulns.
-          5. Tabnabbing, XS-Leaks, prototype pollution, open redirects:
-             only with extremely high confidence.
-          6. React / Angular: do not report XSS in components or .tsx files
-             unless using `dangerouslySetInnerHTML`,
-             `bypassSecurityTrustHtml`, or equivalents.
-          7. GitHub Actions workflow vulns: only when a concrete attack
-             path through untrusted input exists.
-          8. Missing AuthN/AuthZ in client-side code is not a vuln —
-             validation is the server's job.
-          9. MEDIUM findings only when obvious and concrete.
-          10. .ipynb notebook vulns: only with a concrete attack path
-              through untrusted input.
-          11. Logging non-PII data is not a vuln. Only flag when the data
-              is secrets, passwords, or PII.
-          12. Command injection in shell scripts: only when there is a
-              concrete attack path through untrusted input.
-
-          For each surviving finding, score confidence 1–10:
-          - 1–3: low / likely noise — drop
-          - 4–6: medium — drop unless obvious and concrete
-          - 7–10: high — keep
-
-          # PROCESS
-
-          Run this in three steps, exactly:
-
-          1. Spawn a Task sub-agent to identify candidate vulnerabilities.
-             Pass the full instructions above (objective, categories,
-             methodology, hard exclusions, precedents). Have it return a
-             structured list of candidates with file/line/category/
-             description/exploit/fix.
-
-          2. For EACH candidate from step 1, spawn an independent Task
-             sub-agent IN PARALLEL to adversarially verify it. Each
-             verifier gets the full FALSE-POSITIVE FILTER above and is
-             told to default to "drop" if uncertain. Each returns a
-             confidence score 1–10.
-
-          3. Drop any finding with confidence < 8. For every finding that
-             survives, call:
-
-                 mcp__github_inline_comment__create_inline_comment
-
-             with `{ path, line, body }` pointing at the exact file and
-             line in the diff. The body should follow:
-
-                 **<Severity>: <Category>**
-                 <One-paragraph description of the issue and concrete
-                 exploit scenario.>
-                 **Recommendation:** <One-sentence fix.>
-
-             Do NOT post a single summary comment listing all findings —
-             the workflow handles a top-level summary after this run
-             completes. If zero findings survive Phase 3, exit without
-             calling any tool.
-
-          Begin.
-          PROMPT_EOF
-
       - name: Configure AWS credentials
         if: steps.diff.outputs.bytes != '0'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN }}
           aws-region: us-west-2
-
-      - name: Load prompt into env
-        id: load-prompt
-        if: steps.diff.outputs.bytes != '0'
-        # The action only accepts `prompt:` (a string), not a file path —
-        # passing prompt_file silently no-ops, leaves the action with no
-        # trigger, and skips the run with "No trigger found". Read the
-        # built prompt into an environment variable so we can pass it
-        # inline below. Using GITHUB_ENV with a randomized heredoc
-        # sentinel is the standard Actions idiom for multi-line values.
-        env:
-          PROMPT_FILE: ${{ runner.temp }}/prompt/prompt.md
-        run: |
-          set -euo pipefail
-          DELIM="EOF_$(uuidgen)"
-          {
-            echo "PROMPT_BODY<<$DELIM"
-            cat "$PROMPT_FILE"
-            echo "$DELIM"
-          } >> "$GITHUB_ENV"
 
       - name: Run Claude Code
         id: review
@@ -371,7 +192,158 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: 'true'
-          prompt: ${{ env.PROMPT_BODY }}
+          prompt: |
+            You are performing a HIGH-CONFIDENCE security code review of a pull
+            request. The complete diff is at `/tmp/pr.diff` — read it first
+            using the Read tool. That file is the ground truth for what the
+            PR changes; do not run `git diff` or any other git commands. To
+            understand context — callers of a changed function, existing
+            sanitization patterns, the project's threat model — use Grep,
+            Glob, and Read against the repository working tree. Do not use
+            Bash.
+
+            # OBJECTIVE
+
+            Identify HIGH-CONFIDENCE security vulnerabilities newly introduced
+            by this PR that have real exploitation potential. This is NOT a
+            general code review. Focus ONLY on security implications added by
+            the PR. Do not comment on pre-existing issues.
+
+            # CRITICAL INSTRUCTIONS
+
+            1. MINIMIZE FALSE POSITIVES: Only flag issues where you are >80%
+               confident of actual exploitability.
+            2. AVOID NOISE: Skip theoretical issues, style concerns, or
+               low-impact findings.
+            3. FOCUS ON IMPACT: Prioritize vulnerabilities that lead to
+               unauthorized access, data breach, or system compromise.
+            4. DO NOT report any of:
+               - Denial of service / resource exhaustion / rate limiting
+               - Secrets at rest on disk (handled by other tooling)
+               - Memory consumption or CPU exhaustion
+
+            # CATEGORIES TO EXAMINE
+
+            **Input validation**: SQL injection, command injection, XXE,
+            template injection, NoSQL injection, path traversal.
+            **AuthN/AuthZ**: authentication bypass, privilege escalation,
+            session/JWT flaws, authorization-logic bypasses.
+            **Crypto & secrets**: hardcoded keys/passwords/tokens, weak
+            algorithms, improper key storage, weak randomness, certificate
+            validation bypass.
+            **Code execution**: deserialization RCE (pickle, YAML, etc.),
+            eval injection, XSS (reflected/stored/DOM) — only in unsafe paths
+            (see precedents).
+            **Data exposure**: sensitive logging, PII handling violations,
+            API leakage, debug-info exposure.
+
+            A finding can still be HIGH severity if only exploitable from the
+            local network.
+
+            # METHODOLOGY
+
+            Phase 1 — Repository context: identify existing security
+            libraries/frameworks, sanitization patterns, the project's threat
+            model. Use search tools.
+
+            Phase 2 — Comparative analysis: compare new changes against
+            established patterns; flag deviations and net-new attack surface.
+
+            Phase 3 — Vulnerability assessment: for each modified file,
+            trace user input → sensitive operations, look for unsafe privilege
+            boundary crossings, identify injection points.
+
+            # FALSE-POSITIVE FILTER (apply hard)
+
+            Read the code (Read/Grep/Glob); do not run commands to reproduce
+            or write files.
+
+            HARD EXCLUSIONS — drop any finding matching:
+            1. DoS / resource exhaustion.
+            2. Secrets/credentials on disk if otherwise secured.
+            3. Rate limiting or service overload.
+            4. Memory/CPU exhaustion.
+            5. Missing input validation on non-security-critical fields.
+            6. Input sanitization in GitHub Actions workflows unless clearly
+               triggerable via untrusted input.
+            7. Lack of hardening; only flag concrete vulns.
+            8. Theoretical race conditions or timing attacks.
+            9. Outdated third-party libraries (handled separately).
+            10. Memory-safety issues in memory-safe languages (Rust, Go,
+                JS/TS, Python).
+            11. Files that are unit tests or test-only.
+            12. Log spoofing — un-sanitized user input to logs is not a vuln.
+            13. SSRF that only controls the path (host/protocol control is
+                required).
+            14. User-controlled content in AI system prompts is not a vuln.
+            15. Regex injection.
+            16. Regex DoS.
+            17. Insecure documentation (.md and similar).
+            18. Lack of audit logs.
+
+            PRECEDENTS:
+            1. Plaintext-logging high-value secrets IS a vuln; logging URLs
+               is assumed safe.
+            2. UUIDs are unguessable and need no validation.
+            3. Env vars and CLI flags are trusted inputs.
+            4. Resource leaks (memory, fd) are not vulns.
+            5. Tabnabbing, XS-Leaks, prototype pollution, open redirects:
+               only with extremely high confidence.
+            6. React / Angular: do not report XSS in components or .tsx files
+               unless using `dangerouslySetInnerHTML`,
+               `bypassSecurityTrustHtml`, or equivalents.
+            7. GitHub Actions workflow vulns: only when a concrete attack
+               path through untrusted input exists.
+            8. Missing AuthN/AuthZ in client-side code is not a vuln —
+               validation is the server's job.
+            9. MEDIUM findings only when obvious and concrete.
+            10. .ipynb notebook vulns: only with a concrete attack path
+                through untrusted input.
+            11. Logging non-PII data is not a vuln. Only flag when the data
+                is secrets, passwords, or PII.
+            12. Command injection in shell scripts: only when there is a
+                concrete attack path through untrusted input.
+
+            For each surviving finding, score confidence 1–10:
+            - 1–3: low / likely noise — drop
+            - 4–6: medium — drop unless obvious and concrete
+            - 7–10: high — keep
+
+            # PROCESS
+
+            Run this in three steps, exactly:
+
+            1. Spawn a Task sub-agent to identify candidate vulnerabilities.
+               Pass the full instructions above (objective, categories,
+               methodology, hard exclusions, precedents). Have it return a
+               structured list of candidates with file/line/category/
+               description/exploit/fix.
+
+            2. For EACH candidate from step 1, spawn an independent Task
+               sub-agent IN PARALLEL to adversarially verify it. Each
+               verifier gets the full FALSE-POSITIVE FILTER above and is
+               told to default to "drop" if uncertain. Each returns a
+               confidence score 1–10.
+
+            3. Drop any finding with confidence < 8. For every finding that
+               survives, call:
+
+                   mcp__github_inline_comment__create_inline_comment
+
+               with `{ path, line, body }` pointing at the exact file and
+               line in the diff. The body should follow:
+
+                   **<Severity>: <Category>**
+                   <One-paragraph description of the issue and concrete
+                   exploit scenario.>
+                   **Recommendation:** <One-sentence fix.>
+
+               Do NOT post a single summary comment listing all findings —
+               the workflow handles a top-level summary after this run
+               completes. If zero findings survive Phase 3, exit without
+               calling any tool.
+
+            Begin.
           show_full_output: 'true'
           # Read/Grep/Glob let the model explore the repo for context
           # (existing sanitization patterns, threat model, callers of a

--- a/package-lock.json
+++ b/package-lock.json
@@ -2658,14 +2658,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -2952,9 +2952,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3002,37 +3002,28 @@
       "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true
@@ -3062,9 +3053,9 @@
       "peer": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -3079,9 +3070,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -3096,9 +3087,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -3113,9 +3104,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -3130,9 +3121,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -3147,9 +3138,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -3164,9 +3155,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -3181,9 +3172,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -3198,9 +3189,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -3215,9 +3206,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -3232,9 +3223,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -3249,9 +3240,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -3266,9 +3257,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -3285,9 +3276,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -3302,9 +3293,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -3319,9 +3310,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4118,9 +4109,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4999,9 +4990,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6283,17 +6274,17 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6505,9 +6496,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6518,9 +6509,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7766,9 +7757,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -7786,7 +7777,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7853,9 +7844,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -7864,15 +7855,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7915,9 +7905,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8099,14 +8089,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -8115,21 +8105,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/router": {
@@ -8618,9 +8608,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8808,9 +8798,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8877,17 +8867,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -8903,7 +8893,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -9157,9 +9147,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tests_integ/otel-no-user-content.test.ts
+++ b/tests_integ/otel-no-user-content.test.ts
@@ -169,10 +169,9 @@ describe('OTEL spans must not contain user content', () => {
       const port = fastify.server.address().port
 
       await new Promise<void>((resolve, reject) => {
-        const ws = new WebSocket(
-          `ws://127.0.0.1:${port}/ws`,
-          { headers: { 'x-amzn-bedrock-agentcore-runtime-session-id': 'test-session' } },
-        )
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`, {
+          headers: { 'x-amzn-bedrock-agentcore-runtime-session-id': 'test-session' },
+        })
 
         ws.on('open', () => {
           ws.send(JSON.stringify({ prompt: SENTINEL_PROMPT }))


### PR DESCRIPTION
## What

Adds the Claude Code `/security-review` GitHub Actions workflow (`.github/workflows/pr-security-review.yml`), ported verbatim from [`aws/agentcore-cli`](https://github.com/aws/agentcore-cli/blob/main/.github/workflows/pr-security-review.yml).

On each PR it runs `anthropics/claude-code-action` on Amazon Bedrock, invokes the bundled `/security-review` slash command, and posts findings as inline review comments. A top-level summary comment is posted after the run.

## How it's gated

- Runs automatically on PRs authored by maintainers (org team `agentcore-cli-devs` membership, with a repo write/admin fallback — so it works in this repo via the write-access check).
- Community/fork PRs run once a maintainer applies the **`safe-to-review`** label.

## Prerequisites

- ✅ Repo secret `BEDROCK_SECURITY_REVIEW_ROLE_ARN` has been set on this repo.
- ✅ `APP_ID` / `APP_PRIVATE_KEY` (GitHub App token) already present.
- ⚠️ **IAM trust**: the OIDC role `arn:aws:iam::685197708687:role/GitHubActions-ClaudeSecurityReview` must trust `repo:aws/<this-repo>:*`. Until that's granted, the workflow runs but fails closed at the AWS credentials step (it will not silently report "no findings").

Scope: `main` only — new branches cut from `main` inherit it automatically.