### PR TITLE
fix: govcloud support

### DIFF
--- a/src/identity/__tests__/client.test.ts
+++ b/src/identity/__tests__/client.test.ts
@@ -205,7 +205,7 @@ describe('IdentityClient', () => {
         workloadIdentityToken: 'user-identity-token',
       })
 
-      const command = mockSend.mock.calls[0][0]
+      const command = mockSend.mock.calls[0]![0]
       expect(command.input).toMatchObject({
         oauth2Flow: 'ON_BEHALF_OF_TOKEN_EXCHANGE',
         resourceCredentialProviderName: 'downstream-service',
@@ -264,7 +264,7 @@ describe('IdentityClient', () => {
         workloadIdentityToken: 'workload-token',
       })
 
-      const command = mockSend.mock.calls[0][0]
+      const command = mockSend.mock.calls[0]![0]
       expect(command.input.resources).toEqual(['https://api.example.com', 'https://api2.example.com'])
       expect(command.input.audiences).toBeUndefined()
     })
@@ -283,7 +283,7 @@ describe('IdentityClient', () => {
         workloadIdentityToken: 'workload-token',
       })
 
-      const command = mockSend.mock.calls[0][0]
+      const command = mockSend.mock.calls[0]![0]
       expect(command.input.resources).toBeUndefined()
       expect(command.input.audiences).toEqual(['audience-1', 'audience-2'])
     })
@@ -302,7 +302,7 @@ describe('IdentityClient', () => {
         workloadIdentityToken: 'workload-token',
       })
 
-      const command = mockSend.mock.calls[0][0]
+      const command = mockSend.mock.calls[0]![0]
       expect(command.input).toMatchObject({
         resources: ['https://api.example.com'],
         audiences: ['audience-1'],
@@ -324,7 +324,7 @@ describe('IdentityClient', () => {
         workloadIdentityToken: 'workload-token',
       })
 
-      const command = mockSend.mock.calls[0][0]
+      const command = mockSend.mock.calls[0]![0]
       expect(command.input.resources).toBeUndefined()
       expect(command.input.audiences).toBeUndefined()
     })
