### PR TITLE
fix(runtime): bump @fastify/sse to 0.6.0 to stop it corrupting non-streaming error responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/credential-providers": "^3.996.0",
         "@aws-sdk/protocol-http": "^3.370.0",
         "@aws-sdk/signature-v4": "^3.370.0",
-        "@fastify/sse": "^0.4.0",
+        "@fastify/sse": "^0.6.0",
         "@fastify/websocket": "^11.0.1",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/signature-v4": "^5.3.5",
@@ -2317,19 +2317,36 @@
       }
     },
     "node_modules/@fastify/sse": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@fastify/sse/-/sse-0.4.0.tgz",
-      "integrity": "sha512-bBV96iT2kHEw6h3i8IMkZGaqA7Gk81ugUzTNctXuE6N2BEC/qBnUuzlD/O17V43OkJP73h0/kf3Bp/asXlSuFA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@fastify/sse/-/sse-0.6.0.tgz",
+      "integrity": "sha512-+5g8zBbSN8ioKEfll2p6TXe75peq3uJ3/z44SakK5gNr9u6YqbOAHfTSRfXfvnUFzG97+3E055l360ruzsvgcQ==",
       "license": "MIT",
       "dependencies": {
-        "fastify-plugin": "^5.0.0"
+        "@fastify/error": "^4.2.0",
+        "fastify-plugin": "^6.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.20.2"
       },
       "peerDependencies": {
         "fastify": "^5.x"
       }
+    },
+    "node_modules/@fastify/sse/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@fastify/websocket": {
       "version": "11.2.0",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@aws-sdk/credential-providers": "^3.996.0",
     "@aws-sdk/protocol-http": "^3.370.0",
     "@aws-sdk/signature-v4": "^3.370.0",
-    "@fastify/sse": "^0.4.0",
+    "@fastify/sse": "^0.6.0",
     "@fastify/websocket": "^11.0.1",
     "@smithy/protocol-http": "^5.3.5",
     "@smithy/signature-v4": "^5.3.5",

--- a/src/runtime/__tests__/app-sse-errors.test.ts
+++ b/src/runtime/__tests__/app-sse-errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import type { InvocationHandler } from '../types.js'
+import { BedrockAgentCoreApp } from '../app.js'
+
+// This suite deliberately does NOT mock @fastify/sse: it exercises the real
+// plugin, because the behaviour under test is the plugin's own Content-Type
+// timing. app.test.ts mocks the plugin and therefore cannot cover it.
+const buildApp = async (handler: InvocationHandler) => {
+  const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
+  const fastify = (app as any)._app
+  await (app as any)._registerPlugins()
+  ;(app as any)._setupRoutes()
+  await fastify.ready()
+  return fastify
+}
+
+describe('BedrockAgentCoreApp invocation errors with the real @fastify/sse plugin', () => {
+  it('returns HTTP 500 with a JSON body when a handler throws before streaming and the client sent Accept: text/event-stream', async () => {
+    const fastify = await buildApp(async () => {
+      throw new Error('Sync handler blew up')
+    })
+
+    const res = await request(fastify.server)
+      .post('/invocations')
+      .set('x-amzn-bedrock-agentcore-runtime-session-id', 'throw-session-sse-accept')
+      .set('Accept', 'text/event-stream')
+      .send({})
+      .expect(500)
+
+    expect(res.body).toEqual({ error: 'Sync handler blew up' })
+  })
+
+  it('still streams SSE when the handler yields', async () => {
+    const fastify = await buildApp(async function* () {
+      yield 'first'
+      yield 'second'
+    })
+
+    await request(fastify.server)
+      .post('/invocations')
+      .set('x-amzn-bedrock-agentcore-runtime-session-id', 'stream-session')
+      .set('Accept', 'text/event-stream')
+      .send({})
+      .expect('Content-Type', 'text/event-stream')
+      .expect(200)
+      .expect((res) => {
+        expect(res.text).toContain('data: first')
+        expect(res.text).toContain('data: second')
+      })
+  })
+})


### PR DESCRIPTION
## Motivation

Bedrock AgentCore Runtime invocations that send `Accept: text/event-stream` on a `{ sse: true }` route — valid whenever a client doesn't know in advance whether the handler will stream — get a confusing `FST_ERR_REP_INVALID_PAYLOAD_TYPE` instead of the real error whenever the handler throws before it ever streams. `@fastify/sse@0.4.0` eagerly stages the SSE `Content-Type` header the moment `Accept` admits SSE, before the handler even runs, so a non-streaming error response gets serialized against an already-non-JSON content type and Fastify rejects it. The caller never learns why their request actually failed.

This is distinct from the fix in #118 (resolving #66): that one guards errors that occur after streaming has genuinely started and headers were flushed (`headersSent === true`). Here `headersSent` is still `false` — only the header *value* had been staged — so that guard doesn't apply, and the non-streaming branch calls `reply.send()` straight into the corrupted content type.

`@fastify/sse@0.5.0` fixed this at the source ([fastify/sse#42](https://github.com/fastify/sse/pull/42), resolving [fastify/sse#16](https://github.com/fastify/sse/issues/16)): it defers writing SSE headers until the handler actually calls `send()`. A handler that never streams now falls through to Fastify's normal JSON serialization, exactly as if `sse` had never been set. No changes to this SDK's own runtime code are needed — its control flow was already correct.

This targets `^0.6.0`, the current release, rather than `^0.5.0`: 0.6.0 keeps the deferred `sendHeaders()` behaviour and adds only an optional status-code argument to it ([fastify/sse#47](https://github.com/fastify/sse/pull/47)), which this SDK does not use.

Resolves: #212

## Verification

The regression test lives in the unit suite (`src/runtime/__tests__/app-sse-errors.test.ts`). It does not mock `@fastify/sse`, so it exercises the real plugin's `Content-Type` timing — `src/runtime/__tests__/app.test.ts` mocks the plugin and cannot cover this path. A companion test asserts SSE streaming is unaffected.

Run both ways on Node 22: the error test **fails** on `@fastify/sse@0.4.0` with a `{}` body (the masked error), and **passes** on `0.6.0`, returning HTTP 500 with `{ error: 'Sync handler blew up' }`. `npm test` (619 tests), `npm run lint`, `format:check`, `type-check` and `type-check:tests` all pass locally.

I diffed the published type surface between 0.4.0 and 0.6.0, since `SSESource` is re-exported through `RequestContext`: `SSESource` itself is unchanged. The route option widened (`sse?: boolean` → `sse?: SSERouteOptions`, still accepting `true`), and `sendHeaders()` gained an optional status-code argument. 0.6.0 also applies a stricter `Accept` gate to `sse: true` routes, which `app.ts` already handles — every use of `reply.sse` there is guarded by `if (reply.sse)`.

One item worth a maintainer's eye: `@fastify/sse` ≥ 0.5.0 declares `engines.node >= 20.20.2`, while this package declares `>= 20.0.0`. Installs on Node 20.0–20.20.1 would see an `EBADENGINE` warning (CI runs 22.x). Glad to align `engines` here if you'd prefer.

## Public API Changes

No public API changes. `{ sse: true }` routes behave identically for every case that already worked; a previously-crashing case (a non-streaming throw with `Accept: text/event-stream`) now returns the correct HTTP 500 with the real error message.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

