### PR TITLE
fix: disambiguate generated integration docs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Test API docs generator
+        run: npm run test:docs
+
       - name: Check for merge conflicts
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "clean": "rm -rf node_modules dist package-lock.json",
     "test": "vitest run --project unit-node",
     "test:all": "vitest run --project unit-node && vitest run --project integ",
+    "test:docs": "node --test scripts/*.test.mjs && python3 -m unittest scripts/test_render_adoc.py",
     "ci": "npm run lint && npm run format:check && npm run type-check:all && npm run build && npm run test:all",
     "test:watch": "vitest --project unit-node",
     "test:coverage": "vitest run --coverage --project unit-node",

--- a/scripts/extract-api-model.mjs
+++ b/scripts/extract-api-model.mjs
@@ -183,7 +183,7 @@ const PARAMETER_DESCRIPTION_OVERRIDES = new Map([
   ['shellId', 'The shell ID.'],
   ['socket', 'The WebSocket connection to use.'],
   ['storeConfig', 'The memory store configuration.'],
-  ['stores', 'The memory stores to validate. At most one store may be writable.'],
+  ['stores', 'The memory stores to validate. At most one store can be writable.'],
   ['template', 'The template to process.'],
   ['url', 'The URL to use.'],
   ['value', 'The value to process.'],
@@ -205,7 +205,7 @@ const CALLABLE_DESCRIPTION_OVERRIDES = new Map([
     'assertWritableTopology',
     {
       summary:
-        'Validates the memory store topology. At most one store may be writable, ' +
+        'Validates the memory store topology. At most one store can be writable, ' +
         'and a writable store must be present when extraction is expected.',
       description: '',
     },
@@ -268,7 +268,7 @@ const CLASS_DESCRIPTION_OVERRIDES = new Map([
       summary: 'Hosts agents on Amazon Bedrock AgentCore runtime.',
       description:
         'Provides health check and invocation endpoints for deploying agent handlers. ' +
-        'Supports JSON and Server-Sent Events (SSE) response modes.',
+        'The server supports JSON and Server-Sent Events (SSE) response modes.',
     },
   ],
   [
@@ -283,6 +283,16 @@ const CLASS_DESCRIPTION_OVERRIDES = new Map([
     {
       summary: 'Generates WebSocket authentication for Amazon Bedrock AgentCore runtime.',
       description: '',
+    },
+  ],
+  [
+    'CodeInterpreter',
+    {
+      summary: 'Provides a client interface for Amazon Bedrock AgentCore Code Interpreter.',
+      description:
+        'Executes Python, JavaScript, and TypeScript code in isolated sandbox environments ' +
+        'with file system access and shell commands. Each instance manages one session, ' +
+        'which starts automatically on first use and can be managed with startSession or stopSession.',
     },
   ],
 ])

--- a/scripts/extract-api-model.mjs
+++ b/scripts/extract-api-model.mjs
@@ -186,6 +186,13 @@ const CALLABLE_DESCRIPTION_OVERRIDES = new Map([
       description: '',
     },
   ],
+  [
+    'runWithContext',
+    {
+      summary: 'Runs a function within a request context scope.',
+      description: 'The context is available through `getContext()` throughout the asynchronous call chain.',
+    },
+  ],
 ]);
 
 // Build a doc-model entry from a callable reflection (method/function).

--- a/scripts/extract-api-model.mjs
+++ b/scripts/extract-api-model.mjs
@@ -18,9 +18,9 @@
 // typescript`. Standalone here for the draft.
 // =============================================================================
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import { argv } from 'node:process';
-import { pathToFileURL } from 'node:url';
+import { readFileSync, writeFileSync } from 'node:fs'
+import { argv } from 'node:process'
+import { pathToFileURL } from 'node:url'
 
 // group id -> title. Decision: include ALL modules.
 // Keyed by the source subpath TypeDoc reports so we can bucket entries.
@@ -30,51 +30,117 @@ const GROUP_MAP = [
   { id: 'identity', title: 'Identity', match: /\/identity\// },
   { id: 'browser-tool', title: 'Browser Tool', match: /\/tools\/browser\// },
   { id: 'code-interpreter', title: 'Code Interpreter', match: /\/tools\/code-interpreter\// },
-];
+]
 
 // TypeDoc ReflectionKind values we care about.
-const KIND = { Class: 128, Method: 2048, Function: 64, Constructor: 512 };
+const KIND = { Class: 128, Method: 2048, Function: 64, Constructor: 512 }
 
 function getArg(flag) {
-  const i = argv.indexOf(flag);
-  return i >= 0 ? argv[i + 1] : undefined;
+  const i = argv.indexOf(flag)
+  return i >= 0 ? argv[i + 1] : undefined
 }
 
 // Flatten TypeDoc comment summary + block tags into plain text.
 function commentText(comment) {
-  if (!comment) return '';
-  return (comment.summary || []).map((p) => p.text || '').join('').trim();
+  if (!comment) return ''
+  return (comment.summary || [])
+    .map((p) => p.text || '')
+    .join('')
+    .trim()
 }
 
 // Split a comment into first-paragraph summary and the remaining description,
 // so the renderer doesn't print the same first paragraph twice.
 function splitSummaryDescription(comment) {
-  const full = commentText(comment);
-  const parts = full.split('\n\n');
-  return { summary: (parts[0] || '').trim(), description: parts.slice(1).join('\n\n').trim() };
+  const full = commentText(comment)
+  const parts = full.split('\n\n')
+  return { summary: (parts[0] || '').trim(), description: parts.slice(1).join('\n\n').trim() }
 }
 
 function blockTag(comment, tag) {
-  if (!comment || !comment.blockTags) return [];
+  if (!comment || !comment.blockTags) return []
   return comment.blockTags
     .filter((t) => t.tag === tag)
-    .map((t) => (t.content || []).map((p) => p.text || '').join('').trim());
+    .map((t) =>
+      (t.content || [])
+        .map((p) => p.text || '')
+        .join('')
+        .trim()
+    )
 }
 
-function typeToString(type) {
-  if (!type) return null;
-  if (type.name) return type.name;
-  if (type.type === 'array' && type.elementType) return `${typeToString(type.elementType)}[]`;
-  if (type.type === 'union' && type.types) return type.types.map(typeToString).join(' | ');
-  return type.type || null;
+function typeParameterList(typeParameters) {
+  if (!typeParameters || typeParameters.length === 0) return ''
+  const rendered = typeParameters.map((parameter) => {
+    const constraint = parameter.type ? ` extends ${typeToString(parameter.type)}` : ''
+    const defaultType = parameter.default ? ` = ${typeToString(parameter.default)}` : ''
+    return `${parameter.name}${constraint}${defaultType}`
+  })
+  return `<${rendered.join(', ')}>`
+}
+
+function callableType(signature) {
+  const params = (signature.parameters || []).map((parameter) => {
+    const rest = parameter.flags?.isRest ? '...' : ''
+    const optional = parameter.flags?.isOptional ? '?' : ''
+    const renderedType = typeToString(parameter.type) || 'unknown'
+    return `${rest}${parameter.name}${optional}: ${renderedType}`
+  })
+  const result = typeToString(signature.type) || 'void'
+  return `${typeParameterList(signature.typeParameters)}(${params.join(', ')}) => ${result}`
+}
+
+function reflectionType(declaration) {
+  if (!declaration) return 'object'
+  if (declaration.signatures?.length) {
+    return declaration.signatures.map(callableType).join(' & ')
+  }
+  if (declaration.children?.length) {
+    const properties = declaration.children.map((property) => {
+      const optional = property.flags?.isOptional ? '?' : ''
+      return `${property.name}${optional}: ${typeToString(property.type) || 'unknown'}`
+    })
+    return `{ ${properties.join('; ')} }`
+  }
+  return 'object'
+}
+
+export function typeToString(type) {
+  if (!type) return null
+  switch (type.type) {
+    case 'array':
+      return `${typeToString(type.elementType) || 'unknown'}[]`
+    case 'intersection':
+      return (type.types || []).map(typeToString).join(' & ')
+    case 'intrinsic':
+      return type.name
+    case 'literal':
+      return type.value === null ? 'null' : JSON.stringify(type.value)
+    case 'reference': {
+      const name =
+        type.qualifiedName && !type.qualifiedName.startsWith('__global.') ? type.qualifiedName : type.name || 'unknown'
+      const args = type.typeArguments?.length ? `<${type.typeArguments.map(typeToString).join(', ')}>` : ''
+      return `${name}${args}`
+    }
+    case 'reflection':
+      return reflectionType(type.declaration)
+    case 'rest':
+      return `...${typeToString(type.elementType) || 'unknown'}`
+    case 'tuple':
+      return `[${(type.elements || []).map(typeToString).join(', ')}]`
+    case 'typeOperator':
+      return `${type.operator} ${typeToString(type.target) || 'unknown'}`
+    case 'union':
+      return (type.types || []).map(typeToString).join(' | ')
+    default:
+      return type.name || type.type || null
+  }
 }
 
 function signatureText(name, sig) {
-  const params = (sig.parameters || [])
-    .map((p) => `${p.name}: ${typeToString(p.type) || 'unknown'}`)
-    .join(', ');
-  const ret = typeToString(sig.type) || 'void';
-  return `${name}(${params}): ${ret}`;
+  const params = (sig.parameters || []).map((p) => `${p.name}: ${typeToString(p.type) || 'unknown'}`).join(', ')
+  const ret = typeToString(sig.type) || 'void'
+  return `${name}(${params}): ${ret}`
 }
 
 const PARAMETER_DESCRIPTION_OVERRIDES = new Map([
@@ -122,16 +188,16 @@ const PARAMETER_DESCRIPTION_OVERRIDES = new Map([
   ['url', 'The URL to use.'],
   ['value', 'The value to process.'],
   ['width', 'The width in pixels.'],
-]);
+])
 
 function parameterDescription(parameter) {
-  const documented = commentText(parameter.comment);
-  if (documented) return documented;
+  const documented = commentText(parameter.comment)
+  if (documented) return documented
   if (parameter.name === 'client' && typeToString(parameter.type) === 'PlaywrightBrowser') {
-    return 'The PlaywrightBrowser instance to use for browser automation.';
+    return 'The PlaywrightBrowser instance to use for browser automation.'
   }
-  if (parameter.name === 'client') return 'The client instance to use.';
-  return PARAMETER_DESCRIPTION_OVERRIDES.get(parameter.name) || 'The parameter value.';
+  if (parameter.name === 'client') return 'The client instance to use.'
+  return PARAMETER_DESCRIPTION_OVERRIDES.get(parameter.name) || 'The parameter value.'
 }
 
 const CALLABLE_DESCRIPTION_OVERRIDES = new Map([
@@ -139,8 +205,8 @@ const CALLABLE_DESCRIPTION_OVERRIDES = new Map([
     'assertWritableTopology',
     {
       summary:
-        'Validates that at most one store is configured as writable. ' +
-        'Throws if two writable stores are provided, or if extraction is expected but no writable store is present.',
+        'Validates the memory store topology. At most one store may be writable, ' +
+        'and a writable store must be present when extraction is expected.',
       description: '',
     },
   ],
@@ -190,32 +256,58 @@ const CALLABLE_DESCRIPTION_OVERRIDES = new Map([
     'runWithContext',
     {
       summary: 'Runs a function within a request context scope.',
-      description: 'The context is available through `getContext()` throughout the asynchronous call chain.',
+      description: '',
     },
   ],
-]);
+])
+
+const CLASS_DESCRIPTION_OVERRIDES = new Map([
+  [
+    'BedrockAgentCoreApp',
+    {
+      summary: 'Hosts agents on Amazon Bedrock AgentCore runtime.',
+      description:
+        'Provides health check and invocation endpoints for deploying agent handlers. ' +
+        'Supports JSON and Server-Sent Events (SSE) response modes.',
+    },
+  ],
+  [
+    'AgentCoreRuntimeClient',
+    {
+      summary: 'Generates WebSocket authentication for Amazon Bedrock AgentCore runtime.',
+      description: '',
+    },
+  ],
+  [
+    'RuntimeClient',
+    {
+      summary: 'Generates WebSocket authentication for Amazon Bedrock AgentCore runtime.',
+      description: '',
+    },
+  ],
+])
 
 // Build a doc-model entry from a callable reflection (method/function).
 function entryFromCallable(refl) {
-  const sig = (refl.signatures && refl.signatures[0]) || {};
-  const comment = sig.comment || refl.comment;
+  const sig = (refl.signatures && refl.signatures[0]) || {}
+  const comment = sig.comment || refl.comment
   const params = (sig.parameters || []).map((p) => ({
     name: p.name,
     type: typeToString(p.type),
     required: !(p.flags && p.flags.isOptional),
     description: parameterDescription(p),
-  }));
-  const returnsDesc = blockTag(comment, '@returns')[0] || '';
+  }))
+  const returnsDesc = blockTag(comment, '@returns')[0] || ''
   const examples = blockTag(comment, '@example').map((code) => ({
     lang: 'typescript',
     // strip ```typescript fences TSDoc authors often include
     code: code.replace(/^```\w*\n?|\n?```$/g, '').trim(),
-  }));
-  const sd = splitSummaryDescription(comment);
-  const override = CALLABLE_DESCRIPTION_OVERRIDES.get(refl.name);
+  }))
+  const sd = splitSummaryDescription(comment)
+  const override = CALLABLE_DESCRIPTION_OVERRIDES.get(refl.name)
   if (override) {
-    sd.summary = override.summary;
-    sd.description = override.description;
+    sd.summary = override.summary
+    sd.description = override.description
   }
   return {
     kind: 'function',
@@ -228,36 +320,39 @@ function entryFromCallable(refl) {
     raises: blockTag(comment, '@throws').map((d) => ({ type: 'Error', description: d })),
     examples,
     members: [],
-  };
+  }
 }
 
 function entryFromClass(refl) {
-  const comment = refl.comment;
+  const comment = refl.comment
   const examples = blockTag(comment, '@example').map((code) => ({
     lang: 'typescript',
     code: code.replace(/^```\w*\n?|\n?```$/g, '').trim(),
-  }));
+  }))
   const members = (refl.children || [])
     .filter((c) => (c.kind === KIND.Method || c.kind === KIND.Constructor) && !(c.flags && c.flags.isPrivate))
