### PR TITLE
feat(memory): promote AgentCore Memory Strands integration to GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const agent = new Agent({
 - **Code Interpreter** — Execute Python/JS/TS in a sandbox → [Examples](https://github.com/awslabs/bedrock-agentcore-samples-typescript/tree/main/primitives/tools/code-interpreter)
 - **Browser** — Cloud-based web automation → [Examples](https://github.com/awslabs/bedrock-agentcore-samples-typescript/tree/main/primitives/tools/browser)
 - **Identity** — Manage API keys and OAuth tokens → [Examples](https://github.com/awslabs/bedrock-agentcore-samples-typescript/tree/main/primitives/identity)
-- **Memory** — Persistent knowledge across sessions (experimental) → [Guide](docs/MEMORY.md)
+- **Memory** — Persistent knowledge across sessions → [Guide](docs/MEMORY.md)
 - **Gateway** — Transform APIs into MCP tools (coming soon)
 - **Observability** — OpenTelemetry tracing (coming soon)
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -5,9 +5,8 @@ Memory](https://docs.aws.amazon.com/bedrock-agentcore/). This is the conceptual 
 the per-call API reference lives alongside the code in
 [`src/memory/integrations/strands/README.md`](../src/memory/integrations/strands/index.ts).
 
-> **Status: experimental.** This integration implements the Strands `MemoryManager` / `MemoryStore`
-> extraction interface, consumed directly from `@strands-agents/sdk` (>= 1.5.0). The upstream surface
-> is still evolving, so the module is **experimental**, not yet GA. See [Release status](#release-status).
+This integration implements the Strands `MemoryManager` / `MemoryStore` extraction interface,
+consumed directly from `@strands-agents/sdk` (>= 1.5.0). See [Release status](#release-status).
 
 ## What you get
 
@@ -42,7 +41,7 @@ Two consequences the integration leans on:
 
 ```typescript
 import { Agent, MemoryManager } from '@strands-agents/sdk'
-import { createAgentCoreMemoryStores } from 'bedrock-agentcore/experimental/memory/strands'
+import { createAgentCoreMemoryStores } from 'bedrock-agentcore/memory/strands'
 
 const stores = createAgentCoreMemoryStores({
   memoryId: process.env.MEMORY_MYMEMORY_ID!, // injected by the deploy (see below)
@@ -63,7 +62,7 @@ const agent = new Agent({ model, memoryManager: new MemoryManager({ stores }) })
 For a single namespace, construct the store directly (no factory needed):
 
 ```typescript
-import { AgentCoreMemoryStore } from 'bedrock-agentcore/experimental/memory/strands'
+import { AgentCoreMemoryStore } from 'bedrock-agentcore/memory/strands'
 
 const store = new AgentCoreMemoryStore({
   memoryId: process.env.MEMORY_MYMEMORY_ID!,
@@ -216,9 +215,8 @@ See the deploy example for the full per-session-reuse + flush pattern.
 
 ## Release status
 
-This module is **experimental**. It consumes the Strands memory `MemoryManager` / `MemoryStore` /
-extraction surface directly from `@strands-agents/sdk` (>= 1.5.0). That surface is still evolving
-upstream, so the integration should not yet be relied on for GA workloads.
+This module is **generally available**. It consumes the Strands memory `MemoryManager` /
+`MemoryStore` / extraction surface directly from `@strands-agents/sdk` (>= 1.5.0).
 
 **SDK requirements:**
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "import": "./dist/src/tools/code-interpreter/integrations/strands/index.js",
       "types": "./dist/src/tools/code-interpreter/integrations/strands/index.d.ts"
     },
-    "./experimental/memory/strands": {
+    "./memory/strands": {
       "import": "./dist/src/memory/integrations/strands/index.js",
       "types": "./dist/src/memory/integrations/strands/index.d.ts"
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
       "import": "./dist/src/memory/integrations/strands/index.js",
       "types": "./dist/src/memory/integrations/strands/index.d.ts"
     },
+    "./experimental/memory/strands": {
+      "import": "./dist/src/memory/integrations/strands/index.js",
+      "types": "./dist/src/memory/integrations/strands/index.d.ts"
+    },
     "./runtime": {
       "import": "./dist/src/runtime/index.js",
       "types": "./dist/src/runtime/index.d.ts"

--- a/src/memory/integrations/strands/README.md
+++ b/src/memory/integrations/strands/README.md
@@ -1,13 +1,12 @@
-# AgentCore Memory for Strands (`bedrock-agentcore/experimental/memory/strands`)
+# AgentCore Memory for Strands (`bedrock-agentcore/memory/strands`)
 
 `AgentCoreMemoryStore` makes [AgentCore Memory](https://docs.aws.amazon.com/bedrock-agentcore/) a
 first-class [Strands](https://strandsagents.com) `MemoryStore`: the agent recalls long-term memories
 through `search_memory`, and conversation turns are written to AgentCore (role-preserved) for
 server-side extraction into long-term records.
 
-> **Status: experimental.** This integration implements the Strands `MemoryManager` / `MemoryStore`
-> extraction interface, consumed directly from `@strands-agents/sdk` (>= 1.5.0). The surface is still
-> evolving upstream, so treat it as experimental rather than GA.
+This integration implements the Strands `MemoryManager` / `MemoryStore` extraction interface,
+consumed directly from `@strands-agents/sdk` (>= 1.5.0).
 
 ## What it does
 
@@ -26,7 +25,7 @@ server-side extraction into long-term records.
 
 ```typescript
 import { Agent, MemoryManager } from '@strands-agents/sdk'
-import { createAgentCoreMemoryStores } from 'bedrock-agentcore/experimental/memory/strands'
+import { createAgentCoreMemoryStores } from 'bedrock-agentcore/memory/strands'
 
 // One call per (actorId, sessionId). Builds one store per namespace, sharing a client.
 const stores = createAgentCoreMemoryStores({
@@ -52,7 +51,7 @@ const agent = new Agent({
 For a single namespace, the store stands alone — construct it directly:
 
 ```typescript
-import { AgentCoreMemoryStore } from 'bedrock-agentcore/experimental/memory/strands'
+import { AgentCoreMemoryStore } from 'bedrock-agentcore/memory/strands'
 
 const store = new AgentCoreMemoryStore({
   memoryId: 'mem-abc',


### PR DESCRIPTION
## Description

Promotes the AgentCore Memory Strands integration from experimental to GA.

The integration has stabilized against the Strands `MemoryManager` / `MemoryStore` / extraction surface (`@strands-agents/sdk` >= 1.5.0), so it no longer needs the experimental gate. The GA export is `bedrock-agentcore/memory/strands`, matching the flat, un-prefixed path every other GA integration in this package uses (`browser/vercel-ai`, `code-interpreter/vercel-ai`). The old `experimental/memory/strands` subpath is retained as an alias to the same module so existing consumers keep working — this change is non-breaking. Docs now point at the GA path.

The browser and code-interpreter Strands integrations remain experimental and are untouched.

## Public API Changes

New GA import path; the exported API is unchanged, and the old path still resolves.

```typescript
// GA path (use this going forward)
import { createAgentCoreMemoryStores, AgentCoreMemoryStore } from 'bedrock-agentcore/memory/strands'

// Still works (alias, retained for existing consumers)
import { createAgentCoreMemoryStores, AgentCoreMemoryStore } from 'bedrock-agentcore/experimental/memory/strands'
```

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
