### PR TITLE
fix: add root package entrypoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Bedrock AgentCore SDK root entrypoint.
+ */
+
+export { BedrockAgentCoreApp, RuntimeClient } from './runtime/index.js'
+export { withAccessToken, withApiKey } from './identity/index.js'
+export { Browser } from './tools/browser/index.js'
+export { CodeInterpreter } from './tools/code-interpreter/index.js'
+
+export * as runtime from './runtime/index.js'
+export * as identity from './identity/index.js'
+export * as browser from './tools/browser/index.js'
+export * as codeInterpreter from './tools/code-interpreter/index.js'


### PR DESCRIPTION
## Summary

- add the missing root SDK entrypoint at `src/index.ts`
- export core classes/functions directly and expose module namespaces for runtime, identity, browser, and code interpreter APIs
- make the package manifest's existing `main`, `module`, `types`, and root `exports["."]` targets resolvable after build

## Validation

I verified the published package currently declares root entrypoints that are not present in the tarball:

```sh
curl -L --max-time 30 -sS -o pkg.tgz https://registry.npmjs.org/bedrock-agentcore/-/bedrock-agentcore-0.2.4.tgz
tar -xzf pkg.tgz
jq '{main,module,types,exports:.exports["."]}' package/package.json
for f in dist/src/index.js dist/src/index.d.ts; do test -e "package/$f"; echo "$f rc=$?"; done
```

Result before this change: both `dist/src/index.js` and `dist/src/index.d.ts` are missing.

Local validation after this change:

```sh
npm ci --registry=https://registry.npmjs.org --strict-ssl=false --ignore-scripts --no-audit --no-fund
npm run build
test -f dist/src/index.js
test -f dist/src/index.d.ts
node -e "import('./dist/src/index.js').then(m=>console.log(Object.keys(m).filter(k=>/BedrockAgentCoreApp|RuntimeClient|Browser|CodeInterpreter|withAccessToken|runtime|identity|browser|codeInterpreter/.test(k)).sort()))"
git diff --check
```

`npm run build` passes, the root JS and declaration files are generated, and the root entrypoint imports successfully.

AI assistance disclosure: I used Codex to identify the missing package root entrypoint, prepare the patch, and run local validation. I reviewed the final diff before submission.