-    .map(entryFromCallable);
-  const sd = splitSummaryDescription(comment);
+    .map(entryFromCallable)
+  const sd = splitSummaryDescription(comment)
+  const override = CLASS_DESCRIPTION_OVERRIDES.get(refl.name)
+  if (override) {
+    sd.summary = override.summary
+    sd.description = override.description
+  }
   if (refl.name === 'AgentCoreEventSender') {
-    sd.summary = 'Sends batches of conversation messages to AgentCore.';
-    sd.description =
-      'Packs turns into the minimum number of `createEvent` calls. ' +
-      'If `createEvent` fails, the batch is not committed and the caller can retry.';
-    const sendBatch = members.find((member) => member.name === 'sendBatch');
+    sd.summary = 'Sends batches of conversation messages to Amazon Bedrock AgentCore.'
+    sd.description = 'If a batch send fails, the operation throws so the caller can retry safely.'
+    const sendBatch = members.find((member) => member.name === 'sendBatch')
     if (sendBatch) {
-      sendBatch.summary = 'Sends a batch of messages to AgentCore.';
-      sendBatch.description = 'If `createEvent` fails, the batch is not committed and the caller can retry.';
+      sendBatch.summary = 'Sends a batch of messages to Amazon Bedrock AgentCore.'
+      sendBatch.description = 'If the batch send fails, the operation throws so the caller can retry safely.'
     }
   } else if (refl.name === 'AgentCoreMemoryStore') {
-    sd.summary = 'Provides AgentCore memory through the Strands MemoryStore interface.';
-    sd.description = 'Supports searching and, when configured as writable, adding conversation messages.';
-    const addMessages = members.find((member) => member.name === 'addMessages');
+    sd.summary = 'Provides AgentCore memory through the Strands MemoryStore interface.'
+    sd.description = 'Supports searching and, when configured as writable, adding conversation messages.'
+    const addMessages = members.find((member) => member.name === 'addMessages')
     if (addMessages) {
-      addMessages.summary = 'Adds a batch of conversation messages while preserving their roles.';
-      addMessages.description = '';
+      addMessages.summary = 'Adds a batch of conversation messages while preserving their roles.'
+      addMessages.description = ''
     }
   }
   return {
@@ -271,23 +366,23 @@ function entryFromClass(refl) {
     raises: [],
     examples,
     members,
-  };
+  }
 }
 
 function sourcePath(refl) {
-  return refl.sources && refl.sources[0] ? refl.sources[0].fileName : '';
+  return refl.sources && refl.sources[0] ? refl.sources[0].fileName : ''
 }
 
 function groupFor(refl) {
-  const path = sourcePath(refl);
-  const g = GROUP_MAP.find((gm) => gm.match.test(path));
-  return g ? g.id : null;
+  const path = sourcePath(refl)
+  const g = GROUP_MAP.find((gm) => gm.match.test(path))
+  return g ? g.id : null
 }
 
 function integrationLabel(refl) {
-  const match = sourcePath(refl).match(/\/integrations\/(strands|vercel-ai)\//);
-  if (!match) return '';
-  return match[1] === 'strands' ? 'Strands SDK' : 'Vercel AI SDK';
+  const match = sourcePath(refl).match(/\/integrations\/(strands|vercel-ai)\//)
+  if (!match) return ''
+  return match[1] === 'strands' ? 'Strands SDK' : 'Vercel AI SDK'
 }
 
 function slug(value) {
@@ -295,47 +390,47 @@ function slug(value) {
     .toLowerCase()
     .replace(/\.[^.]+$/, '')
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
+    .replace(/^-|-$/g, '')
 }
 
 export function buildModel(doc, version = 'unknown') {
   // Collect all classes + top-level functions across the project tree.
-  const buckets = new Map(GROUP_MAP.map((g) => [g.id, []]));
+  const buckets = new Map(GROUP_MAP.map((g) => [g.id, []]))
   const walk = (node) => {
-    if (!node) return;
+    if (!node) return
     if (node.kind === KIND.Class) {
-      const gid = groupFor(node);
+      const gid = groupFor(node)
       if (gid) {
-        const label = integrationLabel(node);
-        const entry = entryFromClass(node);
+        const label = integrationLabel(node)
+        const entry = entryFromClass(node)
         if (label) {
-          entry.name = `${entry.name} (${label})`;
-          entry.anchor = `${gid}-${slug(sourcePath(node))}-${slug(node.name)}`;
+          entry.name = `${entry.name} (${label})`
+          entry.anchor = `${gid}-${slug(sourcePath(node))}-${slug(node.name)}`
         }
-        buckets.get(gid).push(entry);
+        buckets.get(gid).push(entry)
       }
     } else if (node.kind === KIND.Function) {
-      const gid = groupFor(node);
+      const gid = groupFor(node)
       if (gid) {
-        const label = integrationLabel(node);
-        const entry = entryFromCallable(node);
+        const label = integrationLabel(node)
+        const entry = entryFromCallable(node)
         if (label) {
-          entry.name = `${entry.name} (${label})`;
-          entry.anchor = `${gid}-${slug(sourcePath(node))}-${slug(node.name)}`;
+          entry.name = `${entry.name} (${label})`
+          entry.anchor = `${gid}-${slug(sourcePath(node))}-${slug(node.name)}`
         }
-        buckets.get(gid).push(entry);
+        buckets.get(gid).push(entry)
       }
     }
-    (node.children || []).forEach(walk);
-  };
-  walk(doc);
+    ;(node.children || []).forEach(walk)
+  }
+  walk(doc)
 
   const groups = GROUP_MAP.map((g) => ({
     id: g.id,
     title: g.title,
     summary: '',
     entries: buckets.get(g.id),
-  })).filter((g) => g.entries.length > 0);
+  })).filter((g) => g.entries.length > 0)
 
   return {
     source: 'ts-sdk',
@@ -343,20 +438,20 @@ export function buildModel(doc, version = 'unknown') {
     version,
     language: 'typescript',
     groups,
-  };
+  }
 }
 
 function main() {
-  const typedocPath = getArg('--typedoc');
-  const outPath = getArg('--out');
-  const version = getArg('--version') || 'unknown';
+  const typedocPath = getArg('--typedoc')
+  const outPath = getArg('--out')
+  const version = getArg('--version') || 'unknown'
 
-  const doc = JSON.parse(readFileSync(typedocPath, 'utf8'));
-  const model = buildModel(doc, version);
-  writeFileSync(outPath, JSON.stringify(model, null, 2));
-  process.stderr.write(`Wrote doc-model: ${model.groups.length} groups, version ${version}\n`);
+  const doc = JSON.parse(readFileSync(typedocPath, 'utf8'))
+  const model = buildModel(doc, version)
+  writeFileSync(outPath, JSON.stringify(model, null, 2))
+  process.stderr.write(`Wrote doc-model: ${model.groups.length} groups, version ${version}\n`)
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main();
+  main()
 }

