### PR TITLE
feat: add extractionMode support to AgentCoreEventSender

### DIFF
--- a/src/memory/integrations/strands/__tests__/sender.test.ts
+++ b/src/memory/integrations/strands/__tests__/sender.test.ts
@@ -244,4 +244,18 @@ describe('AgentCoreEventSender.sendBatch', () => {
   it('rejects a non-positive maxTurnsPerEvent at construction', () => {
     expect(() => makeSender(send, { maxTurnsPerEvent: 0 })).toThrow(/maxTurnsPerEvent must be a positive integer/)
   })
+
+  it('passes extractionMode through to CreateEventCommand when configured', async () => {
+    const sender = makeSender(send, { extractionMode: 'SKIP' })
+    await sender.sendBatch([userMsg('sensitive data')])
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(sent[0]!.input.extractionMode).toBe('SKIP')
+  })
+
+  it('does not include extractionMode when not configured', async () => {
+    const sender = makeSender(send)
+    await sender.sendBatch([userMsg('normal data')])
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(sent[0]!.input.extractionMode).toBeUndefined()
+  })
 })

--- a/src/memory/integrations/strands/sender.ts
+++ b/src/memory/integrations/strands/sender.ts
@@ -22,6 +22,11 @@ export interface AgentCoreEventSenderConfig {
    * the payload well under the service limit.
    */
   maxTurnsPerEvent?: number
+  /**
+   * Controls long-term memory extraction for events sent by this sender. When set to `"SKIP"`, events
+   * are stored in short-term memory but excluded from long-term extraction.
+   */
+  extractionMode?: string | undefined
 }
 
 /** A message paired with the sequence number the coordinator assigned it (when available). */
