### PR TITLE
fix(runtime/shell): apply prettier formatting to session.ts (unblocks release)

### DIFF
--- a/src/runtime/shell/session.ts
+++ b/src/runtime/shell/session.ts
@@ -833,10 +833,7 @@ export class ShellSession implements AsyncIterable<ShellFrame> {
     // is promoted to 'open' but _reconnectPromise has not yet been cleared in .finally) must
     // be processed as a NEW event — otherwise a terminal 4000/1003 on the new socket is
     // swallowed (kicked never set) and a fresh drop arms no new reconnect.
-    if (
-      this._reconnectPromise &&
-      (this._state.status === 'reconnecting' || this._state.status === 'connecting')
-    ) {
+    if (this._reconnectPromise && (this._state.status === 'reconnecting' || this._state.status === 'connecting')) {
       return this._reconnectPromise
     }
     if (this._isClosed()) return Promise.resolve(false)


### PR DESCRIPTION
## Description

The **Release** workflow ([run 28199325095](https://github.com/aws/bedrock-agentcore-sdk-typescript/actions/runs/28199325095)) is failing at the **Prepare Release → Create release branch and PR** step. The version-bump commit triggers the husky pre-commit gate (`test → lint → format:check → type-check`), and `format:check` fails:

```
[warn] src/runtime/shell/session.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
husky - pre-commit script failed (code 1)
```

`src/runtime/shell/session.ts` (added in #199) has a multi-line `if` condition that Prettier wants on a single line. This PR runs `prettier --write` on it. **Whitespace-only — no behavior change.**

```diff
-    if (
-      this._reconnectPromise &&
-      (this._state.status === 'reconnecting' || this._state.status === 'connecting')
-    ) {
+    if (this._reconnectPromise && (this._state.status === 'reconnecting' || this._state.status === 'connecting')) {
```

Verified locally: `prettier --check src tests_integ` reports `session.ts` as the **only** offender; after the fix the full repo is clean and the complete gate (614 tests, lint, format, type-check) passes.

> Note: this slipped into `main` via #199 — worth checking why `format:check` didn't gate that PR's CI (possibly a `--no-verify` commit or a CI config gap), but that's a follow-up; this PR unblocks the release.

## Related Issues

<!-- none -->

## Type of Change

Bug fix

## Testing

- [x] I ran `npm run check` (test + lint + format:check + type-check — all pass)

## Checklist
- [x] My changes generate no new warnings
- [x] I have added any necessary tests that prove my fix is effective or my feature works (N/A — formatting-only; existing 614 tests pass)