### PR TITLE
feat(runtime): add interactive shell support (InvokeAgentRuntimeCommand)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,8 @@ export default [
         process: 'readonly',
         URL: 'readonly',
         URLSearchParams: 'readonly',
+        AbortController: 'readonly',
+        AbortSignal: 'readonly',
       },
     },
     plugins: {

--- a/src/runtime/__tests__/client.test.ts
+++ b/src/runtime/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { RuntimeClient } from '../client.js'
+import { ShellSession as MockShellSession } from '../shell/session.js'
 import type { WebSocketConnection } from '../types.js'
 
 // Mock AWS credentials
@@ -8,6 +9,20 @@ const mockCredentials = {
   secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
   sessionToken: 'mock-session-token',
 }
+
+// Mock ShellSession so openShell tests don't need a real WebSocket
+vi.mock('../shell/session.js', () => {
+  const MockShellSession = vi.fn().mockImplementation(function (this: any, opts: any) {
+    this.shellId = opts.shellId ?? 'mock-shell-uuid'
+    this.sessionId = opts.sessionId ?? 'mock-session-uuid'
+    this.reconnected = false
+    this.kicked = false
+    this.bytesDropped = 0
+    this.exitCode = null
+    this.connect = vi.fn(async () => this)
+  })
+  return { ShellSession: MockShellSession }
+})
 
 // Mock the credential provider
 vi.mock('@aws-sdk/credential-provider-node', () => ({
@@ -501,6 +516,274 @@ describe('RuntimeClient', () => {
       expect(result.headers.Upgrade).toBe('websocket')
       expect(result.headers['Sec-WebSocket-Key']).toBeDefined()
       expect(result.headers['Sec-WebSocket-Version']).toBe('13')
+    })
+  })
+
+  // ── Shell Layer 1 helpers ────────────────────────────────────────────────────
+
+  describe('connectShellSigV4', () => {
+    const validArn = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime-id'
+
+    it('returns url and SigV4 signed headers', async () => {
+      const result = await client.connectShellSigV4({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'my-session',
+      })
+      expect(result.url).toMatch(/^wss:\/\//)
+      expect(result.url).toContain('/ws/shells')
+      expect(result.url).toContain('shellId=my-shell')
+      expect(result.headers.Authorization).toContain('AWS4-HMAC-SHA256')
+      expect(result.headers['X-Amzn-Bedrock-AgentCore-Runtime-Session-Id']).toBe('my-session')
+    })
+
+    it('includes endpointName as qualifier query param', async () => {
+      const result = await client.connectShellSigV4({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'my-session',
+        endpointName: 'DEFAULT',
+      })
+      expect(result.url).toContain('qualifier=DEFAULT')
+    })
+
+    it('throws for invalid ARN format', async () => {
+      await expect(
+        client.connectShellSigV4({ runtimeArn: 'bad-arn', shellId: 'my-shell', sessionId: 's' })
+      ).rejects.toThrow('Invalid runtime ARN format')
+    })
+
+    it('throws when ARN region does not match client region', async () => {
+      await expect(
+        client.connectShellSigV4({
+          runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/r',
+          shellId: 'my-shell',
+          sessionId: 's',
+        })
+      ).rejects.toThrow('us-east-1')
+    })
+
+    it('throws for invalid shellId', async () => {
+      await expect(client.connectShellSigV4({ runtimeArn: validArn, shellId: '', sessionId: 's' })).rejects.toThrow()
+    })
+  })
+
+  describe('connectShellPresigned', () => {
+    const validArn = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime-id'
+
+    it('returns a presigned wss:// url', async () => {
+      const result = await client.connectShellPresigned({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'my-session',
+      })
+      expect(result.url).toMatch(/^wss:\/\//)
+      expect(result.url).toContain('X-Amz-Signature')
+      expect(result.url).toContain('X-Amz-Expires=300') // default
+    })
+
+    it('embeds sessionId in the request signed by presign', async () => {
+      const { SignatureV4 } = await import('@aws-sdk/signature-v4')
+      await client.connectShellPresigned({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'embedded-session',
+      })
+      const presignSpy = (SignatureV4 as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value.presign as ReturnType<
+        typeof vi.fn
+      >
+      const signedRequest = presignSpy.mock.calls[0][0]
+      expect(signedRequest.query['X-Amzn-Bedrock-AgentCore-Runtime-Session-Id']).toBe('embedded-session')
+    })
+
+    it('respects custom expires', async () => {
+      const result = await client.connectShellPresigned({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'my-session',
+        expires: 120,
+      })
+      expect(result.url).toContain('X-Amz-Expires=120')
+    })
+
+    it('throws when expires exceeds 300', async () => {
+      await expect(
+        client.connectShellPresigned({ runtimeArn: validArn, shellId: 'my-shell', sessionId: 's', expires: 301 })
+      ).rejects.toThrow('Expiry timeout cannot exceed 300 seconds')
+    })
+
+    it('throws for invalid ARN format', async () => {
+      await expect(
+        client.connectShellPresigned({ runtimeArn: 'bad-arn', shellId: 'my-shell', sessionId: 's' })
+      ).rejects.toThrow('Invalid runtime ARN format')
+    })
+
+    it('throws when ARN region does not match client region', async () => {
+      await expect(
+        client.connectShellPresigned({
+          runtimeArn: 'arn:aws:bedrock-agentcore:eu-west-1:123456789012:runtime/r',
+          shellId: 'my-shell',
+          sessionId: 's',
+        })
+      ).rejects.toThrow('eu-west-1')
+    })
+
+    it('throws for invalid shellId', async () => {
+      await expect(
+        client.connectShellPresigned({ runtimeArn: validArn, shellId: '', sessionId: 's' })
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('connectShellOAuth', () => {
+    const validArn = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime-id'
+
+    it('returns url and base64url subprotocols', async () => {
+      const result = await client.connectShellOAuth({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'my-session',
+        bearerToken: 'tok123',
+      })
+      expect(result.url).toMatch(/^wss:\/\//)
+      expect(result.url).toContain('/ws/shells')
+      expect(result.subprotocols).toHaveLength(2)
+      expect(result.subprotocols[1]).toBe('base64UrlBearerAuthorization')
+      expect(result.subprotocols[0]).toMatch(/^base64UrlBearerAuthorization\./)
+    })
+
+    it('base64url-encodes the bearer token in the subprotocol', async () => {
+      const result = await client.connectShellOAuth({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'my-session',
+        bearerToken: 'hello',
+      })
+      const encoded = Buffer.from('hello').toString('base64url')
+      expect(result.subprotocols[0]).toBe(`base64UrlBearerAuthorization.${encoded}`)
+    })
+
+    it('embeds sessionId in the url', async () => {
+      const result = await client.connectShellOAuth({
+        runtimeArn: validArn,
+        shellId: 'my-shell',
+        sessionId: 'sess-abc',
+        bearerToken: 'tok',
+      })
+      expect(result.url).toContain('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id=sess-abc')
+    })
+
+    it('throws for empty bearerToken', async () => {
+      await expect(
+        client.connectShellOAuth({ runtimeArn: validArn, shellId: 'my-shell', sessionId: 's', bearerToken: '' })
+      ).rejects.toThrow('bearerToken cannot be empty')
+    })
+
+    it('throws for invalid ARN format', async () => {
+      await expect(
+        client.connectShellOAuth({ runtimeArn: 'bad-arn', shellId: 'my-shell', sessionId: 's', bearerToken: 'tok' })
+      ).rejects.toThrow('Invalid runtime ARN format')
+    })
+
+    it('throws when ARN region does not match client region', async () => {
+      await expect(
+        client.connectShellOAuth({
+          runtimeArn: 'arn:aws:bedrock-agentcore:ap-southeast-1:123456789012:runtime/r',
+          shellId: 'my-shell',
+          sessionId: 's',
+          bearerToken: 'tok',
+        })
+      ).rejects.toThrow('ap-southeast-1')
+    })
+
+    it('throws for invalid shellId', async () => {
+      await expect(
+        client.connectShellOAuth({ runtimeArn: validArn, shellId: '', sessionId: 's', bearerToken: 'tok' })
+      ).rejects.toThrow()
+    })
+  })
+
+  // ── Shell Layer 2: openShell ─────────────────────────────────────────────────
+
+  describe('openShell', () => {
+    const validArn = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime-id'
+
+    it('returns a connected ShellSession', async () => {
+      const session = await client.openShell({ runtimeArn: validArn })
+      expect(session).toBeDefined()
+      expect((session as any).connect).toHaveBeenCalledOnce()
+    })
+
+    it('passes shellId and sessionId through to ShellSession', async () => {
+      await client.openShell({ runtimeArn: validArn, shellId: 'custom-shell', sessionId: 'custom-session' })
+      expect(MockShellSession).toHaveBeenCalledWith(
+        expect.objectContaining({ shellId: 'custom-shell', sessionId: 'custom-session' })
+      )
+    })
+
+    it('auto-generates shellId when omitted', async () => {
+      await client.openShell({ runtimeArn: validArn })
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(opts.shellId).toBeTruthy()
+    })
+
+    it('passes reconnectConfig to ShellSession', async () => {
+      const reconnectConfig = { maxRetries: 3 }
+      await client.openShell({ runtimeArn: validArn, reconnectConfig })
+      expect(MockShellSession).toHaveBeenCalledWith(expect.objectContaining({ reconnectConfig }))
+    })
+
+    it('passes keepaliveIntervalMs to ShellSession', async () => {
+      await client.openShell({ runtimeArn: validArn, keepaliveIntervalMs: 10_000 })
+      expect(MockShellSession).toHaveBeenCalledWith(expect.objectContaining({ keepaliveIntervalMs: 10_000 }))
+    })
+
+    it('throws for invalid ARN format', async () => {
+      await expect(client.openShell({ runtimeArn: 'bad-arn' })).rejects.toThrow('Invalid runtime ARN format')
+    })
+
+    it('throws when ARN region does not match client region', async () => {
+      await expect(
+        client.openShell({ runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/r' })
+      ).rejects.toThrow('us-east-1')
+    })
+
+    it('throws for invalid shellId', async () => {
+      await expect(client.openShell({ runtimeArn: validArn, shellId: '' })).rejects.toThrow()
+    })
+
+    it('uses sigv4 auth by default', async () => {
+      await client.openShell({ runtimeArn: validArn })
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      // connectFn should call connectShellSigV4 — invoke it to verify shape
+      const connResult = await opts.connectFn('test-shell', 'test-session')
+      expect(connResult.url).toMatch(/^wss:\/\//)
+      expect(connResult.headers.Authorization).toContain('AWS4-HMAC-SHA256')
+      expect(connResult.protocols).toBeUndefined()
+    })
+
+    it('uses presigned auth when specified', async () => {
+      await client.openShell({ runtimeArn: validArn, auth: { type: 'presigned', expires: 60 } })
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const connResult = await opts.connectFn('test-shell', 'test-session')
+      expect(connResult.url).toMatch(/^wss:\/\//)
+      expect(connResult.url).toContain('X-Amz-Signature')
+      expect(connResult.headers).toEqual({})
+    })
+
+    it('uses oauth auth when specified', async () => {
+      await client.openShell({ runtimeArn: validArn, auth: { type: 'oauth', bearerToken: 'my-token' } })
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const connResult = await opts.connectFn('test-shell', 'test-session')
+      expect(connResult.url).toMatch(/^wss:\/\//)
+      expect(connResult.protocols).toHaveLength(2)
+      expect(connResult.protocols[1]).toBe('base64UrlBearerAuthorization')
+    })
+
+    it('throws for unknown auth mode', async () => {
+      await expect(client.openShell({ runtimeArn: validArn, auth: { type: 'unknown' } as any })).rejects.toThrow(
+        'Unknown auth mode'
+      )
     })
   })
 })

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -1,3 +1,4 @@
+import { Buffer } from 'buffer'
 import { defaultProvider } from '@aws-sdk/credential-provider-node'
 import type { AwsCredentialIdentityProvider } from '@aws-sdk/types'
 import { HttpRequest } from '@aws-sdk/protocol-http'
@@ -12,8 +13,17 @@ import type {
   GenerateWsConnectionOAuthParams,
   WebSocketConnection,
   ParsedRuntimeArn,
+  OpenShellParams,
+  ConnectShellSigV4Params,
+  ConnectShellPresignedParams,
+  ConnectShellOAuthParams,
+  ShellConnectionSigV4,
+  ShellConnectionPresigned,
+  ShellConnectionOAuth,
 } from './types.js'
 import { DEFAULT_PRESIGNED_URL_TIMEOUT, MAX_PRESIGNED_URL_TIMEOUT } from './types.js'
+import { ShellSession } from './shell/session.js'
+import { validateShellId } from './shell/validation.js'
 
 /**
  * Client for generating WebSocket authentication for AgentCore Runtime.
@@ -70,6 +80,17 @@ export class RuntimeClient {
    *
    * @internal
    */
+  private _parseAndValidateRegion(runtimeArn: string): ParsedRuntimeArn {
+    const parsed = this._parseRuntimeArn(runtimeArn)
+    if (parsed.region !== this.region) {
+      throw new Error(
+        `ARN region ${parsed.region} does not match client region ${this.region}. ` +
+          `Create a client for the same region as the runtime ARN, or use the ARN's region.`
+      )
+    }
+    return parsed
+  }
+
   private _parseRuntimeArn(runtimeArn: string): ParsedRuntimeArn {
     const arnRegex = /^arn:aws:bedrock-agentcore:([^:]+):([^:]+):runtime\/(.+)$/
     const match = runtimeArn.match(arnRegex)
@@ -87,39 +108,27 @@ export class RuntimeClient {
     return { region, accountId, runtimeId }
   }
 
-  /**
-   * Builds WebSocket URL with query parameters.
-   *
-   * @param runtimeArn - Full runtime ARN
-   * @param endpointName - Optional endpoint name for qualifier param
-   * @param customHeaders - Optional custom query parameters
-   * @returns WebSocket URL with query parameters
-   *
-   * @internal
-   */
+  /** @internal */
+  private _buildWsUrl(path: string, queryParams?: Record<string, string>): string {
+    const endpoint = getDataPlaneEndpoint(this.region)
+    const url = new URL(`${endpoint}${path}`)
+    if (queryParams) {
+      Object.entries(queryParams).forEach(([k, v]) => url.searchParams.set(k, v))
+    }
+    return url.toString().replace(/^https:\/\//, 'wss://')
+  }
+
+  /** @internal */
   private _buildWebSocketUrl(
     runtimeArn: string,
     endpointName?: string,
     customHeaders?: Record<string, string>
   ): string {
-    // Get the data plane endpoint and build base URL
-    const endpoint = getDataPlaneEndpoint(this.region)
     const encodedArn = encodeURIComponent(runtimeArn)
-    const url = new URL(`${endpoint}/runtimes/${encodedArn}/ws`)
-
-    // Add query parameters
-    if (endpointName) {
-      url.searchParams.set('qualifier', endpointName)
-    }
-
-    if (customHeaders) {
-      Object.entries(customHeaders).forEach(([key, value]) => {
-        url.searchParams.set(key, value)
-      })
-    }
-
-    // Convert to WebSocket URL
-    return url.toString().replace('https://', 'wss://')
+    return this._buildWsUrl(`/runtimes/${encodedArn}/ws`, {
+      ...(endpointName ? { qualifier: endpointName } : {}),
+      ...customHeaders,
+    })
   }
 
   /**
@@ -154,41 +163,13 @@ export class RuntimeClient {
    */
   async generateWsConnection(params: GenerateWsConnectionParams): Promise<WebSocketConnection> {
     this._parseRuntimeArn(params.runtimeArn)
-
     const sessionId = params.sessionId ?? randomUUID()
     const wsUrl = this._buildWebSocketUrl(params.runtimeArn, params.endpointName)
-
-    const credentials = await this.credentialsProvider()
-    if (!credentials) {
-      throw new Error('No AWS credentials found')
-    }
-
-    // Create and sign the request
-    const url = new URL(wsUrl.replace('wss://', 'https://'))
-    const signedRequest = await new SignatureV4({
-      credentials,
-      region: this.region,
-      service: 'bedrock-agentcore',
-      sha256: Sha256,
-    }).sign(
-      new HttpRequest({
-        protocol: 'https:',
-        hostname: url.hostname,
-        path: url.pathname,
-        query: Object.fromEntries(url.searchParams.entries()),
-        method: 'GET',
-        headers: {
-          host: url.hostname,
-          'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
-        },
-      })
-    )
-
-    // Return WebSocket connection with signed headers + WebSocket upgrade headers
+    const signedHeaders = await this._sigV4SignWsUrl(wsUrl, sessionId)
     return {
       url: wsUrl,
       headers: {
-        ...signedRequest.headers,
+        ...signedHeaders,
         Connection: 'Upgrade',
         Upgrade: 'websocket',
         'Sec-WebSocket-Version': '13',
@@ -231,74 +212,256 @@ export class RuntimeClient {
    * ```
    */
   async generatePresignedUrl(params: GeneratePresignedUrlParams): Promise<string> {
-    // Validate expires parameter
     const expires = params.expires ?? DEFAULT_PRESIGNED_URL_TIMEOUT
     if (expires > MAX_PRESIGNED_URL_TIMEOUT) {
       throw new Error(`Expiry timeout cannot exceed ${MAX_PRESIGNED_URL_TIMEOUT} seconds, got ${expires}`)
     }
-
-    // Validate ARN
     this._parseRuntimeArn(params.runtimeArn)
-
-    // Auto-generate session ID if not provided
     const sessionId = params.sessionId ?? randomUUID()
-
-    // Build minimal WebSocket URL without any custom parameters
-    // This should match the working presigned URL format
     const wsUrl = this._buildWebSocketUrl(params.runtimeArn, params.endpointName, {
       ...params.customHeaders,
       'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
     })
+    return this._presignWsUrl(wsUrl, expires)
+  }
 
-    // Convert wss:// to https:// for signing
-    const httpsUrl = wsUrl.replace('wss://', 'https://')
-
-    const url = new URL(httpsUrl)
-
-    // Get AWS credentials
-    const credentials = await this.credentialsProvider()
-    if (!credentials) {
-      throw new Error('No AWS credentials found')
-    }
-
-    // Create minimal request to sign - separate path and query for presigned URLs
-    const request = new HttpRequest({
-      method: 'GET',
-      protocol: 'https:',
-      hostname: url.hostname,
-      path: url.pathname,
-      query: Object.fromEntries(url.searchParams.entries()),
-      headers: {
-        host: url.hostname,
-      },
+  /** @internal */
+  private _buildShellUrl(runtimeArn: string, shellId: string, endpointName?: string): string {
+    const encodedArn = encodeURIComponent(runtimeArn)
+    return this._buildWsUrl(`/runtimes/${encodedArn}/ws/shells`, {
+      shellId,
+      ...(endpointName ? { qualifier: endpointName } : {}),
     })
+  }
 
-    // Sign the request with SigV4 (presigned URL style) following the exact pattern
-    const signer = new SignatureV4({
+  /** Sign a wss:// URL with SigV4 headers, including the session ID. @internal */
+  private async _sigV4SignWsUrl(wsUrl: string, sessionId: string): Promise<Record<string, string>> {
+    const url = new URL(wsUrl.replace(/^wss:\/\//, 'https://'))
+    const credentials = await this.credentialsProvider()
+    if (!credentials) throw new Error('No AWS credentials found')
+    const signedRequest = await new SignatureV4({
       credentials,
       region: this.region,
       service: 'bedrock-agentcore',
       sha256: Sha256,
-    })
+    }).sign(
+      new HttpRequest({
+        protocol: 'https:',
+        hostname: url.hostname,
+        path: url.pathname,
+        query: Object.fromEntries(url.searchParams.entries()),
+        method: 'GET',
+        headers: {
+          host: url.hostname,
+          'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id': sessionId,
+        },
+      })
+    )
+    return signedRequest.headers as Record<string, string>
+  }
 
-    const signedRequest = await signer.presign(request, { expiresIn: expires })
-
-    // Construct the full signed URL with query parameters
-    let presignedUrl = `${signedRequest.protocol}//${signedRequest.hostname}${signedRequest.path}`
-
-    // Add the signature query parameters
-    if (signedRequest.query) {
-      const existingParams = presignedUrl.includes('?') ? '&' : '?'
-      const queryString = Object.entries(signedRequest.query)
-        .map(([key, value]) => `${key}=${encodeURIComponent(String(value))}`)
+  /** Presign a wss:// URL, embedding auth in query params. @internal */
+  private async _presignWsUrl(wsUrl: string, expires: number): Promise<string> {
+    const url = new URL(wsUrl.replace(/^wss:\/\//, 'https://'))
+    const credentials = await this.credentialsProvider()
+    if (!credentials) throw new Error('No AWS credentials found')
+    const signed = await new SignatureV4({
+      credentials,
+      region: this.region,
+      service: 'bedrock-agentcore',
+      sha256: Sha256,
+    }).presign(
+      new HttpRequest({
+        method: 'GET',
+        protocol: 'https:',
+        hostname: url.hostname,
+        path: url.pathname,
+        query: Object.fromEntries(url.searchParams.entries()),
+        headers: { host: url.hostname },
+      }),
+      { expiresIn: expires }
+    )
+    let presignedUrl = `${signed.protocol}//${signed.hostname}${signed.path}`
+    if (signed.query) {
+      const qs = Object.entries(signed.query)
+        .map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`)
         .join('&')
-      presignedUrl += existingParams + queryString
+      presignedUrl += (presignedUrl.includes('?') ? '&' : '?') + qs
+    }
+    return presignedUrl.replace(/^https:\/\//, 'wss://')
+  }
+
+  /**
+   * Generate a SigV4-signed WebSocket URL and headers for a shell connection.
+   * Low-level helper — use `openShell` for a fully managed session.
+   *
+   * @example
+   * ```typescript
+   * const { url, headers } = await client.connectShellSigV4({ runtimeArn, shellId, sessionId })
+   * const ws = new WebSocket(url, { headers })
+   * ```
+   */
+  async connectShellSigV4(params: ConnectShellSigV4Params): Promise<ShellConnectionSigV4> {
+    validateShellId(params.shellId)
+    this._parseAndValidateRegion(params.runtimeArn)
+    const wsUrl = this._buildShellUrl(params.runtimeArn, params.shellId, params.endpointName)
+    const headers = await this._sigV4SignWsUrl(wsUrl, params.sessionId)
+    return { url: wsUrl, headers }
+  }
+
+  /**
+   * Generate a presigned WebSocket URL for a shell connection. Auth is embedded
+   * in the query string — suitable for browser clients or short-lived tokens.
+   * Low-level helper — use `openShell` for a fully managed session.
+   *
+   * @example
+   * ```typescript
+   * const { url } = await client.connectShellPresigned({ runtimeArn, shellId, sessionId, expires: 120 })
+   * const ws = new WebSocket(url)
+   * ```
+   */
+  async connectShellPresigned(params: ConnectShellPresignedParams): Promise<ShellConnectionPresigned> {
+    validateShellId(params.shellId)
+    const expires = params.expires ?? DEFAULT_PRESIGNED_URL_TIMEOUT
+    if (expires > MAX_PRESIGNED_URL_TIMEOUT) {
+      throw new Error(`Expiry timeout cannot exceed ${MAX_PRESIGNED_URL_TIMEOUT} seconds, got ${expires}`)
+    }
+    this._parseAndValidateRegion(params.runtimeArn)
+    const wsUrl = this._buildShellUrl(params.runtimeArn, params.shellId, params.endpointName)
+    const urlWithSession = new URL(wsUrl)
+    urlWithSession.searchParams.set('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id', params.sessionId)
+    return { url: await this._presignWsUrl(urlWithSession.toString(), expires) }
+  }
+
+  /**
+   * Generate a WebSocket URL and OAuth subprotocols for a shell connection.
+   * Low-level helper — use `openShell` for a fully managed session.
+   *
+   * @example
+   * ```typescript
+   * const { url, subprotocols } = await client.connectShellOAuth({ runtimeArn, shellId, sessionId, bearerToken })
+   * const ws = new WebSocket(url, subprotocols)
+   * ```
+   */
+  async connectShellOAuth(params: ConnectShellOAuthParams): Promise<ShellConnectionOAuth> {
+    validateShellId(params.shellId)
+    if (!params.bearerToken) throw new Error('bearerToken cannot be empty')
+    this._parseAndValidateRegion(params.runtimeArn)
+    const encoded = Buffer.from(params.bearerToken).toString('base64url')
+    if (encoded.length > 4096) {
+      throw new Error(
+        `bearerToken too large to embed in Sec-WebSocket-Protocol (${encoded.length} chars encoded, max 4096)`
+      )
+    }
+    const wsUrl = this._buildShellUrl(params.runtimeArn, params.shellId, params.endpointName)
+    const url = new URL(wsUrl)
+    url.searchParams.set('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id', params.sessionId)
+    return {
+      url: url.toString(),
+      subprotocols: [`base64UrlBearerAuthorization.${encoded}`, 'base64UrlBearerAuthorization'],
+    }
+  }
+
+  /**
+   * Open a fully managed interactive PTY shell session on an agent VM.
+   *
+   * Returns a connected `ShellSession` — an async iterable that yields `ShellFrame`
+   * objects. Call `close()` when done, or use `try/finally`.
+   *
+   * For lower-level control (custom WebSocket handling, browser relay), use the
+   * `connectShellSigV4`, `connectShellPresigned`, or `connectShellOAuth` helpers
+   * directly with `ShellFramer`.
+   *
+   * @example
+   * ```typescript
+   * const shell = await client.openShell({ runtimeArn })
+   * try {
+   *   await shell.send('echo hello\n')
+   *   for await (const frame of shell) {
+   *     if (frame.channel === ShellChannel.STDOUT) process.stdout.write(frame.text)
+   *   }
+   * } finally {
+   *   await shell.close()
+   * }
+   * ```
+   *
+   * @example Auto-reconnect:
+   * ```typescript
+   * const shell = await client.openShell({
+   *   runtimeArn,
+   *   shellId: 'debug',
+   *   reconnectConfig: { maxRetries: 5, onReconnect: (r) => console.log('reconnected:', r) }
+   * })
+   * ```
+   */
+  async openShell(params: OpenShellParams): Promise<ShellSession> {
+    this._parseAndValidateRegion(params.runtimeArn)
+    if (params.shellId != null) validateShellId(params.shellId)
+
+    // Generate stable IDs once — reused on every reconnect attempt.
+    const shellId = params.shellId ?? randomUUID()
+    const sessionId = params.sessionId ?? randomUUID()
+    const auth = params.auth ?? 'sigv4'
+
+    let connectFn: (
+      shellId: string,
+      sessionId: string
+    ) => Promise<{ url: string; headers: Record<string, string>; protocols?: string[] }>
+
+    if (auth === 'sigv4') {
+      connectFn = async (
+        sid: string,
+        currentSessionId: string
+      ): Promise<{ url: string; headers: Record<string, string>; protocols?: string[] }> => {
+        const { url, headers } = await this.connectShellSigV4({
+          runtimeArn: params.runtimeArn,
+          shellId: sid,
+          sessionId: currentSessionId,
+          endpointName: params.endpointName,
+        })
+        return { url, headers }
+      }
+    } else if (typeof auth === 'object' && auth.type === 'presigned') {
+      connectFn = async (
+        sid: string,
+        currentSessionId: string
+      ): Promise<{ url: string; headers: Record<string, string>; protocols?: string[] }> => {
+        const { url } = await this.connectShellPresigned({
+          runtimeArn: params.runtimeArn,
+          shellId: sid,
+          sessionId: currentSessionId,
+          endpointName: params.endpointName,
+          expires: auth.expires,
+        })
+        return { url, headers: {} }
+      }
+    } else if (typeof auth === 'object' && auth.type === 'oauth') {
+      connectFn = async (
+        sid: string,
+        currentSessionId: string
+      ): Promise<{ url: string; headers: Record<string, string>; protocols?: string[] }> => {
+        const { url, subprotocols } = await this.connectShellOAuth({
+          runtimeArn: params.runtimeArn,
+          shellId: sid,
+          sessionId: currentSessionId,
+          endpointName: params.endpointName,
+          bearerToken: auth.bearerToken,
+        })
+        return { url, headers: {}, protocols: subprotocols }
+      }
+    } else {
+      throw new Error(`Unknown auth mode: ${JSON.stringify(auth)}`)
     }
 
-    // Convert signed URL from https:// back to wss://
-    const presignedWsUrl = presignedUrl.replace('https://', 'wss://')
-
-    return presignedWsUrl
+    const session = new ShellSession({
+      connectFn,
+      shellId,
+      sessionId,
+      reconnectConfig: params.reconnectConfig,
+      keepaliveIntervalMs: params.keepaliveIntervalMs,
+      logger: params.logger,
+    })
+    return session.connect()
   }
 
   /**
@@ -345,7 +508,7 @@ export class RuntimeClient {
     const wsUrl = this._buildWebSocketUrl(params.runtimeArn, params.endpointName)
 
     // Convert wss:// to https:// to get host
-    const httpsUrl = wsUrl.replace('wss://', 'https://')
+    const httpsUrl = wsUrl.replace(/^wss:\/\//, 'https://')
     const url = new URL(httpsUrl)
 
     // Generate WebSocket key (required for OAuth connections)

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -21,3 +21,21 @@ export type {
   ParsedRuntimeArn,
 } from './types.js'
 export { DEFAULT_PRESIGNED_URL_TIMEOUT, MAX_PRESIGNED_URL_TIMEOUT, DEFAULT_REGION, RuntimeArnSchema } from './types.js'
+
+// Shell — Layer 1: auth helpers + wire protocol
+export type {
+  ConnectShellSigV4Params,
+  ConnectShellPresignedParams,
+  ConnectShellOAuthParams,
+  ShellConnectionSigV4,
+  ShellConnectionPresigned,
+  ShellConnectionOAuth,
+  OpenShellParams,
+  ShellAuthMode,
+} from './types.js'
+export { ShellChannel, ShellFramer, MAX_FRAME_SIZE } from './shell/index.js'
+export type { ShellFrame } from './shell/index.js'
+
+// Shell — Layer 2: managed session
+export { ShellSession } from './shell/index.js'
+export type { ReconnectConfig, ConnectFn, ShellSessionOptions, Logger } from './shell/index.js'

--- a/src/runtime/shell/__tests__/protocol.test.ts
+++ b/src/runtime/shell/__tests__/protocol.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import { ShellChannel, ShellFramer, MAX_FRAME_SIZE } from '../protocol.js'
+
+describe('ShellChannel', () => {
+  it('has correct wire values', () => {
+    expect(ShellChannel.STDIN).toBe(0x00)
+    expect(ShellChannel.STDOUT).toBe(0x01)
+    expect(ShellChannel.STDERR).toBe(0x02)
+    expect(ShellChannel.STATUS).toBe(0x03)
+    expect(ShellChannel.RESIZE).toBe(0x04)
+    expect(ShellChannel.HEARTBEAT).toBe(0x05)
+    expect(ShellChannel.CLOSE).toBe(0xff)
+    expect(ShellChannel.UNKNOWN).toBe(-1)
+  })
+})
+
+describe('ShellFramer.decode', () => {
+  const framer = new ShellFramer()
+
+  it('decodes STDOUT frame', () => {
+    const raw = Buffer.concat([Buffer.from([ShellChannel.STDOUT]), Buffer.from('hello')])
+    const frame = framer.decode(raw)
+    expect(frame.channel).toBe(ShellChannel.STDOUT)
+    expect(frame.rawChannelByte).toBe(0x01)
+    expect(frame.payload).toEqual(Buffer.from('hello'))
+    expect(frame.text).toBe('hello')
+  })
+
+  it('decodes STDIN frame', () => {
+    const raw = Buffer.concat([Buffer.from([ShellChannel.STDIN]), Buffer.from('ls\n')])
+    const frame = framer.decode(raw)
+    expect(frame.channel).toBe(ShellChannel.STDIN)
+    expect(frame.payload).toEqual(Buffer.from('ls\n'))
+  })
+
+  it('decodes STATUS frame with json()', () => {
+    const payload = JSON.stringify({
+      kind: 'Status',
+      status: 'Success',
+      metadata: { shellId: 'abc', reconnected: false },
+    })
+    const raw = Buffer.concat([Buffer.from([ShellChannel.STATUS]), Buffer.from(payload)])
+    const frame = framer.decode(raw)
+    expect(frame.channel).toBe(ShellChannel.STATUS)
+    expect(frame.json()['status']).toBe('Success')
+  })
+
+  it('decodes CLOSE frame with empty payload', () => {
+    const raw = Buffer.from([ShellChannel.CLOSE])
+    const frame = framer.decode(raw)
+    expect(frame.channel).toBe(ShellChannel.CLOSE)
+    expect(frame.payload.length).toBe(0)
+  })
+
+  it('decodes HEARTBEAT frame', () => {
+    const raw = Buffer.from([ShellChannel.HEARTBEAT])
+    const frame = framer.decode(raw)
+    expect(frame.channel).toBe(ShellChannel.HEARTBEAT)
+    expect(frame.payload.length).toBe(0)
+  })
+
+  it('decodes unknown channel byte as UNKNOWN', () => {
+    const raw = Buffer.concat([Buffer.from([0x42]), Buffer.from('future data')])
+    const frame = framer.decode(raw)
+    expect(frame.channel).toBe(ShellChannel.UNKNOWN)
+    expect(frame.rawChannelByte).toBe(0x42)
+    expect(frame.payload).toEqual(Buffer.from('future data'))
+  })
+
+  it('UNKNOWN sentinel (-1) is not treated as a valid wire byte', () => {
+    // 0xFF is CLOSE — verify UNKNOWN=-1 is not confused with any wire byte
+    const raw = Buffer.from([0xff])
+    const frame = framer.decode(raw)
+    expect(frame.channel).toBe(ShellChannel.CLOSE)
+    expect(frame.channel).not.toBe(ShellChannel.UNKNOWN)
+  })
+
+  it('throws on empty frame', () => {
+    expect(() => framer.decode(Buffer.alloc(0))).toThrow('empty')
+  })
+
+  it('text property replaces invalid UTF-8 bytes', () => {
+    const raw = Buffer.concat([Buffer.from([ShellChannel.STDOUT]), Buffer.from([0xff, 0xfe])])
+    const frame = framer.decode(raw)
+    expect(frame.text).toContain('�')
+  })
+
+  it('json() throws SyntaxError on invalid payload', () => {
+    const raw = Buffer.concat([Buffer.from([ShellChannel.STATUS]), Buffer.from('not json')])
+    const frame = framer.decode(raw)
+    expect(() => frame.json()).toThrow(SyntaxError)
+  })
+})
+
+describe('ShellFramer.encodeStdin', () => {
+  const framer = new ShellFramer()
+
+  it('encodes string as STDIN frame', () => {
+    const frame = framer.encodeStdin('ls\n')
+    expect(frame[0]).toBe(ShellChannel.STDIN)
+    expect(frame.slice(1)).toEqual(Buffer.from('ls\n'))
+  })
+
+  it('encodes Buffer as STDIN frame', () => {
+    const data = Buffer.from([0x1b, 0x5b, 0x41]) // ESC[A
+    const frame = framer.encodeStdin(data)
+    expect(frame[0]).toBe(ShellChannel.STDIN)
+    expect(frame.slice(1)).toEqual(data)
+  })
+
+  it('throws when payload exceeds 64KB limit', () => {
+    const big = 'x'.repeat(MAX_FRAME_SIZE)
+    expect(() => framer.encodeStdin(big)).toThrow('64 KB')
+  })
+
+  it('accepts payload exactly at limit (MAX_FRAME_SIZE - 1 bytes)', () => {
+    const data = Buffer.alloc(MAX_FRAME_SIZE - 1)
+    const frame = framer.encodeStdin(data)
+    expect(frame.length).toBe(MAX_FRAME_SIZE)
+  })
+
+  it('round-trips through decode', () => {
+    const original = 'echo hello\n'
+    const encoded = framer.encodeStdin(original)
+    const decoded = framer.decode(encoded)
+    expect(decoded.channel).toBe(ShellChannel.STDIN)
+    expect(decoded.text).toBe(original)
+  })
+})
+
+describe('ShellFramer.encodeResize', () => {
+  const framer = new ShellFramer()
+
+  it('encodes resize frame', () => {
+    const frame = framer.encodeResize(220, 50)
+    expect(frame[0]).toBe(ShellChannel.RESIZE)
+    expect(JSON.parse(frame.slice(1).toString())).toEqual({ width: 220, height: 50 })
+  })
+
+  it.each([
+    [0, 24],
+    [80, 0],
+    [-1, 24],
+    [80, -1],
+    [0, 0],
+  ])('throws for invalid dimensions width=%i height=%i', (w, h) => {
+    expect(() => framer.encodeResize(w, h)).toThrow('positive integers')
+  })
+
+  it('throws for non-integer dimensions', () => {
+    expect(() => framer.encodeResize(10.5, 24)).toThrow('integers')
+    expect(() => framer.encodeResize(80, 24.1)).toThrow('integers')
+  })
+})
+
+describe('ShellFramer.encodeHeartbeat', () => {
+  it('encodes heartbeat as single byte', () => {
+    const framer = new ShellFramer()
+    const frame = framer.encodeHeartbeat()
+    expect(frame).toEqual(Buffer.from([ShellChannel.HEARTBEAT]))
+  })
+})
+
+describe('ShellFramer.encodeClose', () => {
+  it('encodes close as single byte', () => {
+    const framer = new ShellFramer()
+    const frame = framer.encodeClose()
+    expect(frame).toEqual(Buffer.from([ShellChannel.CLOSE]))
+  })
+})

--- a/src/runtime/shell/__tests__/session.test.ts
+++ b/src/runtime/shell/__tests__/session.test.ts
@@ -1,0 +1,559 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'events'
+import { ShellSession } from '../session.js'
+import { ShellChannel } from '../protocol.js'
+import type { ConnectFn, ShellSessionOptions } from '../session.js'
+import type WebSocket from 'ws'
+
+// ── Mock WebSocket factory ────────────────────────────────────────────────────
+// Instead of mocking the `ws` module, we inject a fake WebSocket via the
+// _wsFactory option on ShellSessionOptions. No module mocking required.
+
+type MockWs = EventEmitter & {
+  send: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+  terminate: ReturnType<typeof vi.fn>
+  ping: ReturnType<typeof vi.fn>
+  readyState: number
+}
+
+const WS_OPEN = 1
+
+function makeMockWs(): MockWs {
+  const ws = new EventEmitter() as MockWs
+  ws.send = vi.fn((...args: unknown[]) => {
+    const cb = args[args.length - 1]
+    if (typeof cb === 'function') (cb as () => void)()
+  })
+  ws.close = vi.fn()
+  ws.terminate = vi.fn()
+  ws.ping = vi.fn()
+  ws.readyState = WS_OPEN
+  return ws
+}
+
+// ── Frame helpers ─────────────────────────────────────────────────────────────
+
+function statusFrame(payload: Record<string, unknown>): Buffer {
+  return Buffer.concat([Buffer.from([ShellChannel.STATUS]), Buffer.from(JSON.stringify(payload))])
+}
+function stdoutFrame(text: string): Buffer {
+  return Buffer.concat([Buffer.from([ShellChannel.STDOUT]), Buffer.from(text)])
+}
+function confirmationFrame(shellId = 'server-shell', reconnected = false): Buffer {
+  return statusFrame({
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: { shellId: shellId, reconnected },
+    status: 'Success',
+  })
+}
+function exitFrame(code = 0): Buffer {
+  if (code === 0) return statusFrame({ kind: 'Status', apiVersion: 'v1', metadata: {}, status: 'Success' })
+  return statusFrame({
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Failure',
+    reason: 'NonZeroExitCode',
+    details: { causes: [{ reason: 'ExitCode', message: String(code) }] },
+  })
+}
+function closeFrame(): Buffer {
+  return Buffer.from([ShellChannel.CLOSE])
+}
+function heartbeatFrame(): Buffer {
+  return Buffer.from([ShellChannel.HEARTBEAT])
+}
+
+/**
+ * Build a ShellSessionOptions that feeds `frames` through a mock WebSocket.
+ * The wsFactory creates a MockWs EventEmitter, emits upgrade → open → frames → close
+ * all via process.nextTick so listeners are registered before events fire.
+ */
+function makeOpts(
+  frames: Buffer[],
+  opts: {
+    closeCode?: number
+    headers?: Record<string, string>
+    connectFn?: ConnectFn
+  } = {}
+): ShellSessionOptions & { getWs: () => MockWs } {
+  let capturedWs: MockWs | null = null
+
+  const wsFactory = (_url: string, _protocols?: string[], _options?: Record<string, unknown>): WebSocket => {
+    const ws = makeMockWs()
+    capturedWs = ws
+    return ws as unknown as WebSocket
+  }
+
+  const connectFn: ConnectFn =
+    opts.connectFn ??
+    vi.fn(async (_shellId: string, _sessionId: string) => {
+      process.nextTick(() => {
+        const ws = capturedWs!
+        ws.emit('upgrade', { headers: opts.headers ?? {} })
+        ws.emit('open')
+        let idx = 0
+        function emitNext() {
+          if (idx < frames.length) {
+            ws.emit('message', frames[idx++])
+            process.nextTick(emitNext)
+          } else {
+            process.nextTick(() => ws.emit('close', opts.closeCode ?? 1000, Buffer.from('')))
+          }
+        }
+        process.nextTick(emitNext)
+      })
+      return { url: 'wss://test.local/runtimes/x/ws/shells', headers: {} }
+    })
+
+  return {
+    connectFn,
+    _wsFactory: wsFactory,
+    getWs: () => {
+      if (!capturedWs) throw new Error('WebSocket not yet created')
+      return capturedWs
+    },
+  }
+}
+
+// Suppress console output in unit tests to avoid noise.
+// Tests that assert on specific console calls use vi.spyOn(console, ...) directly.
+beforeEach(() => {
+  vi.spyOn(console, 'debug').mockImplementation(() => {})
+  vi.spyOn(console, 'info').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ShellSession: construction', () => {
+  it('auto-generates shellId and sessionId when omitted', () => {
+    const session = new ShellSession(makeOpts([]))
+    expect(session.shellId).toBeTruthy()
+    expect(session.sessionId).toBeTruthy()
+  })
+
+  it('uses provided shellId and sessionId', () => {
+    const session = new ShellSession({ ...makeOpts([]), shellId: 'my-shell', sessionId: 'my-session' })
+    expect(session.shellId).toBe('my-shell')
+    expect(session.sessionId).toBe('my-session')
+  })
+
+  it('throws for empty string shellId', () => {
+    expect(() => new ShellSession({ ...makeOpts([]), shellId: '' })).toThrow()
+  })
+
+  it('initial attributes are correct', () => {
+    const session = new ShellSession(makeOpts([]))
+    expect(session.reconnected).toBe(false)
+    expect(session.kicked).toBe(false)
+    expect(session.bytesDropped).toBe(0)
+    expect(session.exitCode).toBeNull()
+  })
+})
+
+describe('ShellSession: connect', () => {
+  it('reads shellId and reconnected=false from STATUS confirmation frame', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('srv-shell', false)]))
+    await session.connect()
+    expect(session.shellId).toBe('srv-shell')
+    expect(session.reconnected).toBe(false)
+  })
+
+  it('sets reconnected=true from STATUS frame', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s', true)]))
+    await session.connect()
+    expect(session.reconnected).toBe(true)
+  })
+
+  it('reads shellId and sessionId from 101 upgrade headers', async () => {
+    const session = new ShellSession(
+      makeOpts([confirmationFrame('hdr-shell')], {
+        headers: {
+          'x-amzn-bedrock-agentcore-shell-id': 'hdr-shell',
+          'x-amzn-bedrock-agentcore-runtime-session-id': 'hdr-session',
+        },
+      })
+    )
+    await session.connect()
+    expect(session.shellId).toBe('hdr-shell')
+    expect(session.sessionId).toBe('hdr-session')
+  })
+
+  it('stashes non-STATUS frames received before confirmation', async () => {
+    const session = new ShellSession(makeOpts([stdoutFrame('early'), confirmationFrame('s')]))
+    await session.connect()
+    const frames = []
+    for await (const f of session) {
+      frames.push(f)
+      if (frames.length === 1) break
+    }
+    expect(frames[0]!.channel).toBe(ShellChannel.STDOUT)
+    expect(frames[0]!.text).toBe('early')
+  })
+
+  it('proceeds with warning when STATUS confirmation times out', async () => {
+    const warnSpy = vi.spyOn(console, 'warn')
+
+    let capturedWs: MockWs | null = null
+    const wsFactory = (_url: string): WebSocket => {
+      const ws = makeMockWs()
+      capturedWs = ws
+      return ws as unknown as WebSocket
+    }
+    const connectFn: ConnectFn = vi.fn(async (_shellId, _sessionId) => {
+      process.nextTick(() => {
+        capturedWs!.emit('upgrade', { headers: {} })
+        capturedWs!.emit('open')
+        // No frames emitted — metadata timeout fires after DEFAULT_METADATA_TIMEOUT ms
+      })
+      return { url: 'wss://test.local/runtimes/x/ws/shells', headers: {} }
+    })
+
+    const session = new ShellSession({ connectFn, _wsFactory: wsFactory, logger: console })
+    // AbortSignal.timeout() uses real timers — no fake timers needed, just await with real timeout
+    await session.connect()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('imed out'))
+  }, 15_000)
+})
+
+describe('ShellSession: iterator', () => {
+  it('yields STDOUT frames in order', async () => {
+    const session = new ShellSession(
+      makeOpts([confirmationFrame('s'), stdoutFrame('hello'), stdoutFrame('world'), closeFrame()])
+    )
+    await session.connect()
+    const texts: string[] = []
+    for await (const f of session) {
+      if (f.channel === ShellChannel.STDOUT) texts.push(f.text)
+    }
+    expect(texts).toEqual(['hello', 'world'])
+  })
+
+  it('swallows HEARTBEAT frames — never yields to caller', async () => {
+    const session = new ShellSession(
+      makeOpts([confirmationFrame('s'), heartbeatFrame(), stdoutFrame('after-hb'), closeFrame()])
+    )
+    await session.connect()
+    const channels: ShellChannel[] = []
+    for await (const f of session) channels.push(f.channel)
+    expect(channels).not.toContain(ShellChannel.HEARTBEAT)
+    expect(channels).toContain(ShellChannel.STDOUT)
+  })
+
+  it('stops on CLOSE frame', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), stdoutFrame('x'), closeFrame()]))
+    await session.connect()
+    let count = 0
+    for await (const _ of session) count++
+    expect(count).toBe(1)
+  })
+
+  it('stops on WebSocket close 1000', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), stdoutFrame('x')], { closeCode: 1000 }))
+    await session.connect()
+    let count = 0
+    for await (const _ of session) count++
+    expect(count).toBe(1)
+  })
+
+  it('sets kicked=true on close code 4000', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s')], { closeCode: 4000 }))
+    await session.connect()
+    for await (const _ of session) {
+      /* drain */
+    }
+    expect(session.kicked).toBe(true)
+  })
+
+  it('stops on close code 1003 without reconnecting and warns', async () => {
+    const warnSpy = vi.spyOn(console, 'warn')
+    // reconnectConfig is present so that if 1003 incorrectly fell through to the
+    // reconnect path it would trigger a retry; we assert it does not.
+    const opts = makeOpts([confirmationFrame('s'), stdoutFrame('x')], { closeCode: 1003 })
+    const session = new ShellSession({ ...opts, reconnectConfig: { maxRetries: 1, baseDelay: 0 }, logger: console })
+    await session.connect()
+    let count = 0
+    for await (const _ of session) count++
+    expect(count).toBe(1)
+    expect((session as unknown as { _state: { status: string } })._state.status).not.toBe('open')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('1003'))
+    // connectFn called exactly once — reconnect loop was not entered
+    expect((opts.connectFn as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1)
+  })
+
+  it('stops cleanly when close() is called mid-iteration', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), stdoutFrame('x')]))
+    await session.connect()
+    let count = 0
+    for await (const _ of session) {
+      count++
+      await session.close()
+    }
+    expect(count).toBe(1)
+    expect((session as unknown as { _state: { status: string } })._state.status).toBe('closed')
+  })
+})
+
+describe('ShellSession: exitCode', () => {
+  it('is null during STDOUT frames, set after termination STATUS', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), stdoutFrame('x'), exitFrame(0)]))
+    await session.connect()
+    let midLoopCode: number | null | undefined
+    for await (const f of session) {
+      if (f.channel === ShellChannel.STDOUT) midLoopCode = session.exitCode
+    }
+    expect(midLoopCode).toBeNull()
+    expect(session.exitCode).toBe(0)
+  })
+
+  it('exitCode=0 for clean exit (status=Success)', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), exitFrame(0)]))
+    await session.connect()
+    for await (const _ of session) {
+      /* drain */
+    }
+    expect(session.exitCode).toBe(0)
+  })
+
+  it('exitCode reflects non-zero exit', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), exitFrame(42)]))
+    await session.connect()
+    for await (const _ of session) {
+      /* drain */
+    }
+    expect(session.exitCode).toBe(42)
+  })
+
+  it('exitCode is null for platform error with no ExitCode cause', async () => {
+    const errFrame = statusFrame({
+      kind: 'Status',
+      apiVersion: 'v1',
+      metadata: {},
+      status: 'Failure',
+      reason: 'InternalError',
+      code: 500,
+    })
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), errFrame]))
+    await session.connect()
+    for await (const _ of session) {
+      /* drain */
+    }
+    expect(session.exitCode).toBeNull()
+  })
+
+  it('exitCode set via pending-frames drain path', async () => {
+    // STDOUT arrives before STATUS confirmation → gets stashed; exitCode set when STATUS drained
+    const session = new ShellSession(makeOpts([stdoutFrame('stashed'), confirmationFrame('s'), exitFrame(5)]))
+    await session.connect()
+    const channels: ShellChannel[] = []
+    for await (const f of session) channels.push(f.channel)
+    expect(session.exitCode).toBe(5)
+    expect(channels[0]).toBe(ShellChannel.STDOUT) // pending frame drained first
+  })
+})
+
+describe('ShellSession: bytesDropped', () => {
+  it('set from second confirmation frame with bytesDropped field', async () => {
+    const secondConf = statusFrame({
+      kind: 'Status',
+      apiVersion: 'v1',
+      metadata: { shellId: 's', reconnected: true, bytesDropped: 512 },
+      status: 'Success',
+    })
+    const session = new ShellSession(
+      makeOpts([confirmationFrame('s'), stdoutFrame('output'), secondConf, closeFrame()])
+    )
+    await session.connect()
+    const channels: ShellChannel[] = []
+    for await (const f of session) channels.push(f.channel)
+    expect(session.bytesDropped).toBe(512)
+    expect(channels).toEqual([ShellChannel.STDOUT]) // second confirmation swallowed
+  })
+
+  it('stays 0 when no ring-buffer overflow', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s'), closeFrame()]))
+    await session.connect()
+    for await (const _ of session) {
+      /* drain */
+    }
+    expect(session.bytesDropped).toBe(0)
+  })
+})
+
+describe('ShellSession: close()', () => {
+  it('transitions to closed state after close()', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s')]))
+    await session.connect()
+    await session.close()
+    expect((session as unknown as { _state: { status: string } })._state.status).toBe('closed')
+  })
+
+  it('is idempotent — calling twice does not throw', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s')]))
+    await session.connect()
+    await session.close()
+    await expect(session.close()).resolves.toBeUndefined()
+  })
+
+  it('send() throws after close()', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s')]))
+    await session.connect()
+    await session.close()
+    await expect(session.send('hello\n')).rejects.toThrow()
+  })
+})
+
+describe('ShellSession: keepalive', () => {
+  it('calls ws.ping() on the interval and stops after close()', async () => {
+    vi.useFakeTimers()
+    const opts = makeOpts([confirmationFrame('s')])
+    const session = new ShellSession({ ...opts, keepaliveIntervalMs: 1000 })
+    await session.connect()
+
+    const ws = opts.getWs()
+    expect(ws.ping).not.toHaveBeenCalled()
+
+    // Advance past one keepalive interval — ping should fire
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(ws.ping).toHaveBeenCalledTimes(1)
+
+    // Advance again — ping fires again
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(ws.ping).toHaveBeenCalledTimes(2)
+
+    // close() stops the keepalive timer
+    await session.close()
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(ws.ping).toHaveBeenCalledTimes(2) // no more pings after close
+
+    vi.useRealTimers()
+  })
+
+  it('keepalive disabled when keepaliveIntervalMs=0', async () => {
+    vi.useFakeTimers()
+    const opts = makeOpts([confirmationFrame('s')])
+    const session = new ShellSession({ ...opts, keepaliveIntervalMs: 0 })
+    await session.connect()
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(opts.getWs().ping).not.toHaveBeenCalled()
+
+    await session.close()
+    vi.useRealTimers()
+  })
+
+  it('keepalive timer is stopped when iterator finishes naturally', async () => {
+    vi.useFakeTimers()
+    const opts = makeOpts([confirmationFrame('s')], { closeCode: 1000 })
+    const session = new ShellSession({ ...opts, keepaliveIntervalMs: 500 })
+    await session.connect()
+
+    for await (const _ of session) {
+      /* drain */
+    }
+
+    const callsBefore = opts.getWs().ping.mock.calls.length
+    await vi.advanceTimersByTimeAsync(2000)
+    // No additional pings after iterator ends
+    expect(opts.getWs().ping.mock.calls.length).toBe(callsBefore)
+
+    vi.useRealTimers()
+  })
+})
+
+describe('ShellSession: connect() state guards', () => {
+  it('throws when called on an already-closed session', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s')]))
+    await session.connect()
+    await session.close()
+    await expect(session.connect()).rejects.toThrow('closed')
+  })
+
+  it('throws when called while already connecting/open', async () => {
+    const session = new ShellSession(makeOpts([confirmationFrame('s')]))
+    await session.connect()
+    await expect(session.connect()).rejects.toThrow('idle')
+  })
+
+  it('throws after close() fires mid-flight', async () => {
+    // connectFn suspends so we can race close() during the await
+    let resolveConnect!: () => void
+    const connectFn: ConnectFn = vi.fn(async () => {
+      await new Promise<void>((res) => {
+        resolveConnect = res
+      })
+      return { url: 'wss://test.local/runtimes/x/ws/shells', headers: {} }
+    })
+    const session = new ShellSession({ connectFn, _wsFactory: makeOpts([]).getWs as never })
+    const connectP = session.connect()
+    await session.close()
+    resolveConnect()
+    await expect(connectP).rejects.toThrow('closed')
+  })
+})
+
+describe('ShellSession: HEARTBEAT in pendingFrames', () => {
+  it('does not yield a HEARTBEAT that arrived before STATUS confirmation', async () => {
+    // HEARTBEAT arrives before the confirmation STATUS — it ends up in pendingFrames.
+    // The pendingFrames drain must filter it out just like the main loop does.
+    const session = new ShellSession(
+      makeOpts([heartbeatFrame(), confirmationFrame('s'), stdoutFrame('hi'), closeFrame()])
+    )
+    await session.connect()
+    const channels: ShellChannel[] = []
+    for await (const f of session) channels.push(f.channel)
+    expect(channels).not.toContain(ShellChannel.HEARTBEAT)
+    expect(channels).toContain(ShellChannel.STDOUT)
+  })
+})
+
+describe('ShellSession: reconnectWindow null = unlimited', () => {
+  it('does not expire and reconnects when reconnectWindow is null', async () => {
+    let callCount = 0
+    let capturedWs: MockWs | null = null
+
+    const wsFactory = (_url: string): WebSocket => {
+      const ws = makeMockWs()
+      capturedWs = ws
+      return ws as unknown as WebSocket
+    }
+
+    const connectFn: ConnectFn = vi.fn(async (_shellId, _sessionId) => {
+      const thisCallCount = ++callCount
+      process.nextTick(() => {
+        const ws = capturedWs!
+        ws.emit('upgrade', { headers: {} })
+        ws.emit('open')
+        process.nextTick(() => {
+          ws.emit('message', confirmationFrame('s'))
+          process.nextTick(() => {
+            if (thisCallCount === 1) {
+              ws.emit('close', 1006, Buffer.from('')) // abnormal → triggers reconnect
+            } else {
+              ws.emit('message', closeFrame()) // clean close on second call
+            }
+          })
+        })
+      })
+      return { url: 'wss://test.local/runtimes/x/ws/shells', headers: {} }
+    })
+
+    const session = new ShellSession({
+      connectFn,
+      _wsFactory: wsFactory,
+      reconnectConfig: { maxRetries: 1, baseDelay: 0, reconnectWindow: null },
+    })
+
+    await session.connect()
+    for await (const _ of session) {
+      /* drain */
+    }
+    expect(callCount).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/src/runtime/shell/__tests__/validation.test.ts
+++ b/src/runtime/shell/__tests__/validation.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { validateShellId } from '../validation.js'
+
+describe('validateShellId', () => {
+  it('accepts valid alphanumeric IDs', () => {
+    expect(() => validateShellId('abc123')).not.toThrow()
+    expect(() => validateShellId('a')).not.toThrow()
+    expect(() => validateShellId('A')).not.toThrow()
+    expect(() => validateShellId('myShell')).not.toThrow()
+  })
+
+  it('accepts IDs with hyphens and underscores', () => {
+    expect(() => validateShellId('my-shell')).not.toThrow()
+    expect(() => validateShellId('debug_session_01')).not.toThrow()
+    expect(() => validateShellId('shell-01_test')).not.toThrow()
+  })
+
+  it('accepts exactly 128 characters', () => {
+    expect(() => validateShellId('a'.repeat(128))).not.toThrow()
+  })
+
+  it('throws for empty string', () => {
+    expect(() => validateShellId('')).toThrow()
+  })
+
+  it('throws for ID starting with hyphen', () => {
+    expect(() => validateShellId('-bad-start')).toThrow()
+  })
+
+  it('throws for ID starting with underscore', () => {
+    expect(() => validateShellId('_bad-start')).toThrow()
+  })
+
+  it('throws for ID longer than 128 characters', () => {
+    expect(() => validateShellId('a'.repeat(129))).toThrow()
+  })
+
+  it('throws for forbidden characters', () => {
+    expect(() => validateShellId('shell?bad')).toThrow()
+    expect(() => validateShellId('shell#bad')).toThrow()
+    expect(() => validateShellId('shell&bad')).toThrow()
+    expect(() => validateShellId('shell/bad')).toThrow()
+    expect(() => validateShellId('shell bad')).toThrow()
+  })
+})

--- a/src/runtime/shell/config.ts
+++ b/src/runtime/shell/config.ts
@@ -1,0 +1,93 @@
+/**
+ * Minimal logger interface — compatible with `console`, pino, winston, and
+ * any other logger that exposes `debug / info / warn` methods.
+ *
+ * Pass an instance to `openShell` or `ShellSessionOptions` to receive
+ * diagnostic output from `ShellSession`. When omitted, all logging is silent.
+ *
+ * @example opt in with console:
+ * ```typescript
+ * const shell = await client.openShell({ runtimeArn, logger: console })
+ * ```
+ * @example opt in with pino:
+ * ```typescript
+ * const shell = await client.openShell({ runtimeArn, logger: pinoInstance })
+ * ```
+ */
+export interface Logger {
+  debug: (...args: unknown[]) => void
+  info: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
+}
+
+/** Silent logger used as the default — no output unless the caller opts in. */
+export const noopLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+}
+
+/** Reconnection configuration for ShellSession. */
+
+export const DEFAULT_MAX_RETRIES = 5
+export const DEFAULT_BASE_DELAY = 1000 // ms
+export const DEFAULT_MAX_DELAY = 15000 // ms
+export const DEFAULT_METADATA_TIMEOUT = 10_000 // ms
+export const DEFAULT_RECONNECT_WINDOW = 900_000 // ms — ~15 min, matches server-side KARP idle timeout
+export const DEFAULT_OUTER_LOOP_DELAY = 30_000 // ms
+export const DEFAULT_KEEPALIVE_INTERVAL = 30_000 // ms — KARP idle timeout is ~60s; ping every 30s
+
+/**
+ * Configuration for automatic reconnection on WebSocket disconnect.
+ *
+ * When provided to `openShell`, `ShellSession` will automatically reconnect
+ * using the same `shellId` so the shell's working directory, environment, background jobs,
+ * and up to 256 KB of buffered output are preserved.
+ *
+ * @example
+ * ```typescript
+ * const config: ReconnectConfig = {
+ *   maxRetries: 5,
+ *   reconnectWindow: null, // unlimited
+ *   onReconnect: async (reconnected) => {
+ *     if (reconnected) console.log('Reattached — buffered output will follow')
+ *     else console.log('New shell started')
+ *   }
+ * }
+ * const shell = await client.openShell(runtimeArn, { reconnectConfig: config })
+ * ```
+ */
+export interface ReconnectConfig {
+  /**
+   * Maximum reconnect attempts per inner loop before pausing. Defaults to 5.
+   */
+  maxRetries?: number
+
+  /**
+   * Initial backoff delay in milliseconds. Doubles on each attempt up to maxDelay. Defaults to 1000.
+   */
+  baseDelay?: number
+
+  /**
+   * Upper bound on backoff delay in milliseconds. Defaults to 15000.
+   */
+  maxDelay?: number
+
+  /**
+   * Total milliseconds to keep retrying after a disconnect before giving up.
+   * Set to null to retry indefinitely. Defaults to 900000 (~15 min).
+   */
+  reconnectWindow?: number | null
+
+  /**
+   * Milliseconds to wait between inner loop exhaustion and next outer retry cycle. Defaults to 30000.
+   */
+  outerLoopDelay?: number
+
+  /**
+   * Optional callback invoked after each successful reconnect.
+   * Receives `reconnected: true` when the existing PTY was reattached;
+   * `false` when a fresh shell was started.
+   */
+  onReconnect?: (reconnected: boolean) => void | Promise<void>
+}

--- a/src/runtime/shell/index.ts
+++ b/src/runtime/shell/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Shell subpackage for InvokeAgentRuntimeCommandShell interactive sessions.
+ */
+
+export { ShellChannel, ShellFramer, MAX_FRAME_SIZE } from './protocol.js'
+export type { ShellFrame } from './protocol.js'
+export { ShellSession } from './session.js'
+export type { ConnectFn, ShellSessionOptions } from './session.js'
+export type { ReconnectConfig, Logger } from './config.js'

--- a/src/runtime/shell/protocol.ts
+++ b/src/runtime/shell/protocol.ts
@@ -1,0 +1,125 @@
+/*
+ * Binary channel-prefix framer for InvokeAgentRuntimeCommandShell.
+ *
+ * Wire format (identical to Kubernetes v5.channel.k8s.io):
+ *   [1-byte channel ID][payload bytes]
+ *
+ * Channels:
+ *   0x00  STDIN      Raw bytes, client → shell
+ *   0x01  STDOUT     Raw bytes, shell → client
+ *   0x02  STDERR     UTF-8 text (platform diagnostics), shell → client
+ *   0x03  STATUS     metav1.Status JSON (shell → client):
+ *                      Connection confirmation: metadata.shellId present
+ *                      {"kind":"Status","apiVersion":"v1",
+ *                       "metadata":{"shellId":"…","reconnected":bool},"status":"Success"}
+ *                      Shell exit (code 0):
+ *                      {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}
+ *                      Shell exit (non-zero):
+ *                      {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure",
+ *                       "reason":"NonZeroExitCode","details":{"causes":[{"reason":"ExitCode","message":"N"}]}}
+ *   0x04  RESIZE     JSON {"width":N,"height":N}, client → shell
+ *   0x05  HEARTBEAT  Empty payload, bidirectional keepalive
+ *   0xFF  CLOSE      Empty payload. Client → server: explicit session kill (SIGHUP → SIGKILL).
+ *                    Server echoes [0xFF] back, kills the shell, closes WebSocket with code 1000.
+ *                    Unlike disconnect (which detaches), 0xFF is permanent — no reconnection possible.
+ */
+
+import { Buffer } from 'buffer'
+
+/** Wire channel identifiers for the binary channel-prefix protocol. */
+export enum ShellChannel {
+  STDIN = 0x00,
+  STDOUT = 0x01,
+  STDERR = 0x02,
+  STATUS = 0x03,
+  RESIZE = 0x04,
+  HEARTBEAT = 0x05,
+  CLOSE = 0xff,
+  /** Sentinel for unrecognised channel bytes — not a wire value. */
+  UNKNOWN = -1,
+}
+
+// Pre-built set of known wire channel bytes (excludes UNKNOWN sentinel).
+const KNOWN_CHANNEL_BYTES = new Set(
+  Object.values(ShellChannel).filter((v): v is ShellChannel => typeof v === 'number' && v !== ShellChannel.UNKNOWN)
+)
+
+/** A single decoded WebSocket frame from the shell stream. */
+export interface ShellFrame {
+  /** The channel this frame belongs to. UNKNOWN for unrecognised channel bytes. */
+  channel: ShellChannel
+  /** The original channel byte from the wire. */
+  rawChannelByte: number
+  /** Raw bytes of the frame payload (everything after the channel byte). */
+  payload: Buffer
+  /** Decode payload as UTF-8 text (replacement char on invalid bytes). */
+  readonly text: string
+  /** Parse payload as JSON. Throws SyntaxError if payload is not valid JSON. */
+  json(): Record<string, unknown>
+}
+
+/** Maximum frame size — matches DP WebSocketFlowController limit. */
+export const MAX_FRAME_SIZE = 64 * 1024
+
+function makeFrame(channel: ShellChannel, rawChannelByte: number, payload: Buffer): ShellFrame {
+  return {
+    channel,
+    rawChannelByte,
+    payload,
+    get text(): string {
+      return payload.toString('utf8')
+    },
+    json(): Record<string, unknown> {
+      return JSON.parse(payload.toString('utf8')) as Record<string, unknown>
+    },
+  }
+}
+
+/**
+ * Encodes and decodes binary channel-prefix WebSocket frames.
+ * Stateless — a single instance is safe to reuse across frames.
+ */
+export class ShellFramer {
+  /** Decode one raw WebSocket binary message into a ShellFrame. */
+  decode(frame: Buffer): ShellFrame {
+    if (frame.length === 0) {
+      throw new Error('Cannot decode empty frame')
+    }
+    const rawByte = frame[0]!
+    const channel = KNOWN_CHANNEL_BYTES.has(rawByte as ShellChannel) ? (rawByte as ShellChannel) : ShellChannel.UNKNOWN
+    return makeFrame(channel, rawByte, frame.slice(1))
+  }
+
+  /** Encode keyboard input or paste data as a STDIN frame. */
+  encodeStdin(data: string | Buffer): Buffer {
+    const bytes = typeof data === 'string' ? Buffer.from(data, 'utf8') : data
+    if (bytes.length > MAX_FRAME_SIZE - 1) {
+      throw new Error(
+        `Payload ${bytes.length} bytes exceeds the 64 KB frame limit. Split large pastes into multiple encodeStdin() calls.`
+      )
+    }
+    return Buffer.concat([Buffer.from([ShellChannel.STDIN]), bytes])
+  }
+
+  /** Encode a terminal resize event as a RESIZE frame. */
+  encodeResize(width: number, height: number): Buffer {
+    if (!Number.isInteger(width) || !Number.isInteger(height)) {
+      throw new Error(`width and height must be integers, got ${typeof width} and ${typeof height}`)
+    }
+    if (width <= 0 || height <= 0) {
+      throw new Error(`width and height must be positive integers, got width=${width}, height=${height}`)
+    }
+    const payload = Buffer.from(JSON.stringify({ width, height }), 'utf8')
+    return Buffer.concat([Buffer.from([ShellChannel.RESIZE]), payload])
+  }
+
+  /** Encode an app-level heartbeat frame (channel 0x05, empty payload). */
+  encodeHeartbeat(): Buffer {
+    return Buffer.from([ShellChannel.HEARTBEAT])
+  }
+
+  /** Encode a graceful-shutdown CLOSE frame (empty payload). */
+  encodeClose(): Buffer {
+    return Buffer.from([ShellChannel.CLOSE])
+  }
+}

--- a/src/runtime/shell/session.ts
+++ b/src/runtime/shell/session.ts
@@ -1,0 +1,817 @@
+/**
+ * ShellSession — async-iterable interactive PTY WebSocket session.
+ *
+ * Connects on `connect()`, reads the initial STATUS confirmation frame, and exposes
+ * typed `send()` / `resize()` / `[Symbol.asyncIterator]()` / `close()`.
+ *
+ * When `reconnectConfig` is provided, transparently reconnects on unexpected disconnects
+ * using the same `shellId` so the shell's working directory, environment, background jobs,
+ * and up to 256 KB of buffered output are preserved.
+ *
+ * @example
+ * ```typescript
+ * const shell = await client.openShell({ runtimeArn })
+ * try {
+ *   await shell.send('cat /etc/os-release\n')
+ *   for await (const frame of shell) {
+ *     if (frame.channel === ShellChannel.STDOUT) process.stdout.write(frame.text)
+ *   }
+ * } finally {
+ *   await shell.close()
+ * }
+ * ```
+ */
+
+import WebSocket from 'ws'
+import type { RawData, ClientOptions } from 'ws'
+import type { IncomingMessage } from 'http'
+import { once, on } from 'events'
+import { randomUUID } from 'crypto'
+import { Buffer } from 'buffer'
+import { ShellFramer, ShellChannel, type ShellFrame } from './protocol.js'
+import { validateShellId } from './validation.js'
+import {
+  DEFAULT_BASE_DELAY,
+  DEFAULT_KEEPALIVE_INTERVAL,
+  DEFAULT_MAX_DELAY,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_METADATA_TIMEOUT,
+  DEFAULT_OUTER_LOOP_DELAY,
+  DEFAULT_RECONNECT_WINDOW,
+  noopLogger,
+  type Logger,
+  type ReconnectConfig,
+} from './config.js'
+
+/** Header names in the 101 Switching Protocols response (lowercase per HTTP/1.1). */
+const SESSION_HEADER = 'x-amzn-bedrock-agentcore-runtime-session-id'
+const SHELL_ID_HEADER = 'x-amzn-bedrock-agentcore-shell-id'
+
+/**
+ * Callback that produces connection params for a new WebSocket.
+ * Receives the current `shellId` and `sessionId` so both can be embedded in the
+ * signed URL/headers. Both values are server-confirmed and may differ from the
+ * values originally passed to `openShell` after the first connection.
+ */
+export type ConnectFn = (
+  shellId: string,
+  sessionId: string
+) => Promise<{
+  url: string
+  headers: Record<string, string>
+  /** WebSocket subprotocols — used by OAuth auth (base64UrlBearerAuthorization). */
+  protocols?: string[]
+}>
+
+/** Options for constructing a ShellSession. */
+export interface ShellSessionOptions {
+  connectFn: ConnectFn
+  shellId?: string | undefined
+  sessionId?: string | undefined
+  reconnectConfig?: ReconnectConfig | undefined
+  /**
+   * Interval in milliseconds between RFC 6455 Ping frames sent to keep the connection
+   * alive through the KARP proxy (~60s idle timeout). Defaults to 30000ms.
+   * Set to 0 to disable keepalive (e.g. when the caller manages pings externally).
+   */
+  keepaliveIntervalMs?: number | undefined
+  /**
+   * Optional logger for diagnostic output. When omitted, all logging is silent.
+   * Pass `console` to enable, or any object implementing `{ debug, info, warn }`.
+   */
+  logger?: Logger | undefined
+  /**
+   * Optional WebSocket factory for testing — overrides `new WebSocket(...)`.
+   * @internal
+   */
+  _wsFactory?: ((url: string, protocols?: string[], options?: ClientOptions) => WebSocket) | undefined
+}
+
+// ── Session state machine ─────────────────────────────────────────────────────
+//
+// Transitions:
+//   idle → connecting              connect() called
+//   connecting → open              upgrade + metadata handshake succeeded
+//   connecting → closed            close() called during upgrade
+//   connecting → (throws)          upgrade failed; caller retries or surfaces error
+//   open → reconnecting            WS dropped; _iterate catches the error
+//   open → closed                  close() called
+//   reconnecting → connecting      backoff sleep done; _runInnerRetryLoop retries
+//   reconnecting → closed          close() called, or reconnect budget exhausted
+//
+// _abortController is kept as a class field (not inside the union) because it must
+// be accessible from close() in both 'connecting' and 'open' states — it is created
+// partway through _connectWithUpgrade() before the open state is established.
+// _sessionController is session-lifetime and never goes into the union.
+
+type SessionState =
+  | { status: 'idle' }
+  | { status: 'connecting'; ws: WebSocket | null }
+  | {
+      status: 'open'
+      ws: WebSocket
+      messageIterator: AsyncIterableIterator<unknown[]>
+      keepaliveTimer: ReturnType<typeof globalThis.setInterval> | null
+      pendingFrames: ShellFrame[]
+    }
+  | { status: 'reconnecting' }
+  | { status: 'closed' }
+
+/**
+ * Async-iterable shell session wrapping a live PTY WebSocket.
+ *
+ * Read-only observable attributes (updated by the session as events arrive):
+ * - `shellId`      — Server-confirmed shell identifier. Preserve to reconnect to the same PTY.
+ * - `sessionId`    — Runtime session ID routing to the VM.
+ * - `reconnected`  — True when the most recent connect reattached an existing PTY.
+ * - `kicked`       — True when another client connected with the same shellId (close 4000).
+ *                    Check this after the `for await` loop exits to distinguish a kick from
+ *                    a clean shell exit.
+ * - `bytesDropped` — PTY ring-buffer bytes lost during the most recent disconnect, as
+ *                    reported by the server in the reconnect confirmation frame.
+ *                    Zero if no overflow occurred or on a fresh connection.
+ * - `exitCode`     — Shell process exit code. `null` until the shell exits; `0` for a clean
+ *                    exit. Check this after the `for await` loop exits alongside `kicked`.
+ */
+export class ShellSession implements AsyncIterable<ShellFrame> {
+  private _shellId: string
+  private _sessionId: string
+  private _reconnected = false
+  private _kicked = false
+  private _bytesDropped = 0
+  private _exitCode: number | null = null
+
+  /** Server-confirmed shell identifier. */
+  get shellId(): string {
+    return this._shellId
+  }
+  /** Runtime session ID routing to the VM. */
+  get sessionId(): string {
+    return this._sessionId
+  }
+  /** True when the most recent connect reattached an existing PTY. */
+  get reconnected(): boolean {
+    return this._reconnected
+  }
+  /**
+   * True when another client connected with the same shellId (close 4000).
+   * Check after the `for await` loop exits to distinguish a kick from a clean exit.
+   */
+  get kicked(): boolean {
+    return this._kicked
+  }
+  /**
+   * PTY ring-buffer bytes lost during the most recent disconnect.
+   * Zero when no overflow occurred or on a fresh connection.
+   */
+  get bytesDropped(): number {
+    return this._bytesDropped
+  }
+  /**
+   * Shell process exit code. `null` until the shell exits; `0` for a clean exit.
+   * Check after the `for await` loop exits alongside `kicked`.
+   */
+  get exitCode(): number | null {
+    return this._exitCode
+  }
+
+  private readonly connectFn: ConnectFn
+  private readonly reconnectConfig: ReconnectConfig | undefined
+  private readonly keepaliveIntervalMs: number
+  private readonly log: Logger
+  private readonly framer = new ShellFramer()
+  private readonly _wsFactory: (url: string, protocols?: string[], options?: ClientOptions) => WebSocket
+  private _state: SessionState = { status: 'idle' }
+  private _abortController: AbortController | null = null
+  private readonly _sessionController = new AbortController()
+  private _closeError: (Error & { closeCode?: number }) | null = null
+
+  constructor(opts: ShellSessionOptions) {
+    this.connectFn = opts.connectFn
+    if (opts.shellId != null) validateShellId(opts.shellId)
+    this._shellId = opts.shellId ?? randomUUID()
+    this._sessionId = opts.sessionId ?? randomUUID()
+    this.reconnectConfig = opts.reconnectConfig
+    this.keepaliveIntervalMs = opts.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL
+    this.log = opts.logger ?? noopLogger
+    this._wsFactory =
+      opts._wsFactory ??
+      ((url: string, protocols?: string[], options?: ClientOptions): WebSocket =>
+        protocols?.length ? new WebSocket(url, protocols, options) : new WebSocket(url, options))
+  }
+
+  /** Connect and read the initial STATUS metadata frame. */
+  async connect(): Promise<this> {
+    if (this._state.status === 'closed') throw new Error('ShellSession is closed')
+    if (this._state.status !== 'idle') {
+      throw new Error(`ShellSession.connect() requires idle state (current: ${this._state.status})`)
+    }
+    await this._connectWithUpgrade()
+    // _connectWithUpgrade returns void (not throw) when close() fires mid-flight.
+    if (this._isClosed()) throw new Error('ShellSession was closed during connect()')
+    return this
+  }
+
+  /**
+   * Send text or raw bytes to the shell's stdin.
+   * Pass a string for text commands; pass a Buffer for binary/escape sequences.
+   */
+  async send(data: string | Buffer): Promise<void> {
+    if (this._state.status !== 'open') throw new Error('ShellSession is not connected')
+    await this._wsSend(this._state.ws, this.framer.encodeStdin(data))
+  }
+
+  /** Send a HEARTBEAT frame (0x05) to the server. */
+  async sendHeartbeat(): Promise<void> {
+    if (this._state.status !== 'open') throw new Error('ShellSession is not connected')
+    await this._wsSend(this._state.ws, this.framer.encodeHeartbeat())
+  }
+
+  /** Resize the terminal PTY. */
+  async resize(width: number, height: number): Promise<void> {
+    if (this._state.status !== 'open') throw new Error('ShellSession is not connected')
+    await this._wsSend(this._state.ws, this.framer.encodeResize(width, height))
+  }
+
+  /** Send a CLOSE frame (0xFF) to permanently kill the shell, then close the WebSocket.
+   *  The server kills the shell process (SIGHUP → SIGKILL) and responds with its own [0xFF].
+   *  Unlike dropping the WebSocket (which detaches and allows reconnection), this is permanent. */
+  async close(): Promise<void> {
+    const prev = this._state
+    if (prev.status === 'closed') {
+      this.log.debug(`ShellSession: close() called on already-closed session (shellId=${this.shellId})`)
+      return
+    }
+    // Atomic transition — any concurrent code checks _state.status === 'closed'.
+    this._state = { status: 'closed' }
+    // Abort per-connection iterator (unblocks any suspended _recvRaw) and reconnect sleeps.
+    this._abortController?.abort()
+    this._sessionController.abort()
+    if (prev.status === 'connecting' && prev.ws !== null) {
+      // Terminate any in-progress TLS handshake — the socket is unreachable from
+      // the _connectWithUpgrade local, so close() must kill it here.
+      try {
+        prev.ws.terminate()
+      } catch (err) {
+        this.log.debug(`ShellSession: ws.terminate() threw during connecting (shellId=${this.shellId}): ${String(err)}`)
+      }
+    } else if (prev.status === 'open') {
+      this._stopKeepalive(prev.keepaliveTimer)
+      // ws.send() throws synchronously if the socket is already closing/closed.
+      // Swallow it — the intent is best-effort notification, not guaranteed delivery.
+      try {
+        prev.ws.send(this.framer.encodeClose())
+      } catch (err) {
+        this.log.debug(
+          `ShellSession: CLOSE frame not sent — socket already closing/closed (shellId=${this.shellId}): ${String(err)}`
+        )
+      }
+      try {
+        prev.ws.close()
+      } catch (err) {
+        this.log.debug(`ShellSession: ws.close() threw (shellId=${this.shellId}): ${String(err)}`)
+      }
+    }
+  }
+
+  /**
+   * Forcibly terminates the underlying WebSocket without a clean handshake.
+   * Useful in tests to simulate an abrupt network drop and trigger the reconnect path.
+   * Has no effect if the session is not currently open.
+   * @internal
+   */
+  _terminateConnection(): void {
+    if (this._state.status === 'open') this._state.ws.terminate()
+  }
+
+  /**
+   * Async iterator — yields inbound ShellFrames, reconnecting on drop if configured.
+   *
+   * The loop exits silently (no throw) in three cases: shell exit, kicked by a new
+   * client, or reconnect budget exhausted. Check `exitCode`, `kicked`, and
+   * `bytesDropped` after the loop to distinguish them:
+   *
+   * ```typescript
+   * for await (const frame of shell) { ... }
+   * if (shell.kicked) { ... }          // another client took over
+   * if (shell.exitCode !== null) { ... } // shell process exited
+   * if (shell.bytesDropped > 0) { ... } // ring-buffer overflow on reconnect
+   * ```
+   */
+  [Symbol.asyncIterator](): AsyncIterator<ShellFrame> {
+    return this._iterate()
+  }
+
+  // ── Internal ──────────────────────────────────────────────────────────────
+
+  private _startKeepalive(ws: WebSocket): ReturnType<typeof globalThis.setInterval> | null {
+    if (this.keepaliveIntervalMs <= 0) return null
+    return globalThis.setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) ws.ping()
+    }, this.keepaliveIntervalMs)
+  }
+
+  private _stopKeepalive(timer: ReturnType<typeof globalThis.setInterval> | null): void {
+    if (timer !== null) globalThis.clearInterval(timer)
+  }
+
+  private _wsSend(ws: WebSocket, data: Buffer): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      ws.send(data, (err?: Error) => (err ? reject(err) : resolve()))
+    })
+  }
+
+  /** Open WebSocket, capture 101 upgrade headers, then read metadata frame. */
+  private async _connectWithUpgrade(): Promise<void> {
+    // Guard must be the very first check — any state mutation below would violate the
+    // closed invariant if close() has already fired.
+    if (this._isClosed()) return
+    // Abort any previous per-connection iterator before creating a new one.
+    this._abortController?.abort()
+
+    this._closeError = null
+    this._reconnected = false
+    this._kicked = false
+    this._bytesDropped = 0
+    this._exitCode = null
+    this._state = { status: 'connecting', ws: null }
+
+    let connectResult: { url: string; headers: Record<string, string>; protocols?: string[] }
+    try {
+      connectResult = await this.connectFn(this.shellId, this.sessionId)
+    } catch (err) {
+      // connectFn threw before any WebSocket was created — reset to idle so the
+      // state doesn't stay 'connecting' across the backoff sleep between retries.
+      if (!this._isClosed()) this._state = { status: 'idle' }
+      throw err
+    }
+    // close() may have fired while connectFn was suspended — bail out before
+    // creating a new WebSocket so the session doesn't revive after an explicit close.
+    if (this._isClosed()) return
+
+    const ws = this._wsFactory(connectResult.url, connectResult.protocols, { headers: connectResult.headers })
+    // close() may have fired in the gap between wsFactory() and this state update —
+    // terminate the socket and bail out instead of re-registering in 'connecting'.
+    if (this._isClosed()) {
+      ws.terminate()
+      return
+    }
+    // Register ws in the connecting state so close() can terminate the socket
+    // during the TLS handshake, before the open race resolves.
+    this._state = { status: 'connecting', ws }
+
+    // Capture controller in a local variable so each WebSocket's handlers close over
+    // their own controller — not this._abortController, which is replaced on reconnect.
+    this._abortController = new AbortController()
+    const controller = this._abortController
+    // Single iterator used for both the STATUS handshake and subsequent frame reads.
+    // On the timeout path, one frame may be lost (the abandoned .next() from the
+    // Promise.race in _readMetadataFrame consumes it), but that is a degraded scenario.
+    // Using two independent iterators would cause every pre-STATUS frame to be yielded
+    // twice (once via pendingFrames, once via the independent listener queue).
+    const messageIterator = on(ws, 'message', { signal: controller.signal }) as AsyncIterableIterator<unknown[]>
+
+    ws.on('close', (code: number, reason: Buffer) => {
+      const err = Object.assign(new Error(`WebSocket closed: ${code} ${reason?.toString() ?? ''}`), { closeCode: code })
+      this._closeError = err
+      controller.abort(err)
+    })
+
+    ws.on('error', (err: Error) => {
+      controller.abort(err)
+    })
+
+    // Capture shellId/sessionId from 101 upgrade response headers before open fires.
+    ws.once('upgrade', (response: IncomingMessage) => {
+      const resHeaders = response.headers
+      const hShellId = resHeaders[SHELL_ID_HEADER]
+      const hSessionId = resHeaders[SESSION_HEADER]
+      if (typeof hShellId === 'string') this._shellId = hShellId
+      if (typeof hSessionId === 'string') this._sessionId = hSessionId
+    })
+
+    // Race open against unexpected-response (non-101) and pre-open close.
+    // events.once(ws, 'open') rejects automatically if 'error' fires first.
+    // AbortController cleans up the two losing once() listeners immediately after the race settles.
+    const openRaceAc = new AbortController()
+    try {
+      await Promise.race([
+        once(ws, 'open', { signal: openRaceAc.signal }),
+        once(ws, 'unexpected-response', { signal: openRaceAc.signal }).then((args: unknown[]) => {
+          const res = args[1] as IncomingMessage
+          res.resume()
+          throw new Error(`Server rejected WebSocket connection: HTTP ${res.statusCode ?? 0}`)
+        }),
+        once(ws, 'close', { signal: openRaceAc.signal }).then((args: unknown[]) => {
+          const [code, reason] = args as [number, Buffer]
+          throw new Error(`WebSocket closed before open: ${code} ${reason?.toString() ?? ''}`)
+        }),
+      ])
+    } catch (err) {
+      ws.terminate()
+      if (!this._isClosed()) this._state = { status: 'idle' }
+      this.log.debug(`ShellSession: WebSocket upgrade failed (shellId=${this.shellId}): ${String(err)}`)
+      throw err
+    } finally {
+      openRaceAc.abort()
+    }
+
+    let pendingFrames: ShellFrame[]
+    try {
+      pendingFrames = await this._readMetadataFrame(messageIterator)
+    } catch (err) {
+      // Server closed before sending STATUS, or close() fired during handshake.
+      ws.terminate()
+      if (!this._isClosed()) this._state = { status: 'idle' }
+      throw err
+    }
+
+    // close() may have fired during _readMetadataFrame — terminate and bail out.
+    if (this._isClosed()) {
+      ws.terminate()
+      return
+    }
+
+    const keepaliveTimer = this._startKeepalive(ws)
+    // Atomic promotion: all connection objects become available together.
+    this._state = { status: 'open', ws, messageIterator, keepaliveTimer, pendingFrames }
+  }
+
+  /** Receive one raw binary message from the WebSocket. */
+  private async _recvRaw(messageIterator: AsyncIterableIterator<unknown[]>): Promise<Buffer> {
+    try {
+      const { value, done } = await messageIterator.next()
+      if (done) throw this._closeError ?? new Error('WebSocket closed')
+      const [data] = value as [RawData]
+      if (Buffer.isBuffer(data)) return data
+      if (Array.isArray(data)) return Buffer.concat(data as Buffer[])
+      return Buffer.from(data as ArrayBuffer)
+    } catch (err) {
+      throw this._closeError ?? err
+    }
+  }
+
+  /**
+   * Consume frames until a STATUS confirmation is found, stashing others in pendingFrames.
+   * Returns the accumulated pending frames to be stored in the 'open' state.
+   */
+  private async _readMetadataFrame(messageIterator: AsyncIterableIterator<unknown[]>): Promise<ShellFrame[]> {
+    // Use an explicit AbortController so the timer can be cancelled as soon as
+    // STATUS arrives — AbortSignal.timeout() creates a timer that outlives the
+    // fast-path read and accumulates orphan wakeups on rapid reconnects.
+    const timeoutAc = new AbortController()
+    const timer = globalThis.setTimeout(() => timeoutAc.abort(new Error('timeout')), DEFAULT_METADATA_TIMEOUT)
+    const timeoutP = new Promise<never>((_, rej) =>
+      timeoutAc.signal.addEventListener('abort', () => rej(timeoutAc.signal.reason as Error), { once: true })
+    )
+
+    const pendingFrames: ShellFrame[] = []
+
+    try {
+      while (true) {
+        let raw: Buffer
+        try {
+          raw = await Promise.race([this._recvRaw(messageIterator), timeoutP])
+        } catch (err: unknown) {
+          if (timeoutAc.signal.aborted) {
+            // If the WebSocket also closed concurrently (race between the 10s timer
+            // and a server close event), prefer the real close error — promoting a
+            // dead messageIterator to 'open' would mislead callers and lose the cause.
+            if (this._closeError !== null) throw this._closeError
+            this.log.warn(`ShellSession: Timed out waiting for STATUS confirmation (shellId=${this.shellId})`)
+            return pendingFrames
+          }
+          throw err
+        }
+
+        const frame = this.framer.decode(raw)
+
+        if (frame.channel === ShellChannel.STATUS) {
+          try {
+            const meta = (frame.json()['metadata'] ?? {}) as Record<string, unknown>
+            if (meta['shellId']) {
+              // Confirmation frame — update shellId and we're done.
+              this._shellId = String(meta['shellId'])
+              this._reconnected = Boolean(meta['reconnected'])
+              return pendingFrames
+            }
+          } catch (err) {
+            this.log.debug(
+              `ShellSession: malformed STATUS frame, proceeding with client-generated shellId=${this.shellId}: ${String(err)}`
+            )
+            return pendingFrames
+          }
+          // No shellId → termination frame (shell died before confirmation).
+          // Stash it so _iterate can set exitCode and return cleanly.
+          this.log.debug(`ShellSession: termination STATUS received before confirmation (shellId=${this.shellId})`)
+          pendingFrames.push(frame)
+          return pendingFrames
+        }
+
+        pendingFrames.push(frame)
+      }
+    } finally {
+      globalThis.clearTimeout(timer)
+    }
+  }
+
+  private _isConfirmationStatus(status: Record<string, unknown>): boolean {
+    const meta = status['metadata'] as Record<string, unknown> | undefined
+    return Boolean(meta?.['shellId'])
+  }
+
+  private _isTerminationStatus(status: Record<string, unknown>): boolean {
+    if (this._isConfirmationStatus(status)) return false
+    return status['status'] === 'Success' || status['status'] === 'Failure'
+  }
+
+  private _parseExitCode(status: Record<string, unknown>): number | null {
+    if (status['status'] === 'Success') return 0
+    const details = status['details'] as Record<string, unknown> | undefined
+    const causes = details?.['causes'] as Array<Record<string, unknown>> | undefined
+    for (const cause of causes ?? []) {
+      if (cause['reason'] === 'ExitCode') {
+        const n = parseInt(String(cause['message']), 10)
+        if (!isNaN(n)) return n
+      }
+    }
+    // Platform error with no ExitCode cause — return null so callers can
+    // distinguish "exited cleanly" (0) from "no exit code available" (null).
+    return null
+  }
+
+  private async *_iterate(): AsyncGenerator<ShellFrame> {
+    // Hoisted outside the loop so the finally block can reference the last known
+    // open state's keepaliveTimer even after _state has been transitioned away.
+    let state: Extract<SessionState, { status: 'open' }> | undefined
+    try {
+      while (true) {
+        if (this._state.status !== 'open') return
+
+        // Capture state snapshot before awaiting — close() may transition state
+        // concurrently while the generator is suspended at a yield or await point.
+        state = this._state
+
+        // Drain frames buffered during the metadata handshake first.
+        while (state.pendingFrames.length > 0) {
+          if (this._isClosed()) return
+          const frame = state.pendingFrames.shift()!
+          // HEARTBEAT — server echo of client keepalive, not application data.
+          if (frame.channel === ShellChannel.HEARTBEAT) continue
+          if (frame.channel === ShellChannel.CLOSE) {
+            this._state = { status: 'idle' }
+            this.log.debug(`ShellSession: CLOSE frame received in pending queue (shellId=${this.shellId})`)
+            return
+          }
+          if (frame.channel === ShellChannel.STATUS) {
+            try {
+              const s = frame.json()
+              if (this._isTerminationStatus(s)) {
+                this._exitCode = this._parseExitCode(s)
+                this._state = { status: 'idle' }
+                yield frame
+                return
+              }
+            } catch (err) {
+              this.log.debug(
+                `ShellSession: malformed STATUS frame in pending queue (shellId=${this.shellId}): ${String(err)}`
+              )
+            }
+          }
+          yield frame
+        }
+
+        if (this._state.status !== 'open') return
+
+        let raw: Buffer
+        try {
+          raw = await this._recvRaw(state.messageIterator)
+        } catch (err: unknown) {
+          if (this._isClosed()) return
+
+          const closeCode = this._extractCloseCode(err)
+
+          if (closeCode === 4000) {
+            this._state = { status: 'idle' }
+            this._kicked = true
+            this.log.warn(`ShellSession: kicked by new connection (close 4000, shellId=${this.shellId})`)
+            return
+          }
+
+          // 1003 Unsupported Data — server terminated for text frames; do NOT reconnect.
+          if (closeCode === 1003) {
+            this._state = { status: 'idle' }
+            this.log.warn(
+              `ShellSession: Server closed with 1003 (text frames not supported). ` +
+                `Open a new ShellSession — do not reconnect.`
+            )
+            return
+          }
+
+          // 1000 Normal Closure — shell exited or graceful shutdown.
+          if (closeCode === 1000) {
+            this._state = { status: 'idle' }
+            return
+          }
+
+          if (!this.reconnectConfig) {
+            if (closeCode === 1001) {
+              this.log.warn(
+                `ShellSession: Server sent 1001 Going Away but no reconnectConfig — ` +
+                  `stopping. Reconnect with shellId=${this.shellId}`
+              )
+            }
+            this._state = { status: 'idle' }
+            return
+          }
+
+          // Unexpected disconnect — enter reconnect loop.
+          if (closeCode === 1001) {
+            this.log.warn(
+              `ShellSession: Server sent 1001 Going Away — entering reconnect loop (shellId=${this.shellId})`
+            )
+          }
+          // Stop this connection's timer before `state` is overwritten by `continue`.
+          // The finally block only sees the last captured `state`, so timers from
+          // intermediate reconnect cycles would leak if not stopped here.
+          this._stopKeepalive(state.keepaliveTimer)
+          this._state = { status: 'reconnecting' }
+
+          const didReconnect = await this._reconnectWithBackoff(Date.now())
+          if (!didReconnect) {
+            this.log.warn(`ShellSession: reconnect exhausted, stopping iteration (shellId=${this.shellId})`)
+            if (!this._isClosed()) this._state = { status: 'idle' }
+            return
+          }
+          continue
+        }
+
+        const frame = this.framer.decode(raw)
+
+        if (frame.channel === ShellChannel.CLOSE) {
+          this._state = { status: 'idle' }
+          this.log.debug(`ShellSession: CLOSE frame received (shellId=${this.shellId})`)
+          return
+        }
+
+        // HEARTBEAT — server echo of client keepalive, not application data.
+        if (frame.channel === ShellChannel.HEARTBEAT) continue
+
+        if (frame.channel === ShellChannel.STATUS) {
+          try {
+            const s = frame.json()
+            if (this._isConfirmationStatus(s)) {
+              // Post-reconnect second confirmation — check for ring-buffer overflow.
+              const meta = s['metadata'] as Record<string, unknown> | undefined
+              const dropped = meta?.['bytesDropped']
+              if (typeof dropped === 'number' && dropped > 0) {
+                this._bytesDropped += dropped
+                this.log.warn(
+                  `ShellSession: ${dropped} bytes of PTY output lost during disconnect ` +
+                    `(ring buffer overflow, shellId=${this.shellId})`
+                )
+              }
+              continue
+            }
+            if (this._isTerminationStatus(s)) {
+              this._exitCode = this._parseExitCode(s)
+              this._state = { status: 'idle' }
+              yield frame
+              return
+            }
+          } catch (err) {
+            this.log.debug(`ShellSession: malformed STATUS frame (shellId=${this.shellId}): ${String(err)}`)
+          }
+        }
+
+        yield frame
+      }
+    } finally {
+      // Safety net: stop keepalive if close() fires while the generator is suspended
+      // at a yield point — close() transitions to 'closed' but state.keepaliveTimer
+      // was captured before that transition, so it still holds the live timer handle.
+      this._stopKeepalive(state?.keepaliveTimer ?? null)
+    }
+  }
+
+  /** Returns true when close() has been called. Used after await points to guard
+   *  against close() firing while the method was suspended. A method call prevents
+   *  TypeScript from narrowing away 'closed' comparisons after state assignments. */
+  private _isClosed(): boolean {
+    return this._state.status === 'closed'
+  }
+
+  private _extractCloseCode(err: unknown): number | null {
+    if (err !== null && typeof err === 'object' && 'closeCode' in err) {
+      return (err as { closeCode: number }).closeCode
+    }
+    return null
+  }
+
+  // ── Two-loop exponential backoff reconnect (mirrors Python SDK) ────────────
+
+  private async _reconnectWithBackoff(startTime: number): Promise<boolean> {
+    const cfg = this.reconnectConfig!
+    // reconnectWindow: null means unlimited; undefined falls back to default.
+    const window = cfg.reconnectWindow !== undefined ? cfg.reconnectWindow : DEFAULT_RECONNECT_WINDOW
+
+    while (true) {
+      if (window !== null) {
+        const elapsed = Date.now() - startTime
+        if (elapsed >= window) {
+          this.log.warn(
+            `ShellSession: Reconnection window of ${window}ms expired after ${elapsed}ms ` + `(shellId=${this.shellId})`
+          )
+          return false
+        }
+      }
+
+      const success = await this._runInnerRetryLoop(cfg, startTime, window)
+      if (success) return true
+
+      let outerDelay = cfg.outerLoopDelay ?? DEFAULT_OUTER_LOOP_DELAY
+      // Cap outer sleep to remaining window so we don't overshoot a short window
+      // by up to outerDelay ms (e.g. a 5s window with 30s outerDelay would overshoot
+      // by 25s waiting for a retry that the window check will immediately reject).
+      if (window !== null) {
+        const remaining = window - (Date.now() - startTime)
+        outerDelay = Math.min(outerDelay, Math.max(0, remaining))
+      }
+      this.log.info(
+        `ShellSession: Inner loop exhausted, waiting ${outerDelay}ms before next outer retry ` +
+          `(shellId=${this.shellId})`
+      )
+      await _sleep(outerDelay, this._sessionController.signal)
+      if (this._isClosed()) return false
+    }
+  }
+
+  private async _runInnerRetryLoop(cfg: ReconnectConfig, startTime: number, window: number | null): Promise<boolean> {
+    const maxRetries = cfg.maxRetries ?? DEFAULT_MAX_RETRIES
+    const baseDelay = cfg.baseDelay ?? DEFAULT_BASE_DELAY
+    const maxDelay = cfg.maxDelay ?? DEFAULT_MAX_DELAY
+
+    let attempt = 0
+    while (attempt < maxRetries) {
+      attempt++
+
+      if (window !== null && Date.now() - startTime >= window) return false
+
+      // Attempt first — no pre-attempt sleep. Sleep only after failure so that
+      // transient disconnects reconnect immediately on the first try.
+      this.log.info(`ShellSession: Reconnect attempt ${attempt}/${maxRetries} (shellId=${this.shellId})`)
+      try {
+        await this._connectWithUpgrade()
+        // close() may have fired while connectFn was awaiting — _connectWithUpgrade returns void
+        // rather than throwing in that case, so guard here before claiming a successful reconnect.
+        if (this._isClosed()) return false
+        this.log.info(`ShellSession: Reconnected (reconnected=${this.reconnected}, shellId=${this.shellId})`)
+        if (cfg.onReconnect) {
+          try {
+            await cfg.onReconnect(this.reconnected)
+          } catch (err) {
+            this.log.warn(`ShellSession: onReconnect callback threw (shellId=${this.shellId}): ${String(err)}`)
+          }
+        }
+        return true
+      } catch (err: unknown) {
+        this.log.warn(`ShellSession: Reconnect attempt ${attempt} failed: ${String(err)} (shellId=${this.shellId})`)
+      }
+
+      if (this._isClosed()) return false
+      // Re-check window after a slow _connectWithUpgrade so the backoff sleep
+      // doesn't fire after the window has already expired mid-attempt.
+      if (window !== null && Date.now() - startTime >= window) return false
+
+      // Exponential backoff with ±25% jitter to avoid thundering herd on
+      // simultaneous reconnects from multiple clients.
+      // Use _sessionController.signal (only aborted by close()) — not
+      // _abortController, which is already aborted by the WS close event.
+      const base = Math.min(baseDelay * Math.pow(2, attempt - 1), maxDelay)
+      const jitter = base * 0.25 * (Math.random() * 2 - 1)
+      const delay = base + jitter
+      this.log.info(`ShellSession: Waiting ${Math.round(delay)}ms before next attempt (shellId=${this.shellId})`)
+      await _sleep(delay, this._sessionController.signal)
+      if (this._isClosed()) return false
+    }
+    return false
+  }
+}
+
+function _sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) {
+      resolve()
+      return
+    }
+    const timer = globalThis.setTimeout(resolve, ms)
+    signal?.addEventListener(
+      'abort',
+      () => {
+        globalThis.clearTimeout(timer)
+        resolve()
+      },
+      { once: true }
+    )
+  })
+}

--- a/src/runtime/shell/validation.ts
+++ b/src/runtime/shell/validation.ts
@@ -1,0 +1,20 @@
+/** Validation for shell identifiers. */
+
+const SHELL_ID_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$/
+
+/**
+ * Validate a shell ID.
+ * Must start with alphanumeric, contain only alphanumeric, _ or -, max 128 chars.
+ * @throws Error if invalid.
+ */
+export function validateShellId(shellId: string): void {
+  if (typeof shellId !== 'string') {
+    throw new Error(`shellId must be a string, got ${typeof shellId}`)
+  }
+  if (!SHELL_ID_RE.test(shellId)) {
+    throw new Error(
+      `Invalid shellId ${JSON.stringify(shellId)}: must start with alphanumeric, ` +
+        `contain only [a-zA-Z0-9_-], and be 1–128 characters long`
+    )
+  }
+}

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -493,3 +493,109 @@ export interface WebSocketConnection {
    */
   headers: Record<string, string>
 }
+
+// =============================================================================
+// Shell (InvokeAgentRuntimeCommandShell) Types
+// =============================================================================
+
+// ── Layer 1 — Auth helpers ────────────────────────────────────────────────────
+
+/** Result of connectShellSigV4 — URL and SigV4-signed headers. */
+export interface ShellConnectionSigV4 {
+  url: string
+  headers: Record<string, string>
+}
+
+/** Result of connectShellPresigned — auth embedded in query string. */
+export interface ShellConnectionPresigned {
+  url: string
+}
+
+/** Result of connectShellOAuth — URL and Sec-WebSocket-Protocol subprotocols. */
+export interface ShellConnectionOAuth {
+  url: string
+  subprotocols: string[]
+}
+
+/** Parameters for connectShellSigV4. shellId and sessionId are required — caller owns ID management. */
+export interface ConnectShellSigV4Params {
+  runtimeArn: string
+  shellId: string
+  sessionId: string
+  endpointName?: string | undefined
+}
+
+/** Parameters for connectShellPresigned. */
+export interface ConnectShellPresignedParams {
+  runtimeArn: string
+  shellId: string
+  sessionId: string
+  endpointName?: string | undefined
+  /** Seconds until URL expires. Max 300. Default 300. */
+  expires?: number | undefined
+}
+
+/** Parameters for connectShellOAuth. */
+export interface ConnectShellOAuthParams {
+  runtimeArn: string
+  shellId: string
+  sessionId: string
+  endpointName?: string | undefined
+  bearerToken: string
+}
+
+// ── Layer 2 — Managed session ─────────────────────────────────────────────────
+
+/** Authentication mode for openShell. */
+export type ShellAuthMode = 'sigv4' | { type: 'presigned'; expires?: number } | { type: 'oauth'; bearerToken: string }
+
+/** Parameters for openShell. */
+export interface OpenShellParams {
+  /** Full agent runtime ARN. */
+  runtimeArn: string
+
+  /**
+   * Runtime session ID — routes to an existing VM.
+   * Auto-generated UUID if omitted, stable across reconnects.
+   */
+  sessionId?: string
+
+  /**
+   * Client-chosen shell name (1–128 chars, alphanumeric, _ or - allowed, must start with alphanumeric).
+   * Auto-generated UUID if omitted. Pass the same ID to reconnect to an existing PTY.
+   */
+  shellId?: string
+
+  /** Endpoint qualifier (default: DEFAULT). */
+  endpointName?: string
+
+  /**
+   * Authentication mode.
+   * - `'sigv4'` (default) — SigV4-signed headers. Correct for server-side use.
+   * - `{ type: 'presigned', expires }` — Auth in URL query string.
+   * - `{ type: 'oauth', bearerToken }` — Bearer token in Sec-WebSocket-Protocol header.
+   */
+  auth?: ShellAuthMode
+
+  /** Auto-reconnect configuration. When omitted, disconnects are not retried. */
+  reconnectConfig?: import('./shell/config.js').ReconnectConfig
+
+  /**
+   * Interval in milliseconds between RFC 6455 Ping frames sent to keep the connection
+   * alive through the KARP proxy (~60s idle timeout). Defaults to 30000ms.
+   * Set to 0 to disable (e.g. when managing keepalive externally).
+   */
+  keepaliveIntervalMs?: number
+
+  /**
+   * Optional logger for diagnostic output from `ShellSession`.
+   * When omitted, all logging is silent.
+   * Pass `console` to enable, or any object implementing `{ debug, info, warn }`.
+   *
+   * @example
+   * ```typescript
+   * const shell = await client.openShell({ runtimeArn, logger: console })
+   * ```
+   */
+  logger?: import('./shell/config.js').Logger
+}


### PR DESCRIPTION

* feat(runtime): add interactive shell support (InvokeAgentRuntimeCommand)

Implements two-layer shell API:

Layer 1 — low-level auth helpers:
- RuntimeClient.connectShellSigV4 / connectShellPresigned / connectShellOAuth return connection params (url, headers/subprotocols) for custom WebSocket usage
- ShellFramer for binary channel-prefix frame encode/decode (ShellChannel, ShellFrame, MAX_FRAME_SIZE)
- _sigV4SignWsUrl / _presignWsUrl private helpers eliminate signing duplication

Layer 2 — managed session:
- RuntimeClient.openShell returns a connected ShellSession
- ShellSession: async-iterable PTY session with send/resize/close
- Auto-reconnect with two-loop exponential backoff (+-25% jitter)
- RFC 6455 Ping keepalive every 30s; timer cleared on all session exit paths
- ConnectFn receives (shellId, sessionId) -- stable IDs across reconnects
- Close code handling: 1000/1001/1003/4000; auto-reconnect on abnormal close
- events.on() + AbortController for message streaming; events.once() + Promise.race for open handshake