@@ -73,6 +78,7 @@ export class AgentCoreEventSender {
   private readonly metadataProvider: MetadataProvider | undefined
   private readonly runId: string
   private readonly maxTurnsPerEvent: number
+  private readonly extractionMode: string | undefined
 
   constructor(config: AgentCoreEventSenderConfig) {
     this.client = config.client
@@ -80,6 +86,7 @@ export class AgentCoreEventSender {
     this.actorId = config.actorId
     this.sessionId = config.sessionId
     this.metadataProvider = config.metadataProvider
+    this.extractionMode = config.extractionMode
     this.runId = config.runId ?? randomUUID()
     const cap = config.maxTurnsPerEvent ?? DEFAULT_MAX_TURNS_PER_EVENT
     if (!Number.isInteger(cap) || cap < 1) {
@@ -162,6 +169,7 @@ export class AgentCoreEventSender {
       payload,
       ...(clientToken !== undefined && { clientToken }),
       ...(event.metadata && { metadata: event.metadata }),
+      ...(this.extractionMode && { extractionMode: this.extractionMode }),
     })
 
     await this.client.send(command)

--- a/src/memory/integrations/strands/sender.ts
+++ b/src/memory/integrations/strands/sender.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto'
 import { type BedrockAgentCoreClient, CreateEventCommand } from '@aws-sdk/client-bedrock-agentcore'
 import type { MessageData } from '@strands-agents/sdk'
 import { extractText, isUserOrAssistantWithText, mapRole } from './format.js'
-import { DEFAULT_MAX_TURNS_PER_EVENT, type MetadataProvider } from './types.js'
+import { DEFAULT_MAX_TURNS_PER_EVENT, type ExtractionMode, type MetadataProvider } from './types.js'
 
 export interface AgentCoreEventSenderConfig {
   client: BedrockAgentCoreClient
@@ -26,7 +26,7 @@ export interface AgentCoreEventSenderConfig {
    * Controls long-term memory extraction for events sent by this sender. When set to `"SKIP"`, events
    * are stored in short-term memory but excluded from long-term extraction.
    */
-  extractionMode?: string | undefined
+  extractionMode?: ExtractionMode | undefined
 }
 
 /** A message paired with the sequence number the coordinator assigned it (when available). */
@@ -78,7 +78,7 @@ export class AgentCoreEventSender {
   private readonly metadataProvider: MetadataProvider | undefined
   private readonly runId: string
   private readonly maxTurnsPerEvent: number
-  private readonly extractionMode: string | undefined
+  private readonly extractionMode: ExtractionMode | undefined
 
   constructor(config: AgentCoreEventSenderConfig) {
     this.client = config.client

--- a/src/memory/integrations/strands/store.ts
+++ b/src/memory/integrations/strands/store.ts
@@ -130,6 +130,7 @@ export class AgentCoreMemoryStore implements MemoryStore {
         sessionId: this.sessionId,
         ...(config.metadataProvider !== undefined && { metadataProvider: config.metadataProvider }),
         ...(config.maxTurnsPerEvent !== undefined && { maxTurnsPerEvent: config.maxTurnsPerEvent }),
+        ...(config.extractionMode !== undefined && { extractionMode: config.extractionMode }),
       })
     } else if (storeConfig.extraction !== undefined && storeConfig.extraction !== false) {
       // A real extraction config on a non-writable store would be silently ignored (no write sink), so

--- a/src/memory/integrations/strands/types.ts
+++ b/src/memory/integrations/strands/types.ts
@@ -2,6 +2,13 @@ import type { AwsCredentialIdentityProvider } from '@aws-sdk/types'
 import type { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore'
 import type { JSONValue, MemoryStoreConfig, MessageData } from '@strands-agents/sdk'
 
+/**
+ * Long-term extraction control for `createEvent`. Mirrors the SDK's `ExtractionMode` enum, declared
+ * locally so the type holds across SDK versions (older clients don't export it). `"SKIP"` stores the
+ * event in short-term memory only; omitting it processes the event for extraction as usual.
+ */
+export type ExtractionMode = 'SKIP'
+
 /** Default region used when none is supplied and `AWS_REGION` is unset. */
 export const DEFAULT_REGION = 'us-west-2'
 
@@ -81,7 +88,7 @@ export interface AgentCoreMemoryConfig {
    * Controls long-term memory extraction. Set to `"SKIP"` to store events in short-term memory
    * without triggering long-term extraction.
    */
-  readonly extractionMode?: string | undefined
+  readonly extractionMode?: ExtractionMode | undefined
 
   /** Region for the default client. Ignored if `client` is supplied. */
   readonly region?: string | undefined

--- a/src/memory/integrations/strands/types.ts
+++ b/src/memory/integrations/strands/types.ts
@@ -77,6 +77,12 @@ export interface AgentCoreMemoryConfig {
    */
   readonly maxTurnsPerEvent?: number | undefined
 
+  /**
+   * Controls long-term memory extraction. Set to `"SKIP"` to store events in short-term memory
+   * without triggering long-term extraction.
+   */
+  readonly extractionMode?: string | undefined
+
   /** Region for the default client. Ignored if `client` is supplied. */
   readonly region?: string | undefined
   /** Credentials for the default client. Ignored if `client` is supplied. */

--- a/tests_integ/memory.test.ts
+++ b/tests_integ/memory.test.ts
@@ -202,6 +202,71 @@ describe('AgentCoreMemoryStore (store-level, live data plane)', () => {
     expect(Array.isArray(results)).toBe(true)
   }, 300_000)
 
+  it('sends extractionMode "SKIP" on the live CreateEvent and the service accepts it', async () => {
+    // Capture the real CreateEventCommand input so we prove the value goes over the wire (not just that
+    // it's set on the sender), and that the live data plane accepts "SKIP" without erroring.
+    let skipInput: { extractionMode?: string } | undefined
+    const capturingClient = {
+      send: (command: unknown) => {
+        if ((command as { constructor: { name: string } }).constructor.name === 'CreateEventCommand') {
+          skipInput = (command as { input: { extractionMode?: string } }).input
+        }
+        return dataPlane.send(command as never)
+      },
+    } as unknown as typeof dataPlane
+
+    const skipActor = `skip-actor-${uniqueSuffix()}`
+    const store = new AgentCoreMemoryStore({
+      memoryId,
+      actorId: skipActor,
+      sessionId: `skip-session-${uniqueSuffix()}-padded-to-be-long-enough`,
+      namespace: FACTS_NAMESPACE,
+      writable: true,
+      extraction: true,
+      extractionMode: 'SKIP',
+      client: capturingClient,
+    })
+    // The write must succeed against the live service — this is what would have caught a value the API
+    // rejects.
+    await expect(
+      store.addMessages!([{ role: 'user', content: [{ text: 'Short-term only: my temporary PIN is 4821.' }] }], {
+        sequenceNumbers: [0],
+      })
+    ).resolves.toBeUndefined()
+    // And the wire payload carried the mode.
+    expect(skipInput?.extractionMode).toBe('SKIP')
+  }, 60_000)
+
+  it('omits extractionMode on the live CreateEvent when not configured (default extraction path)', async () => {
+    let defaultInput: { extractionMode?: string } | undefined
+    const capturingClient = {
+      send: (command: unknown) => {
+        if ((command as { constructor: { name: string } }).constructor.name === 'CreateEventCommand') {
+          defaultInput = (command as { input: { extractionMode?: string } }).input
+        }
+        return dataPlane.send(command as never)
+      },
+    } as unknown as typeof dataPlane
+
+    const defaultActor = `default-mode-actor-${uniqueSuffix()}`
+    const store = new AgentCoreMemoryStore({
+      memoryId,
+      actorId: defaultActor,
+      sessionId: `default-mode-session-${uniqueSuffix()}-padded-to-be-long-enough`,
+      namespace: FACTS_NAMESPACE,
+      writable: true,
+      extraction: true,
+      // extractionMode omitted -> field must not be sent
+      client: capturingClient,
+    })
+    await expect(
+      store.addMessages!([{ role: 'user', content: [{ text: 'Extract me normally: I live in Portland.' }] }], {
+        sequenceNumbers: [0],
+      })
+    ).resolves.toBeUndefined()
+    expect(defaultInput?.extractionMode).toBeUndefined()
+  }, 60_000)
+
   it('recalls extracted records and proves the namespace contract (records land where the store queries)', async () => {
     // Recall-only: the writes happen in the earlier writer tests (shared actorId); this store just reads.
     const store = new AgentCoreMemoryStore({


### PR DESCRIPTION
## Summary
- Adds `extractionMode` to `AgentCoreEventSenderConfig`, `AgentCoreMemoryConfig`, and passes it through to `CreateEventCommand`
- When set to `"SKIP"`, events are stored in short-term memory but excluded from long-term extraction

## Test plan
- [x] All 614 existing unit tests pass (`npm test`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Verified the feature end-to-end with boto3 directly against live AgentCore (us-east-1)