### PR TITLE
fix(runtime): track custom ping status timestamps

### DIFF
--- a/src/runtime/__tests__/app.test.ts
+++ b/src/runtime/__tests__/app.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Readable } from 'stream'
 import { z } from 'zod'
-import type { InvocationHandler, WebSocketHandler } from '../types.js'
+import type { HealthStatus, InvocationHandler, WebSocketHandler } from '../types.js'
 import { BedrockAgentCoreApp } from '../app.js'
 
 // Mock fastify module
@@ -262,6 +262,57 @@ describe('BedrockAgentCoreApp', () => {
         status: expect.stringMatching(/^(Healthy|HealthyBusy)$/),
         time_of_last_update: expect.any(Number),
       })
+    })
+
+    it('updates custom ping timestamps only when status changes', async () => {
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1000)
+      try {
+        let customStatus: HealthStatus = 'Healthy'
+        const handler: InvocationHandler = async (_request, _context) => 'test response'
+        const app = new BedrockAgentCoreApp({
+          invocationHandler: { process: handler },
+          pingHandler: () => customStatus,
+        })
+        const mockApp = app['_app'] as any
+
+        app['_setupRoutes']()
+
+        const getCall = mockApp.get.mock.calls.find((call: any[]) => call[0] === '/ping')
+        const pingHandler = getCall[1]
+        const mockReq = {}
+        const mockReply = { send: vi.fn() }
+
+        await pingHandler(mockReq, mockReply)
+        expect(mockReply.send).toHaveBeenLastCalledWith({
+          status: 'Healthy',
+          time_of_last_update: 1,
+        })
+
+        nowSpy.mockReturnValue(2000)
+        await pingHandler(mockReq, mockReply)
+        expect(mockReply.send).toHaveBeenLastCalledWith({
+          status: 'Healthy',
+          time_of_last_update: 1,
+        })
+
+        customStatus = 'HealthyBusy'
+        nowSpy.mockReturnValue(3000)
+        await pingHandler(mockReq, mockReply)
+        expect(mockReply.send).toHaveBeenLastCalledWith({
+          status: 'HealthyBusy',
+          time_of_last_update: 3,
+        })
+
+        customStatus = 'Healthy'
+        nowSpy.mockReturnValue(4000)
+        await pingHandler(mockReq, mockReply)
+        expect(mockReply.send).toHaveBeenLastCalledWith({
+          status: 'Healthy',
+          time_of_last_update: 4,
+        })
+      } finally {
+        nowSpy.mockRestore()
+      }
     })
   })
 

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -159,26 +159,27 @@ export class BedrockAgentCoreApp<TSchema extends z.ZodSchema = z.ZodSchema<unkno
    * @returns Current health status
    */
   public getCurrentPingStatus(): HealthStatus {
+    let status: HealthStatus | undefined
+
     // Priority 1: Forced status
     if (this._forcedPingStatus) {
-      return this._forcedPingStatus
-    }
-
-    // Priority 2: Custom handler
-    if (this._pingHandler) {
+      status = this._forcedPingStatus
+    } else if (this._pingHandler) {
+      // Priority 2: Custom handler
       try {
         const result = this._pingHandler()
         // Handle both sync and async handlers
-        return result instanceof Promise ? 'Healthy' : result
+        status = result instanceof Promise ? 'Healthy' : result
       } catch {
         this._app.log.warn('Custom ping handler failed, falling back to automatic')
       }
     }
 
-    // Priority 3: Automatic based on active tasks
-    const status: HealthStatus = this._activeTasksMap.size > 0 ? 'HealthyBusy' : 'Healthy'
+    if (!status) {
+      // Priority 3: Automatic based on active tasks
+      status = this._activeTasksMap.size > 0 ? 'HealthyBusy' : 'Healthy'
+    }
 
-    // Track status changes
     if (!this._lastKnownStatus || this._lastKnownStatus !== status) {
       this._lastKnownStatus = status
       this._lastStatusUpdateTime = Date.now()


### PR DESCRIPTION
## Description

`BedrockAgentCoreApp.getCurrentPingStatus()` returned forced and custom ping statuses before updating the status timestamp. When a custom ping handler transitions from `Healthy` to `HealthyBusy`, `/ping` could keep reporting an old `time_of_last_update`, making the busy signal look stale to AgentCore.

This aligns the TypeScript runtime with the Python runtime: forced, custom, and automatic ping statuses now flow through the same status-transition timestamp update before `/ping` serializes the response.

No public API changes.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] `npm test -- src/runtime/__tests__/app.test.ts`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run type-check`
- [ ] I ran `npm run check`

`npm run check` was not marked because `npm run type-check:all` currently fails in unrelated existing test files; production `tsc --noEmit`, lint, format check, and the focused runtime unit tests pass.

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
