### PR TITLE
Fix missing package root export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Bedrock AgentCore SDK
+ */
+
+export { BedrockAgentCoreApp, RuntimeClient } from './runtime/index.js'
+export { withAccessToken, withApiKey } from './identity/index.js'
+export { Browser } from './tools/browser/index.js'
+export { CodeInterpreter } from './tools/code-interpreter/index.js'
+
+export type {
+  BedrockAgentCoreAppConfig,
+  ContentTypeParserConfig,
+  Handler,
+  RequestContext,
+  HealthStatus,
+  HealthCheckResponse,
+  AsyncTaskInfo,
+  AsyncTaskStatus,
+  RuntimeClientConfig,
+  GenerateWsConnectionParams,
+  GeneratePresignedUrlParams,
+  GenerateWsConnectionOAuthParams,
+  WebSocketConnection,
+  ParsedRuntimeArn,
+} from './runtime/index.js'


### PR DESCRIPTION
## Summary
- add the missing package root entry at `src/index.ts`
- expose the primary SDK classes and identity helpers from `bedrock-agentcore`
- keep subpath exports unchanged

Fixes #185.

## Validation
- `npm run build`
- `npm run type-check`
- `npm test` (398 tests passed)
- `npm pack --pack-destination /tmp/bedrock-agentcore-pack --json`
- installed `/tmp/bedrock-agentcore-pack/bedrock-agentcore-0.2.4.tgz` into a temporary project and verified `await import('bedrock-agentcore')` exposes `BedrockAgentCoreApp`, `RuntimeClient`, `withAccessToken`, `withApiKey`, `Browser`, and `CodeInterpreter`
- `npx prettier --check src/index.ts`

Note: the local pre-commit hook also ran `npm test` successfully, then stopped on an existing Prettier issue in `tests_integ/otel-no-user-content.test.ts`, which is unrelated to this PR.