@@ -353,8 +353,8 @@ describe('IdentityClient', () => {
 
         // Both calls should have resources/audiences
         expect(mockSend).toHaveBeenCalledTimes(2)
-        const initialCommand = mockSend.mock.calls[0][0]
-        const pollCommand = mockSend.mock.calls[1][0]
+        const initialCommand = mockSend.mock.calls[0]![0]
+        const pollCommand = mockSend.mock.calls[1]![0]
 
         expect(initialCommand.input.resources).toEqual(['https://api.example.com'])
         expect(initialCommand.input.audiences).toEqual(['audience-1'])

--- a/src/identity/__tests__/wrappers.test.ts
+++ b/src/identity/__tests__/wrappers.test.ts
@@ -4,6 +4,16 @@ import { IdentityClient } from '../client.js'
 import { runWithContext } from '../../runtime/context.js'
 import type { RequestContext } from '../../runtime/types.js'
 
+const mockLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+} as any
+
 vi.mock('../client.js')
 
 describe('withAccessToken', () => {
@@ -381,6 +391,7 @@ describe('withAccessToken context integration', () => {
       sessionId: 'test-session',
       workloadAccessToken: 'context-token-value',
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {
@@ -423,6 +434,7 @@ describe('withAccessToken context integration', () => {
       sessionId: 'test-session',
       workloadAccessToken: 'context-token',
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {
@@ -462,6 +474,7 @@ describe('withAccessToken context integration', () => {
       sessionId: 'test-session',
       // NO workloadAccessToken
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {
@@ -489,6 +502,7 @@ describe('withAccessToken context integration', () => {
       workloadAccessToken: 'test-token',
       oauth2CallbackUrl: 'http://localhost:3000/callback',
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {
@@ -529,6 +543,7 @@ describe('withAccessToken context integration', () => {
       workloadAccessToken: 'test-token',
       oauth2CallbackUrl: 'http://context-callback.com',
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {
@@ -619,6 +634,7 @@ describe('withAccessToken context integration', () => {
       sessionId: 'session-1',
       workloadAccessToken: 'token-1',
       headers: {},
+      log: mockLog,
     }
 
     const context2: RequestContext = {
@@ -626,6 +642,7 @@ describe('withAccessToken context integration', () => {
       sessionId: 'session-2',
       workloadAccessToken: 'token-2',
       headers: {},
+      log: mockLog,
     }
 
     // Run concurrently
@@ -669,6 +686,7 @@ describe('withApiKey context integration', () => {
       sessionId: 'test-session',
       workloadAccessToken: 'context-token',
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {
@@ -700,6 +718,7 @@ describe('withApiKey context integration', () => {
       sessionId: 'test-session',
       workloadAccessToken: 'context-token',
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {
@@ -728,6 +747,7 @@ describe('withApiKey context integration', () => {
       sessionId: 'test-session',
       // NO workloadAccessToken
       headers: {},
+      log: mockLog,
     }
 
     await runWithContext(context, async () => {

--- a/src/memory/integrations/strands/__tests__/sender.test.ts
+++ b/src/memory/integrations/strands/__tests__/sender.test.ts
@@ -189,7 +189,7 @@ describe('AgentCoreEventSender.sendBatch', () => {
     // undefined -> JSON.stringify returns the JS value undefined (not a string); NaN/Infinity/null -> "null".
     // All would slip past the charset test and corrupt the event, so they must throw before any createEvent.
     for (const bad of [{ u: undefined }, { n: null }, { x: NaN }, { y: Infinity }]) {
-      const sender = makeSender(send, { metadataProvider: () => bad as Record<string, never> })
+      const sender = makeSender(send, { metadataProvider: () => bad as unknown as Record<string, never> })
       await expect(sender.sendBatch([userMsg('x')])).rejects.toThrow(/no valid string representation/)
     }
     expect(send).not.toHaveBeenCalled()

--- a/src/runtime/__tests__/app.test.ts
+++ b/src/runtime/__tests__/app.test.ts
@@ -67,7 +67,7 @@ describe('BedrockAgentCoreApp', () => {
       const app = new BedrockAgentCoreApp({
         invocationHandler: { process: handler },
         config: {
-          logging: { enabled: true, level: 'debug' },
+          logging: { enabled: true, options: { level: 'debug' } },
         },
       })
       expect(app).toBeDefined()

--- a/src/runtime/__tests__/client.test.ts
+++ b/src/runtime/__tests__/client.test.ts
@@ -602,7 +602,7 @@ describe('RuntimeClient', () => {
       const presignSpy = (SignatureV4 as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value.presign as ReturnType<
         typeof vi.fn
       >
-      const signedRequest = presignSpy.mock.calls[0][0]
+      const signedRequest = presignSpy.mock.calls[0]![0]
       expect(signedRequest.query['X-Amzn-Bedrock-AgentCore-Runtime-Session-Id']).toBe('embedded-session')
     })
 
@@ -733,7 +733,7 @@ describe('RuntimeClient', () => {
 
     it('auto-generates shellId when omitted', async () => {
       await client.openShell({ runtimeArn: validArn })
-      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0]![0]
       expect(opts.shellId).toBeTruthy()
     })
 
@@ -764,7 +764,7 @@ describe('RuntimeClient', () => {
 
     it('uses sigv4 auth by default', async () => {
       await client.openShell({ runtimeArn: validArn })
-      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0]![0]
       // connectFn should call connectShellSigV4 — invoke it to verify shape
       const connResult = await opts.connectFn('test-shell', 'test-session')
       expect(connResult.url).toMatch(/^wss:\/\//)
@@ -774,7 +774,7 @@ describe('RuntimeClient', () => {
 
     it('uses presigned auth when specified', async () => {
       await client.openShell({ runtimeArn: validArn, auth: { type: 'presigned', expires: 60 } })
-      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0]![0]
       const connResult = await opts.connectFn('test-shell', 'test-session')
       expect(connResult.url).toMatch(/^wss:\/\//)
       expect(connResult.url).toContain('X-Amz-Signature')
@@ -783,7 +783,7 @@ describe('RuntimeClient', () => {
 
     it('uses oauth auth when specified', async () => {
       await client.openShell({ runtimeArn: validArn, auth: { type: 'oauth', bearerToken: 'my-token' } })
-      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const opts = (MockShellSession as ReturnType<typeof vi.fn>).mock.calls[0]![0]
       const connResult = await opts.connectFn('test-shell', 'test-session')
       expect(connResult.url).toMatch(/^wss:\/\//)
       expect(connResult.protocols).toHaveLength(2)

--- a/src/runtime/__tests__/client.test.ts
+++ b/src/runtime/__tests__/client.test.ts
@@ -127,6 +127,16 @@ describe('RuntimeClient', () => {
       })
     })
 
+    it('parses GovCloud ARN successfully', () => {
+      const govCloudArn = 'arn:aws-us-gov:bedrock-agentcore:us-gov-west-1:123456789012:runtime/my-runtime-id'
+      const parsed = (client as any)._parseRuntimeArn(govCloudArn)
+      expect(parsed).toEqual({
+        region: 'us-gov-west-1',
+        accountId: '123456789012',
+        runtimeId: 'my-runtime-id',
+      })
+    })
+
     it('throws error for invalid ARN format (wrong structure)', () => {
       const invalidArn = 'invalid-arn'
       expect(() => (client as any)._parseRuntimeArn(invalidArn)).toThrow('Invalid runtime ARN format')

--- a/src/runtime/__tests__/context.test.ts
+++ b/src/runtime/__tests__/context.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { getContext, runWithContext } from '../context.js'
 import type { RequestContext } from '../types.js'
+
+const mockLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+} as any
 
 describe('Context Storage', () => {
   const mockContext: RequestContext = {
@@ -12,6 +22,7 @@ describe('Context Storage', () => {
       authorization: 'Bearer test',
       'x-custom-header': 'value',
     },
+    log: mockLog,
   }
 
   describe('getContext', () => {
@@ -130,11 +141,13 @@ describe('Context Storage', () => {
       const outerContext: RequestContext = {
         sessionId: 'outer-session',
         headers: {},
+        log: mockLog,
       }
 
       const innerContext: RequestContext = {
         sessionId: 'inner-session',
         headers: {},
+        log: mockLog,
       }
 
       runWithContext(outerContext, () => {
@@ -153,12 +166,14 @@ describe('Context Storage', () => {
         sessionId: 'outer',
         workloadAccessToken: 'outer-token',
         headers: {},
+        log: mockLog,
       }
 
       const innerContext: RequestContext = {
         sessionId: 'inner',
         workloadAccessToken: 'inner-token',
         headers: {},
+        log: mockLog,
       }
 
       runWithContext(outerContext, () => {
@@ -182,12 +197,14 @@ describe('Context Storage', () => {
         sessionId: 'session-1',
         workloadAccessToken: 'token-1',
         headers: {},
+        log: mockLog,
       }
 
       const context2: RequestContext = {
         sessionId: 'session-2',
         workloadAccessToken: 'token-2',
         headers: {},
+        log: mockLog,
       }
 
       const promise1 = runWithContext(context1, async () => {
@@ -213,9 +230,9 @@ describe('Context Storage', () => {
 
     it('isolates contexts in Promise.all', async () => {
       const contexts = [
-        { sessionId: 'req-1', headers: {} },
-        { sessionId: 'req-2', headers: {} },
-        { sessionId: 'req-3', headers: {} },
+        { sessionId: 'req-1', headers: {}, log: mockLog },
+        { sessionId: 'req-2', headers: {}, log: mockLog },
+        { sessionId: 'req-3', headers: {}, log: mockLog },
       ] as RequestContext[]
 
       const results = await Promise.all(
@@ -238,6 +255,7 @@ describe('Context Storage', () => {
       const minimalContext: RequestContext = {
         sessionId: 'minimal-session',
         headers: {},
+        log: mockLog,
       }
 
       runWithContext(minimalContext, () => {
@@ -260,6 +278,7 @@ describe('Context Storage', () => {
           authorization: 'Bearer token',
           'x-custom': 'value',
         },
+        log: mockLog,
       }
 
       runWithContext(fullContext, () => {
@@ -274,6 +293,7 @@ describe('Context Storage', () => {
       const context: RequestContext = {
         sessionId: 'mutable-session',
         headers: {},
+        log: mockLog,
       }
 
       runWithContext(context, () => {
@@ -294,6 +314,7 @@ describe('Context Storage', () => {
       const context: RequestContext = {
         sessionId: 'async-mutable',
         headers: {},
+        log: mockLog,
       }
 
       await runWithContext(context, async () => {

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -92,7 +92,7 @@ export class RuntimeClient {
   }
 
   private _parseRuntimeArn(runtimeArn: string): ParsedRuntimeArn {
-    const arnRegex = /^arn:aws:bedrock-agentcore:([^:]+):([^:]+):runtime\/(.+)$/
+    const arnRegex = /^arn:aws[a-z0-9-]*:bedrock-agentcore:([^:]+):([^:]+):runtime\/(.+)$/
     const match = runtimeArn.match(arnRegex)
 
     if (!match) {

--- a/src/runtime/shell/__tests__/session.test.ts
+++ b/src/runtime/shell/__tests__/session.test.ts
@@ -81,7 +81,7 @@ function makeOpts(
 ): ShellSessionOptions & { getWs: () => MockWs } {
   let capturedWs: MockWs | null = null
 
-  const wsFactory = (_url: string, _protocols?: string[], _options?: Record<string, unknown>): WebSocket => {
+  const wsFactory = (_url: string, _protocols?: string[], _options?: import('ws').ClientOptions): WebSocket => {
     const ws = makeMockWs()
     capturedWs = ws
     return ws as unknown as WebSocket
@@ -439,7 +439,12 @@ describe('ShellSession: disconnect handling', () => {
       connectFn,
       _wsFactory: wsFactory,
       reconnectConfig: opts.reconnect
-        ? { maxRetries: 2, baseDelay: 0, reconnectWindow: null, onReconnect: opts.onReconnect }
+        ? {
+            maxRetries: 2,
+            baseDelay: 0,
+            reconnectWindow: null,
+            ...(opts.onReconnect && { onReconnect: opts.onReconnect }),
+          }
         : undefined,
       sockets,
       confirm: () => {},

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -334,8 +334,8 @@ export const DEFAULT_REGION = 'us-west-2'
 export const RuntimeArnSchema = z
   .string()
   .regex(
-    /^arn:aws:bedrock-agentcore:[^:]+:[^:]+:runtime\/.+$/,
-    'Invalid runtime ARN format. Expected: arn:aws:bedrock-agentcore:{region}:{account}:runtime/{runtime_id}'
+    /^arn:aws[a-z0-9-]*:bedrock-agentcore:[^:]+:[^:]+:runtime\/.+$/,
+    'Invalid runtime ARN format. Expected: arn:{partition}:bedrock-agentcore:{region}:{account}:runtime/{runtime_id}'
   )
 
 /**

--- a/tests_integ/vercel-ai-agent.test.ts
+++ b/tests_integ/vercel-ai-agent.test.ts
@@ -25,7 +25,7 @@ describe('ToolLoopAgent with CodeInterpreter', () => {
 
   it('executes code via generate()', async () => {
     const agent = new ToolLoopAgent({
-      model: bedrock('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+      model: bedrock(process.env.MODEL_ID || 'us.anthropic.claude-sonnet-4-20250514-v1:0'),
       instructions: 'You are a helpful assistant. Execute code when asked.',
       tools: { executeCode: codeInterpreter.executeCode },
     })
@@ -41,7 +41,7 @@ describe('ToolLoopAgent with CodeInterpreter', () => {
 
   it('handles file operations', async () => {
     const agent = new ToolLoopAgent({
-      model: bedrock('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+      model: bedrock(process.env.MODEL_ID || 'us.anthropic.claude-sonnet-4-20250514-v1:0'),
       instructions: 'You can work with files and execute code.',
       tools: codeInterpreter.tools,
     })
@@ -68,7 +68,7 @@ describe('ToolLoopAgent with Browser', () => {
 
   it('navigates and extracts content', async () => {
     const agent = new ToolLoopAgent({
-      model: bedrock('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+      model: bedrock(process.env.MODEL_ID || 'us.anthropic.claude-sonnet-4-20250514-v1:0'),
       instructions: 'Navigate to websites and extract content.',
       tools: browser.tools,
     })
@@ -97,7 +97,7 @@ describe('ToolLoopAgent with Combined Tools', () => {
 
   it('uses both tools together', async () => {
     const agent = new ToolLoopAgent({
-      model: bedrock('us.anthropic.claude-sonnet-4-20250514-v1:0'),
+      model: bedrock(process.env.MODEL_ID || 'us.anthropic.claude-sonnet-4-20250514-v1:0'),
       instructions: 'You can browse the web and execute code.',
       tools: {
         ...browser.tools,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
     "noEmit": true
   },
   "include": ["src/**/__tests__/**/*", "tests_integ/**/*"],
-  "exclude": []
+  "exclude": ["src/tools/browser/live-view/BrowserLiveView.tsx", "src/tools/browser/live-view/__tests__/BrowserLiveView.test.tsx"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
         'src/**/__tests__/**',
         'src/**/__fixtures__/**',
         'src/**/index.ts', // Re-export files
+        'src/tools/browser/live-view/nice-dcv-web-client-sdk/**',
       ],
       thresholds: {
         lines: 60,


### PR DESCRIPTION
## Description
fix(runtime ws client):
- Modify arn parsing in runtime client to support gov partitions.

chore: tsc errors + govcloud integ change:
- Fix tsc errors from previous changes
- Modify integ to optionally take MODEL_ID envvar
- Exclude dcv bundle from coverage (which was causing it to hang)

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

N/A

Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run check` - coverage fails due to previous changes
- [x] manual govcloud testing (all clients + major executions) local and remote
- [x] integ tests in govcloud: 

```
AWS_REGION=us-gov-west-1 MODEL_ID="us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0" npm run test:integ

 Test Files  1 failed | 7 passed (8)
      Tests  121 passed | 16 skipped (137)
   Start at  17:59:59
   Duration  30.42s (transform 2.43s, setup 127ms, import 4.39s, tests 87.98s, environment 1ms)
   
  Failure due to memory: ServiceException: Internal server error encountered during CreateMemory (not-built in govcloud)
```

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.