--- a/scripts/extract-api-model.mjs
+++ b/scripts/extract-api-model.mjs
@@ -134,6 +134,60 @@ function parameterDescription(parameter) {
   return PARAMETER_DESCRIPTION_OVERRIDES.get(parameter.name) || 'The parameter value.';
 }
 
+const CALLABLE_DESCRIPTION_OVERRIDES = new Map([
+  [
+    'assertWritableTopology',
+    {
+      summary:
+        'Validates that at most one store is configured as writable. ' +
+        'Throws if two writable stores are provided, or if extraction is expected but no writable store is present.',
+      description: '',
+    },
+  ],
+  [
+    'createAgentCoreMemoryStores',
+    {
+      summary: 'Creates AgentCore memory stores for an actor and session.',
+      description: '',
+    },
+  ],
+  [
+    'isUserOrAssistantWithText',
+    {
+      summary: 'Checks whether a message contains extractable user or assistant text.',
+      description: '',
+    },
+  ],
+  [
+    'mapRole',
+    {
+      summary: 'Maps a Strands message role to an AgentCore conversational role.',
+      description: '',
+    },
+  ],
+  [
+    'assertResolvedNamespace',
+    {
+      summary: 'Validates that a resolved namespace contains no unresolved placeholders or braces.',
+      description: '',
+    },
+  ],
+  [
+    'resolveNamespace',
+    {
+      summary: 'Resolves actor and session placeholders in a namespace template.',
+      description: '',
+    },
+  ],
+  [
+    'slugifyNamespace',
+    {
+      summary: 'Creates a store name from a namespace template.',
+      description: '',
+    },
+  ],
+]);
+
 // Build a doc-model entry from a callable reflection (method/function).
 function entryFromCallable(refl) {
   const sig = (refl.signatures && refl.signatures[0]) || {};
@@ -151,6 +205,11 @@ function entryFromCallable(refl) {
     code: code.replace(/^```\w*\n?|\n?```$/g, '').trim(),
   }));
   const sd = splitSummaryDescription(comment);
+  const override = CALLABLE_DESCRIPTION_OVERRIDES.get(refl.name);
+  if (override) {
+    sd.summary = override.summary;
+    sd.description = override.description;
+  }
   return {
     kind: 'function',
     name: refl.name,
@@ -179,11 +238,19 @@ function entryFromClass(refl) {
     sd.summary = 'Sends batches of conversation messages to AgentCore.';
     sd.description =
       'Packs turns into the minimum number of `createEvent` calls. ' +
-      'Throws an error if an event fails so the caller can retry.';
+      'If `createEvent` fails, the batch is not committed and the caller can retry.';
     const sendBatch = members.find((member) => member.name === 'sendBatch');
     if (sendBatch) {
       sendBatch.summary = 'Sends a batch of messages to AgentCore.';
-      sendBatch.description = 'Throws an error if an event fails so the caller can retry.';
+      sendBatch.description = 'If `createEvent` fails, the batch is not committed and the caller can retry.';
+    }
+  } else if (refl.name === 'AgentCoreMemoryStore') {
+    sd.summary = 'Provides AgentCore memory through the Strands MemoryStore interface.';
+    sd.description = 'Supports searching and, when configured as writable, adding conversation messages.';
+    const addMessages = members.find((member) => member.name === 'addMessages');
+    if (addMessages) {
+      addMessages.summary = 'Adds a batch of conversation messages while preserving their roles.';
+      addMessages.description = '';
     }
   }
   return {

--- a/scripts/extract-api-model.mjs
+++ b/scripts/extract-api-model.mjs
@@ -77,6 +77,63 @@ function signatureText(name, sig) {
   return `${name}(${params}): ${ret}`;
 }
 
+const PARAMETER_DESCRIPTION_OVERRIDES = new Map([
+  ['__namedParameters', 'The named browser live view properties.'],
+  ['actorId', 'The actor ID.'],
+  ['args', 'The arguments to pass.'],
+  ['authObj', 'The authentication object to use.'],
+  ['config', 'The configuration to use.'],
+  ['conn', 'The connection to use.'],
+  ['containerHeight', 'The container height in pixels.'],
+  ['containerWidth', 'The container width in pixels.'],
+  ['customLogger', 'The custom logger to use.'],
+  ['data', 'The data to process.'],
+  ['displays', 'The displays to use.'],
+  ['error', 'The error to process.'],
+  ['expectExtraction', 'Specifies whether extraction is expected.'],
+  ['field', 'The field to process.'],
+  ['fn', 'The function to invoke.'],
+  ['frame', 'The frame data to process.'],
+  ['height', 'The height in pixels.'],
+  ['input', 'The input parameters.'],
+  ['message', 'The message to process.'],
+  ['messages', 'The messages to send.'],
+  ['ns', 'The namespace to use.'],
+  ['options', 'The options to use.'],
+  ['opts', 'The options to use.'],
+  ['params', 'The connection parameters.'],
+  ['props', 'The viewer properties.'],
+  ['protocols', 'The WebSocket protocols to use.'],
+  ['query', 'The search query.'],
+  ['reason', 'The reason for the operation.'],
+  ['reconnected', 'Specifies whether the connection was reestablished.'],
+  ['remoteHeight', 'The remote display height in pixels.'],
+  ['remoteWidth', 'The remote display width in pixels.'],
+  ['request', 'The incoming request.'],
+  ['resolved', 'The resolved value.'],
+  ['result', 'The result to process.'],
+  ['sequenceNumbers', 'The optional sequence numbers for the messages.'],
+  ['sessionId', 'The session ID.'],
+  ['shellId', 'The shell ID.'],
+  ['socket', 'The WebSocket connection to use.'],
+  ['storeConfig', 'The memory store configuration.'],
+  ['stores', 'The memory stores to validate. At most one store may be writable.'],
+  ['template', 'The template to process.'],
+  ['url', 'The URL to use.'],
+  ['value', 'The value to process.'],
+  ['width', 'The width in pixels.'],
+]);
+
+function parameterDescription(parameter) {
+  const documented = commentText(parameter.comment);
+  if (documented) return documented;
+  if (parameter.name === 'client' && typeToString(parameter.type) === 'PlaywrightBrowser') {
+    return 'The PlaywrightBrowser instance to use for browser automation.';
+  }
+  if (parameter.name === 'client') return 'The client instance to use.';
+  return PARAMETER_DESCRIPTION_OVERRIDES.get(parameter.name) || 'The parameter value.';
+}
+
 // Build a doc-model entry from a callable reflection (method/function).
 function entryFromCallable(refl) {
   const sig = (refl.signatures && refl.signatures[0]) || {};
@@ -85,7 +142,7 @@ function entryFromCallable(refl) {
     name: p.name,
     type: typeToString(p.type),
     required: !(p.flags && p.flags.isOptional),
-    description: commentText(p.comment),
+    description: parameterDescription(p),
   }));
   const returnsDesc = blockTag(comment, '@returns')[0] || '';
   const examples = blockTag(comment, '@example').map((code) => ({
@@ -118,6 +175,17 @@ function entryFromClass(refl) {
     .filter((c) => (c.kind === KIND.Method || c.kind === KIND.Constructor) && !(c.flags && c.flags.isPrivate))
     .map(entryFromCallable);
   const sd = splitSummaryDescription(comment);
+  if (refl.name === 'AgentCoreEventSender') {
+    sd.summary = 'Sends batches of conversation messages to AgentCore.';
+    sd.description =
+      'Packs turns into the minimum number of `createEvent` calls. ' +
+      'Throws an error if an event fails so the caller can retry.';
+    const sendBatch = members.find((member) => member.name === 'sendBatch');
+    if (sendBatch) {
+      sendBatch.summary = 'Sends a batch of messages to AgentCore.';
+      sendBatch.description = 'Throws an error if an event fails so the caller can retry.';
+    }
+  }
   return {
     kind: 'class',
     name: refl.name,

--- a/scripts/extract-api-model.mjs
+++ b/scripts/extract-api-model.mjs
@@ -20,6 +20,7 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { argv } from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 // group id -> title. Decision: include ALL modules.
 // Keyed by the source subpath TypeDoc reports so we can bucket entries.
@@ -141,23 +142,47 @@ function groupFor(refl) {
   return g ? g.id : null;
 }
 
-function main() {
-  const typedocPath = getArg('--typedoc');
-  const outPath = getArg('--out');
-  const version = getArg('--version') || 'unknown';
+function integrationLabel(refl) {
+  const match = sourcePath(refl).match(/\/integrations\/(strands|vercel-ai)\//);
+  if (!match) return '';
+  return match[1] === 'strands' ? 'Strands SDK' : 'Vercel AI SDK';
+}
 
-  const doc = JSON.parse(readFileSync(typedocPath, 'utf8'));
+function slug(value) {
+  return value
+    .toLowerCase()
+    .replace(/\.[^.]+$/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
 
+export function buildModel(doc, version = 'unknown') {
   // Collect all classes + top-level functions across the project tree.
   const buckets = new Map(GROUP_MAP.map((g) => [g.id, []]));
   const walk = (node) => {
     if (!node) return;
     if (node.kind === KIND.Class) {
       const gid = groupFor(node);
-      if (gid) buckets.get(gid).push(entryFromClass(node));
+      if (gid) {
+        const label = integrationLabel(node);
+        const entry = entryFromClass(node);
+        if (label) {
+          entry.name = `${entry.name} (${label})`;
+          entry.anchor = `${gid}-${slug(sourcePath(node))}-${slug(node.name)}`;
+        }
+        buckets.get(gid).push(entry);
+      }
     } else if (node.kind === KIND.Function) {
       const gid = groupFor(node);
-      if (gid) buckets.get(gid).push(entryFromCallable(node));
+      if (gid) {
+        const label = integrationLabel(node);
+        const entry = entryFromCallable(node);
+        if (label) {
+          entry.name = `${entry.name} (${label})`;
+          entry.anchor = `${gid}-${slug(sourcePath(node))}-${slug(node.name)}`;
+        }
+        buckets.get(gid).push(entry);
+      }
     }
     (node.children || []).forEach(walk);
   };
@@ -170,15 +195,26 @@ function main() {
     entries: buckets.get(g.id),
   })).filter((g) => g.entries.length > 0);
 
-  const model = {
+  return {
     source: 'ts-sdk',
     package: 'bedrock-agentcore',
     version,
     language: 'typescript',
     groups,
   };
-  writeFileSync(outPath, JSON.stringify(model, null, 2));
-  process.stderr.write(`Wrote doc-model: ${groups.length} groups, version ${version}\n`);
 }
 
-main();
+function main() {
+  const typedocPath = getArg('--typedoc');
+  const outPath = getArg('--out');
+  const version = getArg('--version') || 'unknown';
+
+  const doc = JSON.parse(readFileSync(typedocPath, 'utf8'));
+  const model = buildModel(doc, version);
+  writeFileSync(outPath, JSON.stringify(model, null, 2));
+  process.stderr.write(`Wrote doc-model: ${model.groups.length} groups, version ${version}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/extract-api-model.test.mjs
+++ b/scripts/extract-api-model.test.mjs
@@ -85,3 +85,17 @@ test('assertWritableTopology omits internal stream details', () => {
   assert.doesNotMatch(entry.summary, /stream|deduplication/)
   assert.equal(entry.description, '')
 })
+
+test('runWithContext exposes only its observable contract', () => {
+  const callable = reflection(1, 64, 'runWithContext', 'src/runtime/context.ts')
+  callable.signatures[0].comment = {
+    summary: [{ text: 'This function is internal and should not be used directly.' }],
+  }
+  const doc = { children: [callable] }
+
+  const entry = buildModel(doc, '1.0.0').groups[0].entries[0]
+
+  assert.equal(entry.summary, 'Runs a function within a request context scope.')
+  assert.match(entry.description, /available through `getContext\(\)`/)
+  assert.doesNotMatch(entry.description, /internal|customers/)
+})

--- a/scripts/extract-api-model.test.mjs
+++ b/scripts/extract-api-model.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildModel } from './extract-api-model.mjs'
+
+function reflection(id, kind, name, fileName) {
+  return {
+    id,
+    kind,
+    name,
+    sources: [{ fileName }],
+    signatures: kind === 64 ? [{ parameters: [], type: { name: 'void' } }] : undefined,
+    children: [],
+  }
+}
+
+test('integration entries have distinct labels and anchors', () => {
+  const doc = {
+    children: [
+      reflection(1, 64, 'createClickTool', 'src/tools/browser/integrations/strands/click-tool.ts'),
+      reflection(2, 64, 'createClickTool', 'src/tools/browser/integrations/vercel-ai/click-tool.ts'),
+    ],
+  }
+
+  const entries = buildModel(doc, '1.0.0').groups[0].entries
+  assert.deepEqual(
+    entries.map((entry) => entry.name),
+    ['createClickTool (Strands SDK)', 'createClickTool (Vercel AI SDK)']
+  )
+  assert.equal(new Set(entries.map((entry) => entry.anchor)).size, 2)
+})

--- a/scripts/extract-api-model.test.mjs
+++ b/scripts/extract-api-model.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { buildModel } from './extract-api-model.mjs'
+import { buildModel, typeToString } from './extract-api-model.mjs'
 
 function reflection(id, kind, name, fileName) {
   return {
@@ -61,19 +61,15 @@ test('AgentCoreEventSender omits internal implementation details', () => {
 
   const entry = buildModel(doc, '1.0.0').groups[0].entries[0]
 
-  assert.equal(entry.summary, 'Sends batches of conversation messages to AgentCore.')
-  assert.match(entry.description, /minimum number of `createEvent` calls/)
+  assert.equal(entry.summary, 'Sends batches of conversation messages to Amazon Bedrock AgentCore.')
+  assert.match(entry.description, /operation throws/)
+  assert.doesNotMatch(entry.description, /createEvent|committed/)
   assert.doesNotMatch(entry.description, /coordinator|token derivation/)
-  assert.equal(entry.members[0].summary, 'Sends a batch of messages to AgentCore.')
+  assert.equal(entry.members[0].summary, 'Sends a batch of messages to Amazon Bedrock AgentCore.')
 })
 
 test('assertWritableTopology omits internal stream details', () => {
-  const callable = reflection(
-    1,
-    64,
-    'assertWritableTopology',
-    'src/memory/integrations/strands/factory.ts'
-  )
+  const callable = reflection(1, 64, 'assertWritableTopology', 'src/memory/integrations/strands/factory.ts')
   callable.signatures[0].comment = {
     summary: [{ text: 'Internal stream and deduplication details.' }],
   }
@@ -81,8 +77,8 @@ test('assertWritableTopology omits internal stream details', () => {
 
   const entry = buildModel(doc, '1.0.0').groups[0].entries[0]
 
-  assert.match(entry.summary, /Validates that at most one store/)
-  assert.doesNotMatch(entry.summary, /stream|deduplication/)
+  assert.match(entry.summary, /Validates the memory store topology/)
+  assert.doesNotMatch(entry.summary, /throws|stream|deduplication/)
   assert.equal(entry.description, '')
 })
 
@@ -96,6 +92,87 @@ test('runWithContext exposes only its observable contract', () => {
   const entry = buildModel(doc, '1.0.0').groups[0].entries[0]
 
   assert.equal(entry.summary, 'Runs a function within a request context scope.')
-  assert.match(entry.description, /available through `getContext\(\)`/)
+  assert.equal(entry.description, '')
   assert.doesNotMatch(entry.description, /internal|customers/)
+})
+
+test('TypeDoc types render as concrete TypeScript syntax', () => {
+  assert.equal(
+    typeToString({
+      type: 'typeOperator',
+      operator: 'readonly',
+      target: {
+        type: 'array',
+        elementType: { type: 'reference', name: 'AgentCoreMemoryStore' },
+      },
+    }),
+    'readonly AgentCoreMemoryStore[]'
+  )
+
+  assert.equal(
+    typeToString({
+      type: 'reflection',
+      declaration: {
+        children: [
+          {
+            name: 'host',
+            flags: { isOptional: true },
+            type: { type: 'intrinsic', name: 'string' },
+          },
+          {
+            name: 'port',
+            flags: { isOptional: true },
+            type: { type: 'intrinsic', name: 'number' },
+          },
+        ],
+      },
+    }),
+    '{ host?: string; port?: number }'
+  )
+
+  assert.equal(
+    typeToString({
+      type: 'reflection',
+      declaration: {
+        signatures: [
+          {
+            parameters: [
+              {
+                name: 'args',
+                flags: { isRest: true },
+                type: { type: 'reference', name: 'TParams' },
+              },
+            ],
+            type: {
+              type: 'reference',
+              name: 'Promise',
+              typeArguments: [{ type: 'reference', name: 'TReturn' }],
+            },
+          },
+        ],
+      },
+    }),
+    '(...args: TParams) => Promise<TReturn>'
+  )
+
+  assert.equal(
+    typeToString({
+      type: 'union',
+      types: [
+        { type: 'literal', value: null },
+        { type: 'reference', name: 'Element', qualifiedName: 'JSX.Element' },
+      ],
+    }),
+    'null | JSX.Element'
+  )
+
+  assert.equal(
+    typeToString({
+      type: 'reference',
+      name: 'Buffer',
+      qualifiedName: '__global.Buffer',
+      typeArguments: [{ type: 'reference', name: 'ArrayBufferLike' }],
+    }),
+    'Buffer<ArrayBufferLike>'
+  )
 })

--- a/scripts/extract-api-model.test.mjs
+++ b/scripts/extract-api-model.test.mjs
@@ -78,7 +78,8 @@ test('assertWritableTopology omits internal stream details', () => {
   const entry = buildModel(doc, '1.0.0').groups[0].entries[0]
 
   assert.match(entry.summary, /Validates the memory store topology/)
-  assert.doesNotMatch(entry.summary, /throws|stream|deduplication/)
+  assert.match(entry.summary, /store can be writable/)
+  assert.doesNotMatch(entry.summary, /may|throws|stream|deduplication/)
   assert.equal(entry.description, '')
 })
 

--- a/scripts/extract-api-model.test.mjs
+++ b/scripts/extract-api-model.test.mjs
@@ -66,3 +66,22 @@ test('AgentCoreEventSender omits internal implementation details', () => {
   assert.doesNotMatch(entry.description, /coordinator|token derivation/)
   assert.equal(entry.members[0].summary, 'Sends a batch of messages to AgentCore.')
 })
+
+test('assertWritableTopology omits internal stream details', () => {
+  const callable = reflection(
+    1,
+    64,
+    'assertWritableTopology',
+    'src/memory/integrations/strands/factory.ts'
+  )
+  callable.signatures[0].comment = {
+    summary: [{ text: 'Internal stream and deduplication details.' }],
+  }
+  const doc = { children: [callable] }
+
+  const entry = buildModel(doc, '1.0.0').groups[0].entries[0]
+
+  assert.match(entry.summary, /Validates that at most one store/)
+  assert.doesNotMatch(entry.summary, /stream|deduplication/)
+  assert.equal(entry.description, '')
+})

--- a/scripts/extract-api-model.test.mjs
+++ b/scripts/extract-api-model.test.mjs
@@ -29,3 +29,40 @@ test('integration entries have distinct labels and anchors', () => {
   )
   assert.equal(new Set(entries.map((entry) => entry.anchor)).size, 2)
 })
+
+test('undocumented parameters receive meaningful fallback descriptions', () => {
+  const callable = reflection(1, 64, 'createTool', 'src/tools/browser/create-tool.ts')
+  callable.signatures[0].parameters = [
+    { name: 'client', type: { name: 'PlaywrightBrowser' }, flags: {} },
+    { name: 'expectExtraction', type: { name: 'boolean' }, flags: {} },
+  ]
+  const doc = { children: [callable] }
+
+  const params = buildModel(doc, '1.0.0').groups[0].entries[0].params
+
+  assert.deepEqual(
+    params.map((param) => param.description),
+    ['The PlaywrightBrowser instance to use for browser automation.', 'Specifies whether extraction is expected.']
+  )
+})
+
+test('AgentCoreEventSender omits internal implementation details', () => {
+  const sender = reflection(1, 128, 'AgentCoreEventSender', 'src/memory/integrations/strands/sender.ts')
+  sender.comment = { summary: [{ text: 'Internal coordinator and token derivation details.' }] }
+  sender.children = [
+    {
+      id: 2,
+      kind: 2048,
+      name: 'sendBatch',
+      signatures: [{ parameters: [], type: { name: 'Promise' } }],
+    },
+  ]
+  const doc = { children: [sender] }
+
+  const entry = buildModel(doc, '1.0.0').groups[0].entries[0]
+
+  assert.equal(entry.summary, 'Sends batches of conversation messages to AgentCore.')
+  assert.match(entry.description, /minimum number of `createEvent` calls/)
+  assert.doesNotMatch(entry.description, /coordinator|token derivation/)
+  assert.equal(entry.members[0].summary, 'Sends a batch of messages to AgentCore.')
+})

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -55,15 +55,44 @@ import textwrap
 SCHEMA_VERSION = 1
 
 
+def normalize_style(text):
+    """Apply style-safe substitutions to generated prose."""
+    if not text:
+        return ""
+    text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
+    text = text.replace(
+        "This feature is in preview and may change in future releases.",
+        "This feature is in preview and might change in future releases.",
+    )
+    return re.sub(r"\bAWS\b", "{aws}", text)
+
+
+def normalize_param_description(text):
+    """Normalize recurring parameter-description style issues."""
+    text = normalize_style(text).strip()
+    substitutions = (
+        (r"^Optional\b", "An optional"),
+        (r"^(?:\{aws\}|AWS)\s+region\b", "The {aws} Region"),
+        (r"^id of\b", "The ID of"),
+        (r"^Behaviour\b", "The behavior"),
+        (r"^Behavior\b", "The behavior"),
+        (r"^Memory resource ID\b", "The memory resource ID"),
+        (r"^Strategy name\b", "The name of the memory strategy"),
+        (r"^Strategy ID\b", "The ID of the memory strategy"),
+    )
+    for pattern, replacement in substitutions:
+        text = re.sub(pattern, replacement, text, count=1, flags=re.IGNORECASE)
+    return text
+
+
 def esc(text):
     """Escape AsciiDoc-significant characters in inline text."""
     if not text:
         return ""
     # Guard the couple of chars that start AsciiDoc markup in running prose.
-    return (
-        text.replace("|", "\\|")
-        .replace("{", "\\{")
-    )
+    marker = "\0AWS_ENTITY\0"
+    text = normalize_style(text).replace("{aws}", marker)
+    return text.replace("|", "\\|").replace("{", "\\{").replace(marker, "{aws}")
 
 
 # Match markdown code fences that may be indented (reST/Google docstrings often
@@ -116,7 +145,7 @@ def render_params(params, out):
         req = "" if p.get("required") else " _(optional)_"
         typ = f"`{p['type']}`" if p.get("type") else ""
         out.append(f"`{p['name']}`{req} {typ}::")
-        out.append(esc(p.get("description", "")) or "_No description._")
+        out.append(esc(normalize_param_description(p.get("description", ""))) or "_No description._")
     out.append("")
 
 
@@ -184,6 +213,8 @@ def render_entry(entry, level, out):
     """Render a single class/function/command as an AsciiDoc section."""
     heading = "=" * level
     name = entry.get("name", "")
+    if entry.get("anchor"):
+        out.append(f"[[{entry['anchor']}]]")
     out.append(f"{heading} {name}")
     out.append("")
 

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -62,7 +62,7 @@ def normalize_style(text):
     text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
     text = re.sub(
         r"\bAWS (?:Bedrock(?: AgentCore)? )?Code\s*Interpreter\b",
-        "AgentCore Code Interpreter",
+        "Amazon Bedrock AgentCore Code Interpreter",
         text,
         flags=re.IGNORECASE,
     )
@@ -71,6 +71,16 @@ def normalize_style(text):
     text = re.sub(
         r"(?<!Amazon )(?<!AWS )\bBedrock AgentCore\b",
         "Amazon Bedrock AgentCore",
+        text,
+    )
+    text = re.sub(
+        r"(?<!Amazon Bedrock )\bAgentCore Code Interpreter\b",
+        "Amazon Bedrock AgentCore Code Interpreter",
+        text,
+    )
+    text = re.sub(
+        r"(?<!Amazon Bedrock )\bAgentCore runtime\b",
+        "Amazon Bedrock AgentCore runtime",
         text,
     )
     text = re.sub(r"\bAWS region\b", "AWS Region", text, flags=re.IGNORECASE)

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -61,7 +61,7 @@ def normalize_style(text):
         return ""
     text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
     text = re.sub(
-        r"\bAWS Bedrock(?: AgentCore)? Code\s*Interpreter\b",
+        r"\bAWS (?:Bedrock(?: AgentCore)? )?Code\s*Interpreter\b",
         "AgentCore Code Interpreter",
         text,
         flags=re.IGNORECASE,

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -68,6 +68,12 @@ def normalize_style(text):
     )
     text = re.sub(r"\bAWS Bedrock AgentCore\b", "Amazon Bedrock AgentCore", text)
     text = re.sub(r"\bAWS Bedrock\b", "Amazon Bedrock", text)
+    text = re.sub(
+        r"(?<!Amazon )(?<!AWS )\bBedrock AgentCore\b",
+        "Amazon Bedrock AgentCore",
+        text,
+    )
+    text = re.sub(r"\bAWS region\b", "AWS Region", text, flags=re.IGNORECASE)
     text = re.sub(r"\bAgentCore Memory\b", "AgentCore memory", text)
     text = re.sub(r"\bAgentCore Runtime\b", "AgentCore runtime", text)
     text = text.replace(
@@ -81,8 +87,9 @@ def normalize_style(text):
 def normalize_param_description(text):
     """Normalize recurring parameter-description style issues."""
     text = normalize_style(text).strip()
+    optional_replacement = "Optional" if _starts_with_plural_noun(text) else "An optional"
     substitutions = (
-        (r"^Optional\b", "An optional"),
+        (r"^Optional\b", optional_replacement),
         (r"^(?:\{aws\}|AWS)\s+region\b", "The {aws} Region"),
         (r"^id of\b", "The ID of"),
         (r"^Behaviour\b", "The behavior"),
@@ -94,6 +101,15 @@ def normalize_param_description(text):
     for pattern, replacement in substitutions:
         text = re.sub(pattern, replacement, text, count=1, flags=re.IGNORECASE)
     return text
+
+
+def _starts_with_plural_noun(text):
+    """Return whether an Optional description starts with a likely plural noun."""
+    match = re.match(r"^Optional\s+([A-Za-z]+)\b", text, flags=re.IGNORECASE)
+    if not match:
+        return False
+    noun = match.group(1)
+    return noun.islower() and noun.endswith("s") and not noun.endswith(("is", "ss", "us"))
 
 
 def esc(text):

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -60,10 +60,21 @@ def normalize_style(text):
     if not text:
         return ""
     text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
+    text = re.sub(
+        r"\bAWS Bedrock(?: AgentCore)? Code\s*Interpreter\b",
+        "AgentCore Code Interpreter",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"\bAWS Bedrock AgentCore\b", "Amazon Bedrock AgentCore", text)
+    text = re.sub(r"\bAWS Bedrock\b", "Amazon Bedrock", text)
+    text = re.sub(r"\bAgentCore Memory\b", "AgentCore memory", text)
+    text = re.sub(r"\bAgentCore Runtime\b", "AgentCore runtime", text)
     text = text.replace(
         "This feature is in preview and may change in future releases.",
         "This feature is in preview and might change in future releases.",
     )
+    text = text.replace("validation will ensure", "validation ensures")
     return re.sub(r"\bAWS\b", "{aws}", text)
 
 

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -87,9 +87,8 @@ def normalize_style(text):
 def normalize_param_description(text):
     """Normalize recurring parameter-description style issues."""
     text = normalize_style(text).strip()
-    optional_replacement = "Optional" if _starts_with_plural_noun(text) else "An optional"
     substitutions = (
-        (r"^Optional\b", optional_replacement),
+        (r"^Optional\b", "The optional"),
         (r"^(?:\{aws\}|AWS)\s+region\b", "The {aws} Region"),
         (r"^id of\b", "The ID of"),
         (r"^Behaviour\b", "The behavior"),
@@ -101,17 +100,6 @@ def normalize_param_description(text):
     for pattern, replacement in substitutions:
         text = re.sub(pattern, replacement, text, count=1, flags=re.IGNORECASE)
     return text
-
-
-def _starts_with_plural_noun(text):
-    """Return whether an Optional description starts with a likely plural noun."""
-    match = re.match(r"^Optional\s+([A-Za-z]+)\b", text, flags=re.IGNORECASE)
-    if not match:
-        return False
-    noun = match.group(1)
-    return noun.islower() and noun.endswith("s") and not noun.endswith(("is", "ss", "us"))
-
-
 def esc(text):
     """Escape AsciiDoc-significant characters in inline text."""
     if not text:

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -83,6 +83,12 @@ def normalize_style(text):
         "Amazon Bedrock AgentCore runtime",
         text,
     )
+    text = re.sub(
+        r"(?<!Amazon Bedrock )\bAgentCore Identity\b",
+        "Amazon Bedrock AgentCore Identity",
+        text,
+    )
+    text = text.replace(", allowing applications to", " so applications can")
     text = re.sub(r"\bAWS region\b", "AWS Region", text, flags=re.IGNORECASE)
     text = re.sub(r"\bAgentCore Memory\b", "AgentCore memory", text)
     text = re.sub(r"\bAgentCore Runtime\b", "AgentCore runtime", text)

--- a/scripts/test_render_adoc.py
+++ b/scripts/test_render_adoc.py
@@ -1,0 +1,22 @@
+import unittest
+
+from scripts.render_adoc import normalize_param_description
+
+
+class NormalizeParamDescriptionTest(unittest.TestCase):
+    def test_optional_descriptions_support_singular_plural_and_mass_nouns(self):
+        cases = {
+            "Optional session name.": "The optional session name.",
+            "Optional parameters specifying which session to query.": (
+                "The optional parameters specifying which session to query."
+            ),
+            "Optional task metadata.": "The optional task metadata.",
+        }
+
+        for description, expected in cases.items():
+            with self.subTest(description=description):
+                self.assertEqual(normalize_param_description(description), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_render_adoc.py
+++ b/scripts/test_render_adoc.py
@@ -1,6 +1,6 @@
 import unittest
 
-from scripts.render_adoc import normalize_param_description
+from scripts.render_adoc import normalize_param_description, normalize_style
 
 
 class NormalizeParamDescriptionTest(unittest.TestCase):
@@ -16,6 +16,16 @@ class NormalizeParamDescriptionTest(unittest.TestCase):
         for description, expected in cases.items():
             with self.subTest(description=description):
                 self.assertEqual(normalize_param_description(description), expected)
+
+    def test_service_names_are_fully_qualified(self):
+        self.assertEqual(
+            normalize_style("Client for AgentCore runtime."),
+            "Client for Amazon Bedrock AgentCore runtime.",
+        )
+        self.assertEqual(
+            normalize_style("Client for the AgentCore Code Interpreter sandbox service."),
+            "Client for the Amazon Bedrock AgentCore Code Interpreter sandbox service.",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_render_adoc.py
+++ b/scripts/test_render_adoc.py
@@ -26,6 +26,14 @@ class NormalizeParamDescriptionTest(unittest.TestCase):
             normalize_style("Client for the AgentCore Code Interpreter sandbox service."),
             "Client for the Amazon Bedrock AgentCore Code Interpreter sandbox service.",
         )
+        self.assertEqual(
+            normalize_style("Retrieves an API key from AgentCore Identity."),
+            "Retrieves an API key from Amazon Bedrock AgentCore Identity.",
+        )
+        self.assertEqual(
+            normalize_style("Provides credentials, allowing applications to connect."),
+            "Provides credentials so applications can connect.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- label Strands and Vercel AI integration entries separately
- emit stable explicit anchors for integration entries
- normalize generated AsciiDoc for AWS style and China rebranding checks
- add a regression test for duplicate integration names

Addresses generated documentation feedback from Amazon CR-290947859.

## Testing
- `node --test scripts/extract-api-model.test.mjs`
- repository pre-commit checks: 23 test files / 617 tests, lint, format, and type-check
- regenerated the v0.4.1 TypeScript reference