### PR TITLE
feat(harness): add AgentCore Harness Strands integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,17 @@ bedrock-agentcore-sdk-typescript/
 │   └── TESTING.md                # Comprehensive testing guidelines
 │
 ├── src/                          # Source code (all production code)
+│   ├── harness/                  # AgentCore Harness integrations
+│   │   └── integrations/         # Framework-specific integrations
+│   │       └── strands/          # AgentCoreHarnessAgent (Strands InvokableAgent)
+│   │           ├── __tests__/    # Unit tests for the Harness adapter
+│   │           ├── README.md     # Harness Strands usage and ownership guide
+│   │           ├── agent.ts      # AgentCoreHarnessAgent implementation
+│   │           ├── events.ts     # Harness stream event wrappers
+│   │           ├── index.ts      # Harness Strands integration exports
+│   │           ├── model.ts      # InvokeHarness to Strands model adapter
+│   │           ├── stream-decoder.ts  # InvokeHarness stream to Strands message
+│   │           └── types.ts      # Harness adapter type definitions
 │   ├── runtime/                  # Runtime server for hosting agents
 │   │   ├── __tests__/            # Unit tests for runtime
 │   │   ├── app.ts                # BedrockAgentCoreApp implementation
@@ -96,6 +107,7 @@ bedrock-agentcore-sdk-typescript/
 ├── tests_integ/                  # Integration tests
 │   ├── browser.test.ts           # Browser integration tests
 │   ├── code-interpreter.test.ts  # Code interpreter integration tests
+│   ├── harness-strands.test.ts   # Live Harness and inline-function integration tests
 │   ├── runtime.test.ts           # Runtime server integration tests
 │   ├── setup.ts                  # Test setup utilities and helpers
 │   └── vercel-ai-agent.test.ts   # Vercel AI integration tests
@@ -129,6 +141,8 @@ bedrock-agentcore-sdk-typescript/
 - **`.husky/`**: Git hooks for pre-commit quality checks and validation
 - **`docs/`**: Comprehensive documentation for development processes and guidelines
 - **`src/`**: All production source code for the SDK
+- **`src/harness/`**: Adapters exposing a deployed AgentCore Harness through agent-framework interfaces
+- **`src/harness/integrations/strands/`**: `AgentCoreHarnessAgent`, a Strands `InvokableAgent` backed by `InvokeHarness`
 - **`src/runtime/`**: HTTP server for hosting agents on AWS Bedrock AgentCore Runtime
 - **`src/tools/`**: Tool definitions and implementations for browser automation and code interpretation
 - **`src/tools/browser/`**: Browser automation client with AWS Bedrock integration
@@ -187,6 +201,10 @@ The SDK follows a layered integration pattern:
 2. **Integrations translate**: Convert between framework types and AWS types
 3. **Clear separation**: Each framework gets its own subdirectory
 4. **Testability**: Mock at client layer, not AWS SDK layer
+
+The Harness integration translates directly between Strands and
+`@aws-sdk/client-bedrock-agentcore` because `InvokeHarness` is already the framework-agnostic client
+surface. It does not introduce a redundant Harness base client.
 
 ## Development Workflow for Agents
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ const agent = new Agent({
 - **Browser** — Cloud-based web automation → [Examples](https://github.com/awslabs/bedrock-agentcore-samples-typescript/tree/main/primitives/tools/browser)
 - **Identity** — Manage API keys and OAuth tokens → [Examples](https://github.com/awslabs/bedrock-agentcore-samples-typescript/tree/main/primitives/identity)
 - **Memory** — Persistent knowledge across sessions → [Guide](docs/MEMORY.md)
+- **Harness** — Invoke a deployed Harness as a Strands agent (experimental) → [Guide](src/harness/integrations/strands/README.md)
 - **Gateway** — Transform APIs into MCP tools (coming soon)
 - **Observability** — OpenTelemetry tracing (coming soon)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,6 +63,8 @@ export default [
         setTimeout: 'readonly',
         Buffer: 'readonly',
         URL: 'readonly',
+        AbortController: 'readonly',
+        AbortSignal: 'readonly',
       },
     },
     plugins: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-sdk/client-bedrock-agentcore": "^3.1065.0",
-        "@aws-sdk/client-bedrock-agentcore-control": "^3.996.0",
+        "@aws-sdk/client-bedrock-agentcore-control": "^3.1035.0",
         "@aws-sdk/credential-providers": "^3.996.0",
         "@aws-sdk/protocol-http": "^3.370.0",
         "@aws-sdk/signature-v4": "^3.370.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
       "import": "./dist/src/memory/integrations/strands/index.js",
       "types": "./dist/src/memory/integrations/strands/index.d.ts"
     },
+    "./experimental/harness/strands": {
+      "import": "./dist/src/harness/integrations/strands/index.js",
+      "types": "./dist/src/harness/integrations/strands/index.d.ts"
+    },
     "./runtime": {
       "import": "./dist/src/runtime/index.js",
       "types": "./dist/src/runtime/index.d.ts"
@@ -156,7 +160,7 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
     "@aws-sdk/client-bedrock-agentcore": "^3.1065.0",
-    "@aws-sdk/client-bedrock-agentcore-control": "^3.996.0",
+    "@aws-sdk/client-bedrock-agentcore-control": "^3.1035.0",
     "@aws-sdk/credential-providers": "^3.996.0",
     "@aws-sdk/protocol-http": "^3.370.0",
     "@aws-sdk/signature-v4": "^3.370.0",

--- a/src/harness/integrations/strands/README.md
+++ b/src/harness/integrations/strands/README.md
@@ -1,0 +1,201 @@
+# AgentCore Harness for Strands (`bedrock-agentcore/experimental/harness/strands`)
+
+`AgentCoreHarnessAgent` makes a deployed
+[AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) a
+first-class [Strands](https://strandsagents.com) agent. It implements the same `InvokableAgent`
+interface as a local `Agent`, so a Harness drops into `Graph` without special-casing at the call site.
+
+This integration is experimental and its API may change before promotion to a stable import path.
+
+This integration consumes the Strands agent and tool interfaces directly from `@strands-agents/sdk` (>= 1.5.0).
+
+## Installation
+
+```bash
+npm install bedrock-agentcore @strands-agents/sdk
+```
+
+## What it does
+
+- **Invoke** — `invoke()` starts a turn with one text message and returns an `AgentResult`.
+- **Inline functions** — local Strands tools are registered dynamically as Harness `inline_function`
+  definitions, merged with the deployed tools, executed client-side, and returned to the same Harness
+  session.
+- **Human-in-the-loop** — tool lifecycle interventions and tool callback interrupts can pause a local
+  callback and resume it from an `InterruptResponseContent`.
+- **Stream** — `stream()` yields every non-error Harness event as it arrives, then a final result event.
+- **Session continuity** — reuse one `runtimeSessionId` and the Harness continues the conversation
+  server-side; no client-side message history is replayed.
+- **Typed errors** — AgentCore and in-stream failures are translated to the Strands error types
+  (`ModelError`, `ModelThrottledError`, `ContextWindowOverflowError`, `MaxTokensError`) that retry
+  strategies and conversation managers already key off.
+- **Cancellation** — an `AbortSignal` aborts an active Harness request and returns
+  `stopReason: 'cancelled'` with content decoded before the abort. A local callback already in
+  progress is cooperatively cancelled, then its result is sent to the Harness before the invocation
+  returns.
+
+## Usage
+
+```typescript
+import { randomUUID } from 'node:crypto'
+import { FunctionTool } from '@strands-agents/sdk'
+import { AgentCoreHarnessAgent } from 'bedrock-agentcore/experimental/harness/strands'
+
+const getWeather = new FunctionTool({
+  name: 'get_weather',
+  description: 'Get the current weather',
+  inputSchema: {
+    type: 'object',
+    properties: { city: { type: 'string' } },
+    required: ['city'],
+  },
+  callback: async (input) => {
+    const { city } = input as { city: string }
+    return { city, temperatureF: 72 }
+  },
+})
+
+const agent = new AgentCoreHarnessAgent({
+  harnessArn: process.env.AGENTCORE_HARNESS_ARN!,
+  runtimeSessionId: randomUUID(),
+  tools: [getWeather],
+})
+
+const result = await agent.invoke('What is the weather in Seattle?')
+console.log(result.toString())
+```
+
+The adapter translates each local tool's name, description, and input schema into a Harness
+`inline_function` definition. The deployed Harness does not need to define the tool in advance. When
+local tools are supplied, the adapter calls `GetHarness` once per invocation, merges the deployed and
+local tool definitions, and sends the combined list to `InvokeHarness`. A local definition replaces a
+deployed tool with the same name. Restrictive deployed allow-lists are extended with the local tool
+names. The caller therefore needs permission to get and invoke the Harness.
+
+Callback results may be text or JSON; JSON values are encoded as text in the continuation request for
+Harness runtime compatibility. Callback failures and missing local tools are returned to the Harness
+as error tool results so its agent loop can decide how to recover.
+
+The local Strands tool schema is authoritative for inline-function input. Validate callback input
+inside the local tool when the callback crosses a trust boundary. If cancellation occurs while a
+callback is running, `context.agent.cancelSignal` is aborted; callbacks should pass that signal to
+cancellable operations. A callback that ignores the signal is allowed to finish so the adapter can
+send a matching result and leave the Harness session in a valid state. Any additional inline
+functions requested while cancellation is being resolved receive cancellation results without
+executing their callbacks.
+
+### Human-in-the-loop callbacks
+
+Pass Strands tool lifecycle intervention handlers through `interventions`. Model and invocation
+lifecycle interventions are rejected because they can retry or replace the deployed Harness's
+reasoning turn. When a handler or callback requests input, the invocation returns an `AgentResult`
+with `stopReason: 'interrupt'`. Resume it on the same agent instance with the corresponding response:
+
+```typescript
+import {
+  BeforeToolCallEvent,
+  FunctionTool,
+  InterruptResponseContent,
+  InterventionActions,
+  InterventionHandler,
+} from '@strands-agents/sdk'
+
+class ConfirmDeletion extends InterventionHandler {
+  readonly name = 'confirm-deletion'
+
+  override beforeToolCall(event: BeforeToolCallEvent) {
+    return InterventionActions.confirm(`Approve ${event.toolUse.name}?`)
+  }
+}
+
+const deleteRecord = new FunctionTool({
+  name: 'delete_record',
+  description: 'Delete one record',
+  inputSchema: {
+    type: 'object',
+    properties: { id: { type: 'string' } },
+    required: ['id'],
+  },
+  callback: async (input) => {
+    const { id } = input as { id: string }
+    await records.delete(id)
+    return { deleted: id }
+  },
+})
+
+const deletionAgent = new AgentCoreHarnessAgent({
+  harnessArn: process.env.AGENTCORE_HARNESS_ARN!,
+  runtimeSessionId: randomUUID(),
+  tools: [deleteRecord],
+  interventions: [new ConfirmDeletion()],
+})
+
+const interrupted = await deletionAgent.invoke('Delete record 123.')
+const result = await deletionAgent.invoke([
+  new InterruptResponseContent({
+    interruptId: interrupted.interrupts![0]!.id,
+    response: 'yes',
+  }),
+])
+```
+
+### Streaming
+
+`stream()` yields `AgentCoreHarnessStreamUpdateEvent` wrapping each non-error `InvokeHarness` event,
+so you can render deltas as the Harness produces them, and finishes with an
+`AgentCoreHarnessResultEvent`. When local callbacks require continuation requests, raw events from
+every request are yielded in arrival order.
+
+```typescript
+for await (const event of agent.stream('Summarize the worktree.')) {
+  if (event.type === 'agentCoreHarnessStreamUpdateEvent' && 'contentBlockDelta' in event.event) {
+    process.stdout.write(event.event.contentBlockDelta?.delta?.text ?? '')
+  }
+}
+```
+
+### Composition
+
+Because the adapter satisfies `InvokableAgent`, a Harness is just another node:
+
+```typescript
+import { Graph } from '@strands-agents/sdk/multiagent'
+
+const graph = new Graph({
+  nodes: [localResearcher, harnessAgent],
+  edges: [[localResearcher.id, harnessAgent.id]],
+})
+
+await graph.invoke('Research and summarize.')
+```
+
+## Ownership boundary
+
+The deployed Harness owns its **model, system prompt, tools, skills, memory, execution limits, and
+server-side agent loop**. Remote tool events such as `server_tool_use` and `mcp_tool_use` stay inside
+the Harness and are never dispatched to local callbacks.
+
+When `tools` is supplied, the adapter merges dynamic `inline_function` definitions generated from the
+Strands tool specifications with the deployed tool configuration. Strands executes those callbacks
+locally. After a callback completes, the adapter sends the assistant tool use and user tool result to
+`InvokeHarness` under the same `runtimeSessionId`, allowing the deployed agent loop to continue.
+
+Consequently the following are rejected before any request is made:
+
+| Input / option           | Reason                                                             |
+| ------------------------ | ------------------------------------------------------------------ |
+| Non-text initial content | `InvokeHarness` receives text-only user input through this adapter |
+| Checkpoint resume        | The Harness owns turn state under `runtimeSessionId`               |
+| `structuredOutputSchema` | Structured output is not part of the Harness invocation contract   |
+| `limits`                 | Execution limits belong to the deployed Harness                    |
+
+Text input is normalized to a single message: a string is used verbatim, multiple text blocks are
+joined with newlines, and message-history input uses the **latest user message** only. Earlier turns
+already live in the Harness session, so replaying them would duplicate them server-side.
+
+The default AgentCore clients use standard AWS configuration resolution. The data-plane client uses
+one request attempt because retrying a stateful Harness turn could duplicate work. Pass pre-built
+`client` and `controlClient` instances when you need different client configuration.
+
+One instance serves one invocation at a time. A concurrent `invoke()` or `stream()` throws
+`ConcurrentInvocationError`; construct one agent per concurrent conversation.

--- a/src/harness/integrations/strands/__tests__/agent.test.ts
+++ b/src/harness/integrations/strands/__tests__/agent.test.ts
@@ -1,0 +1,473 @@
+import { describe, expect, it } from 'vitest'
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import {
+  ConcurrentInvocationError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  Message,
+  ModelError,
+  ModelThrottledError,
+  ReasoningBlock,
+  TextBlock,
+} from '@strands-agents/sdk'
+import { AgentCoreHarnessStreamUpdateEvent } from '../events.js'
+import {
+  HARNESS_ARN,
+  RUNTIME_SESSION_ID,
+  collectGenerator,
+  commandInput,
+  createHarnessAgent,
+  createMockControlClient,
+  createMockClient,
+  harnessEvent,
+  harnessStream,
+} from './harness-test-helpers.js'
+
+async function* cancelledStream(controller: AbortController): AsyncGenerator<InvokeHarnessStreamOutput> {
+  yield harnessEvent.messageStart()
+  yield harnessEvent.textDelta('partial')
+  controller.abort()
+  throw new Error('aborted')
+}
+
+describe('AgentCoreHarnessAgent', () => {
+  describe('constructor', () => {
+    it('derives identity from the Harness session and accepts overrides', () => {
+      expect(createHarnessAgent()).toMatchObject({
+        id: `${HARNESS_ARN}:${RUNTIME_SESSION_ID}`,
+      })
+      expect(
+        createHarnessAgent({ id: 'research-harness', name: 'researcher', description: 'does research' })
+      ).toMatchObject({
+        id: 'research-harness',
+        name: 'researcher',
+        description: 'does research',
+      })
+    })
+  })
+
+  describe('stream', () => {
+    it('sends one text request and streams raw events before the final result', async () => {
+      const metadata = harnessEvent.metadata({ inputTokens: 10, outputTokens: 4, totalTokens: 14 }, 25)
+      const events = [
+        harnessEvent.messageStart(),
+        harnessEvent.textDelta('Complete.'),
+        harnessEvent.contentBlockStop(),
+        harnessEvent.messageStop('end_turn'),
+        metadata,
+      ]
+      const { client, send } = createMockClient(harnessStream(...events))
+      const { client: controlClient, send: getHarness } = createMockControlClient()
+      const invocationState = { requestId: 'request-1' }
+
+      const { items, result } = await collectGenerator(
+        createHarnessAgent({ client, controlClient }).stream('Run it.', { invocationState })
+      )
+
+      expect(getHarness).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledOnce()
+      expect(commandInput(send)).toStrictEqual({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'Run it.' }] }],
+      })
+      expect(send.mock.calls[0]![1]).toStrictEqual({ abortSignal: expect.any(AbortSignal) })
+      expect(result).toMatchObject({
+        stopReason: 'endTurn',
+        lastMessage: { role: 'assistant', content: [new TextBlock('Complete.')] },
+        invocationState,
+      })
+      expect(items).toStrictEqual([
+        ...events.map((event) => new AgentCoreHarnessStreamUpdateEvent(event)),
+        expect.objectContaining({ type: 'agentCoreHarnessResultEvent', result }),
+      ])
+    })
+
+    it('returns only pre-abort content when an aborted stream throws', async () => {
+      const controller = new AbortController()
+      const stream = cancelledStream(controller)
+      const { client, send } = createMockClient(stream)
+
+      const { items, result } = await collectGenerator(
+        createHarnessAgent({ client }).stream('Run it.', { cancelSignal: controller.signal })
+      )
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(result.lastMessage.content).toStrictEqual([new TextBlock('partial')])
+      expect(items).toStrictEqual([
+        new AgentCoreHarnessStreamUpdateEvent(harnessEvent.messageStart()),
+        new AgentCoreHarnessStreamUpdateEvent(harnessEvent.textDelta('partial')),
+        expect.objectContaining({ type: 'agentCoreHarnessResultEvent', result }),
+      ])
+      expect(send.mock.calls[0]![1]).toStrictEqual({ abortSignal: expect.any(AbortSignal) })
+      expect((send.mock.calls[0]![1] as { abortSignal: AbortSignal }).abortSignal.aborted).toBe(true)
+    })
+
+    it('preserves partial content when the consumer aborts after receiving a raw delta', async () => {
+      const controller = new AbortController()
+      async function* streamUntilClosed(): AsyncGenerator<InvokeHarnessStreamOutput> {
+        yield harnessEvent.messageStart()
+        yield harnessEvent.textDelta('partial')
+        await new Promise<void>((resolve) => {
+          if (controller.signal.aborted) resolve()
+          else controller.signal.addEventListener('abort', () => resolve(), { once: true })
+        })
+      }
+      const { client } = createMockClient(streamUntilClosed())
+      const generator = createHarnessAgent({ client }).stream('Run it.', { cancelSignal: controller.signal })
+
+      await generator.next()
+      await generator.next()
+      controller.abort()
+      const { result } = await collectGenerator(generator)
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(result.lastMessage.content).toStrictEqual([new TextBlock('partial')])
+    })
+
+    it('does not decode a buffered chunk returned by the read that triggers cancellation', async () => {
+      const controller = new AbortController()
+      const events = [harnessEvent.messageStart(), harnessEvent.textDelta('before'), harnessEvent.textDelta(' after')]
+      let index = 0
+      const stream: AsyncIterableIterator<InvokeHarnessStreamOutput> = {
+        [Symbol.asyncIterator]() {
+          return this
+        },
+        next() {
+          const value = events[index++]
+          if (index === events.length) controller.abort()
+          return Promise.resolve(value === undefined ? { done: true, value } : { done: false, value })
+        },
+        return() {
+          return Promise.resolve({ done: true, value: undefined })
+        },
+      }
+      const { client } = createMockClient(stream)
+
+      const { items, result } = await collectGenerator(
+        createHarnessAgent({ client }).stream('Run it.', { cancelSignal: controller.signal })
+      )
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(result.lastMessage.content).toStrictEqual([new TextBlock('before')])
+      expect(items).toStrictEqual([
+        new AgentCoreHarnessStreamUpdateEvent(events[0]!),
+        new AgentCoreHarnessStreamUpdateEvent(events[1]!),
+        expect.objectContaining({ type: 'agentCoreHarnessResultEvent', result }),
+      ])
+    })
+
+    it('does not send a request when already cancelled', async () => {
+      const { client, send } = createMockClient(harnessStream())
+
+      const result = await createHarnessAgent({ client }).invoke('Run it.', { cancelSignal: AbortSignal.abort() })
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('emits an unmapped raw event before waiting for a later Harness event', async () => {
+      let markWaiting: () => void = () => {}
+      let releaseStream: () => void = () => {}
+      const waiting = new Promise<void>((resolve) => {
+        markWaiting = resolve
+      })
+      const release = new Promise<void>((resolve) => {
+        releaseStream = resolve
+      })
+      const toolResultStart = harnessEvent.toolResultStart('tool-1')
+      async function* delayedErrorStream(): AsyncGenerator<InvokeHarnessStreamOutput> {
+        yield harnessEvent.messageStart()
+        yield toolResultStart
+        markWaiting()
+        await release
+        yield { internalServerException: { message: 'later failure' } } as InvokeHarnessStreamOutput
+      }
+      const { client } = createMockClient(delayedErrorStream())
+      const generator = createHarnessAgent({ client }).stream('Run it.')
+
+      expect(await generator.next()).toMatchObject({
+        done: false,
+        value: new AgentCoreHarnessStreamUpdateEvent(harnessEvent.messageStart()),
+      })
+      expect(await generator.next()).toMatchObject({
+        done: false,
+        value: new AgentCoreHarnessStreamUpdateEvent(toolResultStart),
+      })
+      const pendingFailure = generator.next()
+      await waiting
+      releaseStream()
+
+      await expect(pendingFailure).rejects.toThrow('later failure')
+    })
+
+    it('does not buffer unmapped Harness events ahead of the stream consumer', async () => {
+      let produced = 0
+      async function* countedStream(): AsyncGenerator<InvokeHarnessStreamOutput> {
+        const events = [
+          harnessEvent.messageStart(),
+          harnessEvent.toolResultStart('tool-1'),
+          harnessEvent.toolResultDelta('first'),
+          harnessEvent.toolResultDelta('second'),
+        ]
+        for (const event of events) {
+          produced += 1
+          yield event
+        }
+      }
+      const { client } = createMockClient(countedStream())
+      const generator = createHarnessAgent({ client }).stream('Run it.')
+
+      await generator.next()
+      expect(await generator.next()).toMatchObject({
+        done: false,
+        value: new AgentCoreHarnessStreamUpdateEvent(harnessEvent.toolResultStart('tool-1')),
+      })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(produced).toBe(2)
+
+      await generator.return(undefined as never)
+    })
+
+    it('releases the invocation when the consumer stops streaming', async () => {
+      const { client, send } = createMockClient()
+      send.mockImplementationOnce((_command, options) => {
+        async function* untilAborted(): AsyncGenerator<InvokeHarnessStreamOutput> {
+          yield harnessEvent.messageStart()
+          await new Promise<void>((resolve) => {
+            const signal = options?.abortSignal as
+              | { addEventListener(type: 'abort', listener: () => void, options: { once: boolean }): void }
+              | undefined
+            if (options?.abortSignal?.aborted) resolve()
+            else signal?.addEventListener('abort', () => resolve(), { once: true })
+          })
+        }
+        return Promise.resolve({ stream: untilAborted() }) as never
+      })
+      send.mockResolvedValueOnce({
+        stream: harnessStream(
+          harnessEvent.messageStart(),
+          harnessEvent.textDelta('Available again.'),
+          harnessEvent.messageStop('end_turn')
+        ),
+      } as never)
+      const agent = createHarnessAgent({ client })
+      const generator = agent.stream('Run it.')
+
+      expect(await generator.next()).toMatchObject({
+        done: false,
+        value: new AgentCoreHarnessStreamUpdateEvent(harnessEvent.messageStart()),
+      })
+      await generator.return(undefined as never)
+
+      await expect(agent.invoke('Run it again.')).resolves.toMatchObject({
+        stopReason: 'endTurn',
+        lastMessage: { content: [new TextBlock('Available again.')] },
+      })
+      expect(send).toHaveBeenCalledTimes(2)
+    })
+
+    it('rejects a concurrent invocation and releases the instance afterward', async () => {
+      let release: (response: { stream: AsyncGenerator<InvokeHarnessStreamOutput> }) => void
+      const pending = new Promise<{ stream: AsyncGenerator<InvokeHarnessStreamOutput> }>((resolve) => {
+        release = resolve
+      })
+      const { client, send } = createMockClient()
+      send.mockReturnValueOnce(pending as never)
+      const agent = createHarnessAgent({ client })
+
+      const first = agent.invoke('First')
+      await expect(agent.invoke('Second')).rejects.toBeInstanceOf(ConcurrentInvocationError)
+      release!({ stream: harnessStream(harnessEvent.messageStart(), harnessEvent.messageStop('end_turn')) })
+      await first
+
+      send.mockResolvedValueOnce({
+        stream: harnessStream(harnessEvent.messageStart(), harnessEvent.messageStop('end_turn')),
+      } as never)
+      await expect(agent.invoke('Third')).resolves.toMatchObject({ stopReason: 'endTurn' })
+    })
+  })
+
+  describe('input normalization', () => {
+    it.each([
+      {
+        label: 'text blocks',
+        args: [new TextBlock('Line one'), new TextBlock('Line two')],
+        expected: 'Line one\nLine two',
+      },
+      {
+        label: 'message history',
+        args: [
+          new Message({ role: 'user', content: [new TextBlock('Earlier')] }),
+          new Message({ role: 'assistant', content: [new TextBlock('Reply')] }),
+          new Message({ role: 'user', content: [new TextBlock('Latest'), new TextBlock('request')] }),
+        ],
+        expected: 'Latest\nrequest',
+      },
+    ])('normalizes $label before calling AgentCore', async ({ args, expected }) => {
+      const { client, send } = createMockClient(
+        harnessStream(harnessEvent.messageStart(), harnessEvent.messageStop('end_turn'))
+      )
+
+      await createHarnessAgent({ client }).invoke(args)
+
+      expect(commandInput(send).messages).toStrictEqual([{ role: 'user', content: [{ text: expected }] }])
+    })
+
+    it.each([
+      { label: 'empty string', args: '', options: undefined, message: 'input must contain non-empty text' },
+      { label: 'empty array', args: [], options: undefined, message: 'input must contain non-empty text' },
+      {
+        label: 'non-text blocks',
+        args: [new ReasoningBlock({ text: 'private reasoning' })],
+        options: undefined,
+        message: 'accepts only text content blocks; received reasoningBlock',
+      },
+      {
+        label: 'history without a user message',
+        args: [new Message({ role: 'assistant', content: [new TextBlock('No user message')] })],
+        options: undefined,
+        message: 'must include at least one user message',
+      },
+      {
+        label: 'checkpoint resume',
+        args: { checkpointResume: { checkpoint: { position: 'afterModel' } } },
+        options: undefined,
+        message: 'does not support checkpoint resume input',
+      },
+      {
+        label: 'structuredOutputSchema',
+        args: 'Hi',
+        options: { structuredOutputSchema: { _output: undefined } },
+        message: 'structuredOutputSchema is not supported',
+      },
+      { label: 'limits', args: 'Hi', options: { limits: { turns: 1 } }, message: 'limits is not supported' },
+    ])('rejects $label before calling AgentCore', async ({ args, options, message }) => {
+      const { client, send } = createMockClient(harnessStream())
+
+      const rejection = await createHarnessAgent({ client })
+        .invoke(args as never, options as never)
+        .catch((error: unknown) => error)
+
+      expect(rejection).toBeInstanceOf(TypeError)
+      expect(rejection).toMatchObject({ message: expect.stringContaining(message) })
+      expect(send).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('errors', () => {
+    it.each([
+      {
+        label: 'internalServerException',
+        errorChunk: { internalServerException: { message: 'internal failure' } } as InvokeHarnessStreamOutput,
+        error: ModelError,
+        message: 'internal failure',
+      },
+      {
+        label: 'a context-window validationException',
+        errorChunk: { validationException: { message: 'Prompt is too long' } } as InvokeHarnessStreamOutput,
+        error: ContextWindowOverflowError,
+        message: 'Prompt is too long',
+      },
+      {
+        label: 'a generic validationException',
+        errorChunk: { validationException: { message: 'bad request' } } as InvokeHarnessStreamOutput,
+        error: ModelError,
+        message: 'bad request',
+      },
+      {
+        label: 'runtimeClientError',
+        errorChunk: { runtimeClientError: { message: 'runtime failure' } } as InvokeHarnessStreamOutput,
+        error: ModelError,
+        message: 'runtime failure',
+      },
+    ])('translates $label from the stream', async ({ errorChunk, error, message }) => {
+      const { client } = createMockClient(harnessStream(errorChunk))
+
+      const rejection = await createHarnessAgent({ client })
+        .invoke('Run it.')
+        .catch((thrown: unknown) => thrown)
+
+      expect(rejection).toBeInstanceOf(error)
+      expect(rejection).toMatchObject({ message })
+    })
+
+    it('rejects malformed tool input before returning a tool-use result', async () => {
+      const { client } = createMockClient(
+        harnessStream(
+          harnessEvent.messageStart(),
+          harnessEvent.toolUseStart('tool-1', 'deployed_inline'),
+          harnessEvent.toolUseDelta('{'),
+          harnessEvent.contentBlockStop(),
+          harnessEvent.messageStop('tool_use')
+        )
+      )
+
+      await expect(createHarnessAgent({ client }).invoke('Run it.')).rejects.toThrow(
+        'Unable to parse Harness tool input JSON.'
+      )
+    })
+
+    it('surfaces max-token termination as MaxTokensError carrying the partial message', async () => {
+      const { client } = createMockClient(
+        harnessStream(
+          harnessEvent.messageStart(),
+          harnessEvent.textDelta('partial'),
+          harnessEvent.messageStop('max_tokens')
+        )
+      )
+
+      const rejection = await createHarnessAgent({ client })
+        .invoke('Run it.')
+        .catch((thrown: unknown) => thrown)
+
+      expect(rejection).toBeInstanceOf(MaxTokensError)
+      expect((rejection as MaxTokensError).partialMessage.content).toStrictEqual([new TextBlock('partial')])
+    })
+
+    it.each(['interrupted', 'malformed_model_output', 'malformed_tool_use'])(
+      'rejects the non-resumable stop reason %s',
+      async (stopReason) => {
+        const { client } = createMockClient(
+          harnessStream(
+            harnessEvent.messageStart(),
+            harnessEvent.textDelta('partial'),
+            harnessEvent.messageStop(stopReason)
+          )
+        )
+
+        await expect(createHarnessAgent({ client }).invoke('Run it.')).rejects.toThrow(
+          'Harness ended the turn with an unrecoverable stop reason'
+        )
+      }
+    )
+
+    it.each([
+      { name: 'ThrottlingException', error: ModelThrottledError },
+      { name: 'OtherException', error: ModelError },
+    ])('normalizes a rejected AgentCore request ($name)', async ({ name, error }) => {
+      const original = Object.assign(new Error('request failed'), { name })
+      const { client, send } = createMockClient()
+      send.mockRejectedValueOnce(original)
+
+      const rejection = await createHarnessAgent({ client })
+        .invoke('Run it.')
+        .catch((thrown: unknown) => thrown)
+
+      expect(rejection).toBeInstanceOf(error)
+      expect(rejection).toMatchObject({ message: 'request failed', cause: original })
+    })
+
+    it('maps a rejected request whose message signals context overflow', async () => {
+      const { client, send } = createMockClient()
+      send.mockRejectedValueOnce(new Error('Input is too long for requested model'))
+
+      const rejection = await createHarnessAgent({ client })
+        .invoke('Run it.')
+        .catch((thrown: unknown) => thrown)
+
+      expect(rejection).toBeInstanceOf(ContextWindowOverflowError)
+      expect((rejection as ContextWindowOverflowError).cause).toBeInstanceOf(Error)
+    })
+  })
+})

--- a/src/harness/integrations/strands/__tests__/composition.test.ts
+++ b/src/harness/integrations/strands/__tests__/composition.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { TextBlock } from '@strands-agents/sdk'
+import { Graph, Status } from '@strands-agents/sdk/multiagent'
+import { commandInput, createHarnessAgent, createMockClient, textTurn } from './harness-test-helpers.js'
+
+describe('AgentCoreHarnessAgent', () => {
+  describe('composition', () => {
+    it('runs as a Graph node and receives its predecessor output', async () => {
+      const { client, send } = createMockClient(textTurn('Upstream summary'), textTurn('Harness graph result'))
+      const upstream = createHarnessAgent({ client, id: 'upstream' })
+      const downstream = createHarnessAgent({ client, id: 'downstream' })
+      const graph = new Graph({
+        nodes: [upstream, downstream],
+        edges: [[upstream.id, downstream.id]],
+      })
+
+      const result = await graph.invoke('Original task')
+
+      expect(result.status).toBe(Status.COMPLETED)
+      expect(result.content).toStrictEqual([new TextBlock('Harness graph result')])
+      const downstreamInput = commandInput(send, 1).messages![0]!.content![0]!
+      expect(downstreamInput).toMatchObject({ text: expect.stringContaining('Original task') })
+      expect(downstreamInput).toMatchObject({ text: expect.stringContaining('Upstream summary') })
+    })
+  })
+})

--- a/src/harness/integrations/strands/__tests__/events.test.ts
+++ b/src/harness/integrations/strands/__tests__/events.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { AgentResult, Message, TextBlock } from '@strands-agents/sdk'
+import { AgentCoreHarnessResultEvent, AgentCoreHarnessStreamUpdateEvent } from '../events.js'
+import { harnessEvent } from './harness-test-helpers.js'
+
+describe('AgentCoreHarnessStreamUpdateEvent', () => {
+  it('serializes the raw Harness event', () => {
+    const event = harnessEvent.textDelta('hi')
+
+    const streamEvent = new AgentCoreHarnessStreamUpdateEvent(event as AgentCoreHarnessStreamUpdateEvent['event'])
+
+    expect(streamEvent.toJSON()).toStrictEqual({
+      type: 'agentCoreHarnessStreamUpdateEvent',
+      event,
+    })
+  })
+})
+
+describe('AgentCoreHarnessResultEvent', () => {
+  it('serializes the result without a private agent reference', () => {
+    const result = new AgentResult({
+      stopReason: 'endTurn',
+      lastMessage: new Message({ role: 'assistant', content: [new TextBlock('done')] }),
+      invocationState: {},
+    })
+
+    const resultEvent = new AgentCoreHarnessResultEvent({ result })
+
+    expect(resultEvent.toJSON()).toStrictEqual({ type: 'agentCoreHarnessResultEvent', result })
+    expect(resultEvent).not.toHaveProperty('agent')
+  })
+})

--- a/src/harness/integrations/strands/__tests__/harness-test-helpers.ts
+++ b/src/harness/integrations/strands/__tests__/harness-test-helpers.ts
@@ -1,0 +1,133 @@
+import {
+  BedrockAgentCoreClient,
+  InvokeHarnessCommand,
+  type InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import {
+  BedrockAgentCoreControlClient,
+  GetHarnessCommand,
+  type HarnessTool,
+} from '@aws-sdk/client-bedrock-agentcore-control'
+import type { JSONValue } from '@strands-agents/sdk'
+import { type MockInstance, vi } from 'vitest'
+import { AgentCoreHarnessAgent } from '../agent.js'
+import type { AgentCoreHarnessStreamUpdateEvent } from '../events.js'
+import type { AgentCoreHarnessAgentConfig } from '../types.js'
+
+export const HARNESS_ARN = 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/TestHarness-abcdefghij'
+export const HARNESS_ID = 'TestHarness-abcdefghij'
+export const RUNTIME_SESSION_ID = 'session-id-padded-to-thirty-three'
+
+export type SendMock = MockInstance<BedrockAgentCoreClient['send']>
+export type ControlSendMock = MockInstance<BedrockAgentCoreControlClient['send']>
+type HarnessEvent = AgentCoreHarnessStreamUpdateEvent['event']
+
+export const harnessEvent = {
+  messageStart: (role: 'assistant' | 'user' = 'assistant'): HarnessEvent =>
+    ({ messageStart: { role } }) as HarnessEvent,
+  textDelta: (text: string): HarnessEvent => ({ contentBlockDelta: { delta: { text } } }) as HarnessEvent,
+  reasoningDelta: (reasoningContent: { text?: string; signature?: string }): HarnessEvent =>
+    ({ contentBlockDelta: { delta: { reasoningContent } } }) as HarnessEvent,
+  toolUseStart: (toolUseId: string, name: string, type: string | null = 'tool_use'): HarnessEvent => {
+    const toolUse = { toolUseId, name, ...(type !== null && { type }) }
+    return { contentBlockStart: { start: { toolUse } } } as HarnessEvent
+  },
+  toolUseDelta: (input: string): HarnessEvent =>
+    ({ contentBlockDelta: { delta: { toolUse: { input } } } }) as HarnessEvent,
+  toolResultStart: (toolUseId: string, status = 'success'): HarnessEvent =>
+    ({ contentBlockStart: { start: { toolResult: { toolUseId, status } } } }) as HarnessEvent,
+  toolResultDelta: (toolResult: Record<string, unknown>[] | string): HarnessEvent =>
+    ({
+      contentBlockDelta: {
+        delta: { toolResult: typeof toolResult === 'string' ? [{ text: toolResult }] : toolResult },
+      },
+    }) as unknown as HarnessEvent,
+  contentBlockStop: (): HarnessEvent => ({ contentBlockStop: {} }) as HarnessEvent,
+  messageStop: (stopReason: string): HarnessEvent => ({ messageStop: { stopReason } }) as HarnessEvent,
+  metadata: (usage: Record<string, number>, latencyMs: number): HarnessEvent =>
+    ({ metadata: { usage, metrics: { latencyMs } } }) as unknown as HarnessEvent,
+}
+
+export async function* harnessStream(
+  ...events: InvokeHarnessStreamOutput[]
+): AsyncGenerator<InvokeHarnessStreamOutput> {
+  yield* events
+}
+
+export function textTurn(text: string): AsyncGenerator<InvokeHarnessStreamOutput> {
+  return harnessStream(
+    harnessEvent.messageStart(),
+    harnessEvent.textDelta(text),
+    harnessEvent.contentBlockStop(),
+    harnessEvent.messageStop('end_turn')
+  )
+}
+
+export function inlineFunctionTurn(
+  ...tools: { toolUseId: string; name: string; input: JSONValue }[]
+): AsyncGenerator<InvokeHarnessStreamOutput> {
+  const events: InvokeHarnessStreamOutput[] = [harnessEvent.messageStart()]
+  for (const tool of tools) {
+    events.push(
+      harnessEvent.toolUseStart(tool.toolUseId, tool.name),
+      harnessEvent.toolUseDelta(JSON.stringify(tool.input)),
+      harnessEvent.contentBlockStop()
+    )
+  }
+  events.push(harnessEvent.messageStop('tool_use'))
+  return harnessStream(...events)
+}
+
+export function createMockClient(...streams: AsyncIterable<InvokeHarnessStreamOutput>[]): {
+  client: BedrockAgentCoreClient
+  send: SendMock
+} {
+  const client = new BedrockAgentCoreClient({ region: 'us-east-1' })
+  const send = vi.spyOn(client, 'send')
+  for (const stream of streams) {
+    send.mockResolvedValueOnce({ stream } as never)
+  }
+  return { client, send }
+}
+
+export function commandInput(send: SendMock, index = 0): InvokeHarnessCommand['input'] {
+  return (send.mock.calls[index]![0] as InvokeHarnessCommand).input
+}
+
+export function createMockControlClient(
+  tools: HarnessTool[] = [],
+  allowedTools?: string[]
+): {
+  client: BedrockAgentCoreControlClient
+  send: ControlSendMock
+} {
+  const client = new BedrockAgentCoreControlClient({ region: 'us-east-1' })
+  const send = vi.spyOn(client, 'send').mockResolvedValue({ harness: { tools, allowedTools } } as never)
+  return { client, send }
+}
+
+export function getHarnessInput(send: ControlSendMock, index = 0): GetHarnessCommand['input'] {
+  return (send.mock.calls[index]![0] as GetHarnessCommand).input
+}
+
+export function createHarnessAgent(config: Partial<AgentCoreHarnessAgentConfig> = {}): AgentCoreHarnessAgent {
+  const { controlClient = createMockControlClient().client, ...overrides } = config
+  return new AgentCoreHarnessAgent({
+    harnessArn: HARNESS_ARN,
+    runtimeSessionId: RUNTIME_SESSION_ID,
+    controlClient,
+    ...overrides,
+  })
+}
+
+export async function collectGenerator<T, R>(
+  generator: AsyncGenerator<T, R, undefined>
+): Promise<{ items: T[]; result: R }> {
+  const items: T[] = []
+  let next = await generator.next()
+  while (!next.done) {
+    items.push(next.value)
+    next = await generator.next()
+  }
+  return { items, result: next.value }
+}

--- a/src/harness/integrations/strands/__tests__/inline-functions.test.ts
+++ b/src/harness/integrations/strands/__tests__/inline-functions.test.ts
@@ -1,0 +1,747 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import {
+  BeforeToolCallEvent,
+  ConcurrentInvocationError,
+  FunctionTool,
+  InterruptResponseContent,
+  InterventionActions,
+  InterventionHandler,
+} from '@strands-agents/sdk'
+import type { ToolContext } from '@strands-agents/sdk'
+import {
+  HARNESS_ARN,
+  HARNESS_ID,
+  RUNTIME_SESSION_ID,
+  commandInput,
+  createHarnessAgent,
+  createMockControlClient,
+  createMockClient,
+  getHarnessInput,
+  harnessEvent,
+  harnessStream,
+  inlineFunctionTurn,
+  textTurn,
+} from './harness-test-helpers.js'
+
+class ConfirmToolCall extends InterventionHandler {
+  readonly name = 'confirm-tool-call'
+
+  override beforeToolCall(event: BeforeToolCallEvent): ReturnType<(typeof InterventionActions)['confirm']> {
+    return InterventionActions.confirm(`Approve ${event.toolUse.name}?`)
+  }
+}
+
+class UnsupportedLifecycleIntervention extends InterventionHandler {
+  readonly name = 'unsupported-lifecycle'
+
+  override beforeInvocation(): ReturnType<(typeof InterventionActions)['guide']> {
+    return InterventionActions.guide('Replace the invocation')
+  }
+
+  override beforeModelCall(): ReturnType<(typeof InterventionActions)['guide']> {
+    return InterventionActions.guide('Replace the request')
+  }
+
+  override afterModelCall(): ReturnType<(typeof InterventionActions)['guide']> {
+    return InterventionActions.guide('Try again')
+  }
+}
+
+class RewriteToolUseId extends InterventionHandler {
+  readonly name = 'rewrite-tool-use-id'
+
+  override beforeToolCall(event: BeforeToolCallEvent): ReturnType<(typeof InterventionActions)['transform']> {
+    return InterventionActions.transform(() => {
+      event.toolUse.toolUseId = 'rewritten-id'
+    })
+  }
+}
+
+describe('AgentCoreHarnessAgent', () => {
+  describe('inline functions', () => {
+    it('rejects model lifecycle interventions', () => {
+      expect(() => createHarnessAgent({ interventions: [new UnsupportedLifecycleIntervention()] })).toThrow(
+        "intervention 'unsupported-lifecycle' overrides unsupported lifecycle methods: " +
+          'beforeInvocation, beforeModelCall, afterModelCall'
+      )
+    })
+
+    it('executes text and JSON callbacks and continues the same Harness session', async () => {
+      const weather = vi.fn((_input: unknown): string => '72F')
+      const profile = vi.fn((_input: unknown): { units: string } => ({ units: 'fahrenheit' }))
+      const weatherTool = new FunctionTool({
+        name: 'get_weather',
+        description: 'Get weather',
+        inputSchema: {
+          type: 'object',
+          properties: { city: { type: 'string' } },
+          required: ['city'],
+          additionalProperties: false,
+        },
+        callback: weather,
+      })
+      const profileTool = new FunctionTool({
+        name: 'get_profile',
+        description: 'Get preferences',
+        callback: profile,
+      })
+      const deployedTools = [
+        {
+          type: 'remote_mcp' as const,
+          name: 'deployed_search',
+          config: { remoteMcp: { url: 'https://example.com/mcp' } },
+        },
+        {
+          type: 'inline_function' as const,
+          name: 'get_weather',
+          config: {
+            inlineFunction: {
+              description: 'Deployed weather callback',
+              inputSchema: { type: 'object' },
+            },
+          },
+        },
+      ]
+      const expectedTools = [
+        deployedTools[0],
+        {
+          type: 'inline_function',
+          name: 'get_weather',
+          config: {
+            inlineFunction: {
+              description: 'Get weather',
+              inputSchema: {
+                type: 'object',
+                properties: { city: { type: 'string' } },
+                required: ['city'],
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+        {
+          type: 'inline_function',
+          name: 'get_profile',
+          config: {
+            inlineFunction: {
+              description: 'Get preferences',
+              inputSchema: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+      ]
+      const { client, send } = createMockClient(
+        inlineFunctionTurn(
+          { toolUseId: 'weather-1', name: 'get_weather', input: { city: 'Seattle' } },
+          { toolUseId: 'profile-1', name: 'get_profile', input: {} }
+        ),
+        textTurn('It is 72F in Seattle.')
+      )
+      const { client: controlClient, send: getHarness } = createMockControlClient(deployedTools, ['deployed_search'])
+      const agent = createHarnessAgent({
+        client,
+        controlClient,
+        tools: [weatherTool, profileTool],
+      })
+
+      const result = await agent.invoke('What is the weather?')
+
+      expect(result.toString()).toBe('It is 72F in Seattle.')
+      expect(weather.mock.calls.map(([input]) => input)).toStrictEqual([{ city: 'Seattle' }])
+      expect(profile.mock.calls.map(([input]) => input)).toStrictEqual([{}])
+      expect(getHarness).toHaveBeenCalledOnce()
+      expect(getHarnessInput(getHarness)).toStrictEqual({ harnessId: HARNESS_ID })
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(commandInput(send, 0)).toStrictEqual({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        messages: [{ role: 'user', content: [{ text: 'What is the weather?' }] }],
+        tools: expectedTools,
+        allowedTools: ['deployed_search', 'get_weather', 'get_profile'],
+      })
+      expect(commandInput(send, 1)).toStrictEqual({
+        harnessArn: HARNESS_ARN,
+        runtimeSessionId: RUNTIME_SESSION_ID,
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              {
+                toolUse: {
+                  name: 'get_weather',
+                  toolUseId: 'weather-1',
+                  input: { city: 'Seattle' },
+                  type: 'tool_use',
+                },
+              },
+              {
+                toolUse: {
+                  name: 'get_profile',
+                  toolUseId: 'profile-1',
+                  input: {},
+                  type: 'tool_use',
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            content: [
+              {
+                toolResult: {
+                  toolUseId: 'weather-1',
+                  status: 'success',
+                  type: 'tool_use',
+                  content: [{ text: '72F' }],
+                },
+              },
+              {
+                toolResult: {
+                  toolUseId: 'profile-1',
+                  status: 'success',
+                  type: 'tool_use',
+                  content: [{ text: '{"units":"fahrenheit"}' }],
+                },
+              },
+            ],
+          },
+        ],
+        tools: expectedTools,
+        allowedTools: ['deployed_search', 'get_weather', 'get_profile'],
+      })
+    })
+
+    it.each([
+      {
+        label: 'a callback failure',
+        tools: [
+          new FunctionTool({
+            name: 'failing_tool',
+            description: 'Fails',
+            callback: (): never => {
+              throw new Error('callback failed')
+            },
+          }),
+        ],
+        name: 'failing_tool',
+        expectedMessage: 'Error: callback failed',
+      },
+      {
+        label: 'an unknown callback',
+        tools: [],
+        name: 'missing_tool',
+        expectedMessage: "Tool 'missing_tool' not found in registry",
+      },
+      {
+        label: 'unsupported callback content',
+        tools: [
+          new FunctionTool({
+            name: 'capture_image',
+            description: 'Capture an image',
+            callback: () => ({
+              image: {
+                format: 'png',
+                source: { url: 'https://example.com/image.png' },
+              },
+            }),
+          }),
+        ],
+        name: 'capture_image',
+        expectedMessage:
+          'AgentCoreHarnessAgent supports only text and JSON inline-function results; received imageBlock.',
+      },
+    ])('returns $label to the Harness as an error result', async ({ tools, name, expectedMessage }) => {
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'tool-1', name, input: {} }),
+        textTurn('Handled the tool error.')
+      )
+      const agent = createHarnessAgent({ client, tools })
+
+      const result = await agent.invoke('Run the tool.')
+
+      expect(result.toString()).toBe('Handled the tool error.')
+      expect(commandInput(send, 1).messages![1]!.content).toStrictEqual([
+        {
+          toolResult: {
+            toolUseId: 'tool-1',
+            status: 'error',
+            type: 'tool_use',
+            content: [{ text: expectedMessage }],
+          },
+        },
+      ])
+    })
+
+    it('preserves the Harness tool-use ID when an intervention rewrites the local ID', async () => {
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'service-id', name: 'local_tool', input: {} }),
+        textTurn('Completed.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'local_tool', description: 'Run locally', callback: () => 'done' })],
+        interventions: [new RewriteToolUseId()],
+      })
+
+      await agent.invoke('Run it.')
+
+      expect(commandInput(send, 1).messages).toStrictEqual([
+        {
+          role: 'assistant',
+          content: [
+            {
+              toolUse: {
+                name: 'local_tool',
+                toolUseId: 'service-id',
+                input: {},
+                type: 'tool_use',
+              },
+            },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              toolResult: {
+                toolUseId: 'service-id',
+                status: 'success',
+                type: 'tool_use',
+                content: [{ text: 'done' }],
+              },
+            },
+          ],
+        },
+      ])
+    })
+
+    it('pauses for an intervention and resumes after approval without repeating the Harness call', async () => {
+      const callback = vi.fn((_input: unknown): string => 'deleted')
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'delete-1', name: 'delete_record', input: { id: '123' } }),
+        textTurn('Record deleted.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'delete_record', description: 'Delete a record', callback })],
+        interventions: [new ConfirmToolCall()],
+      })
+
+      const interrupted = await agent.invoke('Delete record 123.')
+
+      expect(interrupted).toMatchObject({
+        stopReason: 'interrupt',
+        interrupts: [{ name: 'confirm-tool-call', reason: 'Approve delete_record?' }],
+      })
+      expect(callback).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledOnce()
+
+      const result = await agent.invoke([
+        new InterruptResponseContent({
+          interruptId: interrupted.interrupts![0]!.id,
+          response: 'yes',
+        }),
+      ])
+
+      expect(result.toString()).toBe('Record deleted.')
+      expect(callback).toHaveBeenCalledOnce()
+      expect(send).toHaveBeenCalledTimes(2)
+    })
+
+    it('returns a denied intervention to the Harness without executing the callback', async () => {
+      const callback = vi.fn((_input: unknown): string => 'must not execute')
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'delete-1', name: 'delete_record', input: { id: '123' } }),
+        textTurn('Deletion was denied.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'delete_record', description: 'Delete a record', callback })],
+        interventions: [new ConfirmToolCall()],
+      })
+      const interrupted = await agent.invoke('Delete record 123.')
+
+      const result = await agent.invoke([
+        new InterruptResponseContent({
+          interruptId: interrupted.interrupts![0]!.id,
+          response: 'no',
+        }),
+      ])
+
+      expect(result.toString()).toBe('Deletion was denied.')
+      expect(callback).not.toHaveBeenCalled()
+      expect(commandInput(send, 1).messages![1]!.content![0]).toMatchObject({
+        toolResult: { toolUseId: 'delete-1', status: 'error' },
+      })
+    })
+
+    it('resumes an interrupt raised inside the inline-function callback', async () => {
+      const callback = vi.fn((_input: unknown, context: ToolContext): string => {
+        const response = context.interrupt<string>({
+          name: 'provide_code',
+          reason: 'Provide the authorization code',
+        })
+        return `code=${response}`
+      })
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'authorize-1', name: 'authorize', input: {} }),
+        textTurn('Authorized.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'authorize', description: 'Authorize an action', callback })],
+      })
+
+      const interrupted = await agent.invoke('Authorize the action.')
+      const result = await agent.invoke([
+        new InterruptResponseContent({
+          interruptId: interrupted.interrupts![0]!.id,
+          response: 'ABC123',
+        }),
+      ])
+
+      expect(interrupted).toMatchObject({
+        stopReason: 'interrupt',
+        interrupts: [{ name: 'provide_code', reason: 'Provide the authorization code' }],
+      })
+      expect(result.toString()).toBe('Authorized.')
+      expect(callback).toHaveBeenCalledTimes(2)
+      expect(commandInput(send, 1).messages![1]!.content![0]).toMatchObject({
+        toolResult: { status: 'success', content: [{ text: 'code=ABC123' }] },
+      })
+    })
+
+    it.each(['server_tool_use', 'mcp_tool_use'])(
+      'does not execute %s events as local callbacks',
+      async (toolUseType) => {
+        const callback = vi.fn((_input: unknown): string => 'must not execute')
+        const { client, send } = createMockClient(
+          harnessStream(
+            harnessEvent.messageStart(),
+            harnessEvent.toolUseStart('browser-1', 'browser', toolUseType),
+            harnessEvent.toolUseDelta('{"url":"https://example.com"}'),
+            harnessEvent.contentBlockStop(),
+            harnessEvent.messageStop('tool_use'),
+            harnessEvent.messageStart('user'),
+            harnessEvent.toolResultStart('browser-1'),
+            harnessEvent.toolResultDelta('Example Domain'),
+            harnessEvent.contentBlockStop(),
+            harnessEvent.messageStop('tool_result'),
+            harnessEvent.messageStart(),
+            harnessEvent.textDelta('The page is Example Domain.'),
+            harnessEvent.contentBlockStop(),
+            harnessEvent.messageStop('end_turn')
+          )
+        )
+        const agent = createHarnessAgent({
+          client,
+          tools: [new FunctionTool({ name: 'browser', description: 'Browse', callback })],
+        })
+
+        const result = await agent.invoke('Open example.com.')
+
+        expect(result.toString()).toBe('The page is Example Domain.')
+        expect(callback).not.toHaveBeenCalled()
+        expect(send).toHaveBeenCalledOnce()
+      }
+    )
+
+    it('does not execute a terminal tool use with an omitted type', async () => {
+      const callback = vi.fn((_input: unknown): string => 'must not execute')
+      const { client, send } = createMockClient(
+        harnessStream(
+          harnessEvent.messageStart(),
+          harnessEvent.toolUseStart('tool-1', 'local_tool', null),
+          harnessEvent.toolUseDelta('{"url":"https://example.com"}'),
+          harnessEvent.contentBlockStop(),
+          harnessEvent.messageStop('tool_use')
+        )
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'local_tool', description: 'Run locally', callback })],
+      })
+
+      await expect(agent.invoke('Run it.')).rejects.toThrow('Harness returned an incomplete non-inline tool call.')
+
+      expect(callback).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledOnce()
+    })
+
+    it('keeps the active callback invocation isolated from a rejected concurrent call', async () => {
+      let markCallbackStarted: () => void = () => {}
+      let finishCallback: (result: string) => void = () => {}
+      const callbackStarted = new Promise<void>((resolve) => {
+        markCallbackStarted = resolve
+      })
+      const callbackResult = new Promise<string>((resolve) => {
+        finishCallback = resolve
+      })
+      const callback = vi.fn(async (): Promise<string> => {
+        markCallbackStarted()
+        return callbackResult
+      })
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'tool-1', name: 'local_tool', input: {} }),
+        textTurn('Completed the first invocation.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'local_tool', description: 'Run locally', callback })],
+      })
+
+      const first = agent.invoke('First invocation.')
+      await callbackStarted
+      const concurrentRejection = await agent
+        .invoke('Second invocation.', { cancelSignal: AbortSignal.abort() })
+        .catch((error: unknown) => error)
+      finishCallback('done')
+      const result = await first
+
+      expect(concurrentRejection).toBeInstanceOf(ConcurrentInvocationError)
+      expect(result.toString()).toBe('Completed the first invocation.')
+      expect(send).toHaveBeenCalledTimes(2)
+    })
+
+    it('cancels the continuation request after an inline function executes', async () => {
+      const controller = new AbortController()
+      async function* cancelledContinuation(): AsyncGenerator<InvokeHarnessStreamOutput> {
+        yield harnessEvent.messageStart()
+        yield harnessEvent.textDelta('partial continuation')
+        controller.abort()
+        throw new Error('aborted')
+      }
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'tool-1', name: 'local_tool', input: {} }),
+        cancelledContinuation()
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'local_tool', description: 'Local tool', callback: () => 'done' })],
+      })
+
+      const result = await agent.invoke('Run it.', { cancelSignal: controller.signal })
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(result.toString()).toBe('partial continuation')
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(send.mock.calls[1]![1]).toStrictEqual({ abortSignal: expect.any(AbortSignal) })
+      expect((send.mock.calls[1]![1] as { abortSignal: AbortSignal }).abortSignal.aborted).toBe(true)
+    })
+
+    it('resolves a completed inline call when cancellation wins after message stop', async () => {
+      const controller = new AbortController()
+      async function* completedThenCancelled(): AsyncGenerator<InvokeHarnessStreamOutput> {
+        yield* inlineFunctionTurn({ toolUseId: 'tool-1', name: 'local_tool', input: {} })
+        controller.abort()
+      }
+      const callback = vi.fn((): string => 'must not execute')
+      const { client, send } = createMockClient(completedThenCancelled(), textTurn('Remote turn resolved.'))
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'local_tool', description: 'Local tool', callback })],
+      })
+
+      const result = await agent.invoke('Run it.', { cancelSignal: controller.signal })
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(callback).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(commandInput(send, 1).messages![1]!.content).toStrictEqual([
+        {
+          toolResult: {
+            toolUseId: 'tool-1',
+            status: 'error',
+            type: 'tool_use',
+            content: [{ text: 'Tool execution cancelled' }],
+          },
+        },
+      ])
+    })
+
+    it('cancels a pre-aborted HITL resume without executing its callback', async () => {
+      const callback = vi.fn((): string => 'must not execute')
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'delete-1', name: 'delete_record', input: { id: '123' } }),
+        textTurn('Remote turn resolved.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'delete_record', description: 'Delete a record', callback })],
+        interventions: [new ConfirmToolCall()],
+      })
+      const interrupted = await agent.invoke('Delete record 123.')
+
+      const result = await agent.invoke(
+        [
+          new InterruptResponseContent({
+            interruptId: interrupted.interrupts![0]!.id,
+            response: 'yes',
+          }),
+        ],
+        { cancelSignal: AbortSignal.abort() }
+      )
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(callback).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(commandInput(send, 1).messages![1]!.content).toStrictEqual([
+        {
+          toolResult: {
+            toolUseId: 'delete-1',
+            status: 'error',
+            type: 'tool_use',
+            content: [{ text: 'Tool execution cancelled' }],
+          },
+        },
+      ])
+    })
+
+    it('submits the inline-function result before returning cancellation during a callback', async () => {
+      const controller = new AbortController()
+      let markCallbackStarted: () => void = () => {}
+      let finishCallback: () => void = () => {}
+      const callbackStarted = new Promise<void>((resolve) => {
+        markCallbackStarted = resolve
+      })
+      const callbackFinished = new Promise<void>((resolve) => {
+        finishCallback = resolve
+      })
+      const callback = vi.fn(async (_input: unknown, context: ToolContext): Promise<string> => {
+        markCallbackStarted()
+        await callbackFinished
+        expect(context.agent.cancelSignal.aborted).toBe(true)
+        return 'done'
+      })
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'tool-1', name: 'local_tool', input: {} }),
+        textTurn('Remote turn resolved.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [new FunctionTool({ name: 'local_tool', description: 'Run locally', callback })],
+      })
+
+      const invocation = agent.invoke('Run it.', { cancelSignal: controller.signal })
+      await callbackStarted
+      controller.abort()
+      finishCallback()
+      const result = await invocation
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(send).toHaveBeenCalledTimes(2)
+      expect(commandInput(send, 1).messages![1]!.content).toStrictEqual([
+        {
+          toolResult: {
+            toolUseId: 'tool-1',
+            status: 'success',
+            type: 'tool_use',
+            content: [{ text: 'done' }],
+          },
+        },
+      ])
+    })
+
+    it('cancels additional inline functions requested while resolving cancellation', async () => {
+      const controller = new AbortController()
+      let markCallbackStarted: () => void = () => {}
+      let finishCallback: () => void = () => {}
+      const callbackStarted = new Promise<void>((resolve) => {
+        markCallbackStarted = resolve
+      })
+      const callbackFinished = new Promise<void>((resolve) => {
+        finishCallback = resolve
+      })
+      const firstCallback = vi.fn(async (): Promise<string> => {
+        markCallbackStarted()
+        await callbackFinished
+        return 'first result'
+      })
+      const secondCallback = vi.fn((): string => 'must not execute')
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'first-1', name: 'first_tool', input: {} }),
+        inlineFunctionTurn({ toolUseId: 'second-1', name: 'second_tool', input: {} }),
+        textTurn('Remote turn resolved.')
+      )
+      const agent = createHarnessAgent({
+        client,
+        tools: [
+          new FunctionTool({ name: 'first_tool', description: 'First local tool', callback: firstCallback }),
+          new FunctionTool({ name: 'second_tool', description: 'Second local tool', callback: secondCallback }),
+        ],
+      })
+
+      const invocation = agent.invoke('Run it.', { cancelSignal: controller.signal })
+      await callbackStarted
+      controller.abort()
+      finishCallback()
+      const result = await invocation
+
+      expect(result.stopReason).toBe('cancelled')
+      expect(firstCallback).toHaveBeenCalledOnce()
+      expect(secondCallback).not.toHaveBeenCalled()
+      expect(send).toHaveBeenCalledTimes(3)
+      expect(commandInput(send, 2).messages![1]!.content).toStrictEqual([
+        {
+          toolResult: {
+            toolUseId: 'second-1',
+            status: 'error',
+            type: 'tool_use',
+            content: [{ text: 'Tool execution cancelled' }],
+          },
+        },
+      ])
+    })
+
+    it('clears cancellation state when a cleanup continuation request fails', async () => {
+      const controller = new AbortController()
+      let markCallbackStarted: () => void = () => {}
+      let finishCallback: () => void = () => {}
+      const callbackStarted = new Promise<void>((resolve) => {
+        markCallbackStarted = resolve
+      })
+      const callbackFinished = new Promise<void>((resolve) => {
+        finishCallback = resolve
+      })
+      const firstCallback = vi.fn(async (): Promise<string> => {
+        markCallbackStarted()
+        await callbackFinished
+        return 'first result'
+      })
+      const secondCallback = vi.fn((): string => 'second result')
+      const { client, send } = createMockClient(
+        inlineFunctionTurn({ toolUseId: 'first-1', name: 'first_tool', input: {} })
+      )
+      send.mockRejectedValueOnce(new Error('cleanup failed') as never)
+      send.mockResolvedValueOnce({
+        stream: inlineFunctionTurn({ toolUseId: 'second-1', name: 'second_tool', input: {} }),
+      } as never)
+      send.mockResolvedValueOnce({ stream: textTurn('Second invocation completed.') } as never)
+      const agent = createHarnessAgent({
+        client,
+        tools: [
+          new FunctionTool({ name: 'first_tool', description: 'First local tool', callback: firstCallback }),
+          new FunctionTool({ name: 'second_tool', description: 'Second local tool', callback: secondCallback }),
+        ],
+      })
+
+      const firstInvocation = agent.invoke('Run the first tool.', { cancelSignal: controller.signal })
+      await callbackStarted
+      controller.abort()
+      finishCallback()
+      await expect(firstInvocation).rejects.toThrow('cleanup failed')
+
+      const secondResult = await agent.invoke('Run the second tool.')
+
+      expect(secondCallback).toHaveBeenCalledOnce()
+      expect(secondResult.stopReason).toBe('endTurn')
+      expect(secondResult.toString()).toBe('Second invocation completed.')
+      expect(send).toHaveBeenCalledTimes(4)
+    })
+  })
+})

--- a/src/harness/integrations/strands/__tests__/stream-decoder.test.ts
+++ b/src/harness/integrations/strands/__tests__/stream-decoder.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import { JsonBlock, Message, ModelError, ReasoningBlock, TextBlock, ToolResultBlock } from '@strands-agents/sdk'
+import { HarnessStreamDecoder } from '../stream-decoder.js'
+import { harnessEvent } from './harness-test-helpers.js'
+
+function decode(...events: InvokeHarnessStreamOutput[]): ReturnType<HarnessStreamDecoder['complete']> {
+  const decoder = new HarnessStreamDecoder()
+  for (const event of events) decoder.accept(event)
+  return decoder.complete()
+}
+
+describe('HarnessStreamDecoder', () => {
+  it('emits model events and reconstructs the final message from one fold', () => {
+    const decoder = new HarnessStreamDecoder()
+    const modelEvents = [
+      harnessEvent.messageStart(),
+      harnessEvent.textDelta('Done.'),
+      harnessEvent.contentBlockStop(),
+      harnessEvent.messageStop('end_turn'),
+    ].flatMap((streamEvent) => decoder.accept(streamEvent))
+
+    expect(modelEvents.map(({ type }) => type)).toStrictEqual([
+      'modelMessageStartEvent',
+      'modelContentBlockStartEvent',
+      'modelContentBlockDeltaEvent',
+      'modelContentBlockStopEvent',
+      'modelMessageStopEvent',
+    ])
+    expect(decoder.complete()).toStrictEqual({
+      message: new Message({ role: 'assistant', content: [new TextBlock('Done.')] }),
+      stopReason: 'endTurn',
+    })
+  })
+
+  describe('complete', () => {
+    it('keeps the latest message and assembles its reasoning and text blocks', () => {
+      const result = decode(
+        harnessEvent.messageStart(),
+        harnessEvent.textDelta('superseded'),
+        harnessEvent.messageStop('end_turn'),
+        harnessEvent.messageStart('user'),
+        harnessEvent.messageStop('tool_result'),
+        harnessEvent.messageStart(),
+        harnessEvent.reasoningDelta({ text: 'considering' }),
+        harnessEvent.reasoningDelta({ signature: 'signed' }),
+        harnessEvent.contentBlockStop(),
+        harnessEvent.textDelta('Complete.'),
+        harnessEvent.contentBlockStop(),
+        harnessEvent.messageStop('end_turn')
+      )
+
+      expect(result).toStrictEqual({
+        message: new Message({
+          role: 'assistant',
+          content: [new ReasoningBlock({ text: 'considering', signature: 'signed' }), new TextBlock('Complete.')],
+        }),
+        stopReason: 'endTurn',
+      })
+    })
+
+    it('decodes text and JSON content from an error tool result', () => {
+      const result = decode(
+        harnessEvent.messageStart(),
+        harnessEvent.toolResultStart('tool-1', 'error'),
+        harnessEvent.toolResultDelta([{ text: 'boom' }, { json: { code: 42 } }]),
+        harnessEvent.contentBlockStop(),
+        harnessEvent.messageStop('tool_result')
+      )
+
+      expect(result).toStrictEqual({
+        message: new Message({
+          role: 'assistant',
+          content: [
+            new ToolResultBlock({
+              toolUseId: 'tool-1',
+              status: 'error',
+              content: [new TextBlock('boom'), new JsonBlock({ json: { code: 42 } })],
+            }),
+          ],
+        }),
+        stopReason: 'toolResult',
+      })
+    })
+
+    it.each([
+      {
+        label: 'content before message start',
+        events: [harnessEvent.textDelta('orphaned')],
+      },
+      {
+        label: 'a tool-use delta without a block start',
+        events: [harnessEvent.messageStart(), harnessEvent.toolUseDelta('{}')],
+      },
+      {
+        label: 'an unknown block start',
+        events: [
+          harnessEvent.messageStart(),
+          { contentBlockStart: { start: { $unknown: ['futureBlock', {}] } } } as InvokeHarnessStreamOutput,
+        ],
+      },
+    ])('rejects $label', ({ events }) => {
+      expect(() => decode(...events)).toThrow(ModelError)
+    })
+
+    it('rejects a stream without a completed message', () => {
+      const decoder = new HarnessStreamDecoder()
+      decoder.accept(harnessEvent.messageStart())
+      decoder.accept(harnessEvent.textDelta('no stop event'))
+
+      expect(() => decoder.complete()).toThrow(
+        new ModelError('AgentCore Harness stream ended without completing a message')
+      )
+    })
+  })
+})

--- a/src/harness/integrations/strands/agent.ts
+++ b/src/harness/integrations/strands/agent.ts
@@ -1,0 +1,334 @@
+import { BedrockAgentCoreClient, type InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import { BedrockAgentCoreControlClient } from '@aws-sdk/client-bedrock-agentcore-control'
+import {
+  AfterInvocationEvent,
+  Agent,
+  AgentResult,
+  BeforeToolsEvent,
+  ConcurrentInvocationError,
+  InterventionHandler,
+  MessageAddedEvent,
+} from '@strands-agents/sdk'
+import type { InvokeArgs, InvokeOptions, Message, ToolResultBlock } from '@strands-agents/sdk'
+import { AgentCoreHarnessResultEvent, AgentCoreHarnessStreamUpdateEvent } from './events.js'
+import type { AgentCoreHarnessStreamEvent } from './events.js'
+import { HarnessModel } from './model.js'
+import type { AgentCoreHarnessAgentConfig } from './types.js'
+
+const DEFAULT_MAX_ATTEMPTS = 1
+
+/**
+ * Adapts one deployed [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html)
+ * to the Strands `InvokableAgent` interface, so a Harness composes into a Strands `Graph`.
+ *
+ * The deployed Harness owns its model, system prompt, tools, skills, memory, limits, and server-side
+ * agent loop. Local Strands tools registered through `tools` are translated into per-invocation
+ * Harness `inline_function` definitions and merged with the deployed tools. Strands owns local tool
+ * execution, interventions, and human-in-the-loop interrupt/resume behavior.
+ *
+ * @example
+ * ```typescript
+ * import { randomUUID } from 'node:crypto'
+ * import { FunctionTool } from '@strands-agents/sdk'
+ * import { AgentCoreHarnessAgent } from 'bedrock-agentcore/experimental/harness/strands'
+ *
+ * const getWeather = new FunctionTool({
+ *   name: 'get_weather',
+ *   description: 'Get the current weather',
+ *   inputSchema: {
+ *     type: 'object',
+ *     properties: { city: { type: 'string' } },
+ *     required: ['city'],
+ *   },
+ *   callback: async (input) => {
+ *     const { city } = input as { city: string }
+ *     return fetchWeather(city)
+ *   },
+ * })
+ *
+ * const agent = new AgentCoreHarnessAgent({
+ *   harnessArn: process.env.AGENTCORE_HARNESS_ARN!,
+ *   runtimeSessionId: randomUUID(),
+ *   tools: [getWeather],
+ * })
+ *
+ * const result = await agent.invoke('What is the weather in Seattle?')
+ * console.log(result.toString())
+ * ```
+ */
+export class AgentCoreHarnessAgent {
+  private readonly _agent: Agent
+  private readonly _model: HarnessModel
+  private _isInvoking = false
+  private _cancelRequested = false
+  private _cancelledToolResults: Message | undefined
+
+  /** Identifier unique to this Harness session. */
+  readonly id: string
+
+  /** Name surfaced to Strands multi-agent primitives. */
+  readonly name?: string
+
+  /** Description surfaced to Strands multi-agent primitives. */
+  readonly description?: string
+
+  /**
+   * Creates a Harness adapter.
+   *
+   * @param config - Harness identity, dynamic inline-function tools, and optional client configuration
+   */
+  constructor(config: AgentCoreHarnessAgentConfig) {
+    this.id = config.id ?? `${config.harnessArn}:${config.runtimeSessionId}`
+    if (config.name !== undefined) this.name = config.name
+    if (config.description !== undefined) this.description = config.description
+
+    // Harness identifiers are validated by AgentCore, not here: the service owns the ARN and
+    // session-ID formats, and duplicating them client-side would reject valid future shapes.
+    const client = config.client ?? new BedrockAgentCoreClient({ maxAttempts: DEFAULT_MAX_ATTEMPTS })
+    const controlClient = config.controlClient ?? new BedrockAgentCoreControlClient({})
+    assertSupportedInterventions(config.interventions)
+
+    this._model = new HarnessModel({
+      client,
+      controlClient,
+      harnessArn: config.harnessArn,
+      runtimeSessionId: config.runtimeSessionId,
+    })
+    this._agent = new Agent({
+      model: this._model,
+      id: this.id,
+      printer: false,
+      retryStrategy: null,
+      tools: config.tools ?? [],
+      ...(this.name !== undefined && { name: this.name }),
+      ...(this.description !== undefined && { description: this.description }),
+      ...(config.interventions !== undefined && { interventions: config.interventions }),
+    })
+    this._agent.addHook(BeforeToolsEvent, () => this._cancelPendingTools())
+    this._agent.addHook(MessageAddedEvent, (event) => this._captureCancelledToolResults(event))
+    this._agent.addHook(AfterInvocationEvent, (event) => this._resumeCancelledInlineFunction(event))
+  }
+
+  /**
+   * Invokes the deployed Harness, executes requested inline functions locally, and returns the final
+   * result.
+   *
+   * @param args - Text, message input, or interrupt responses for a paused inline function
+   * @param options - Cancellation and invocation state; other options are unsupported
+   * @returns Final Harness result after all local inline-function callbacks complete
+   * @throws {@link https://strandsagents.com | ConcurrentInvocationError} If this instance is already invoking
+   * @throws TypeError If input or invocation options are unsupported
+   * @throws {@link https://strandsagents.com | ModelThrottledError} If AgentCore reports throttling
+   * @throws {@link https://strandsagents.com | ModelError} If AgentCore or the Harness stream fails
+   */
+  async invoke(args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+    const generator = this.stream(args, options)
+    let next = await generator.next()
+    while (!next.done) {
+      next = await generator.next()
+    }
+    return next.value
+  }
+
+  /**
+   * Streams every raw event from all Harness requests in the turn, followed by one final result event.
+   *
+   * A turn can contain multiple Harness requests when an inline function executes locally. Events from
+   * every request are yielded in arrival order under the same `runtimeSessionId`.
+   *
+   * @param args - Text, message input, or interrupt responses for a paused inline function
+   * @param options - Cancellation and invocation state; other options are unsupported
+   * @returns Raw Harness events followed by the final result event and generator return value
+   * @throws {@link https://strandsagents.com | ConcurrentInvocationError} If this instance is already invoking
+   * @throws TypeError If input or invocation options are unsupported
+   * @throws {@link https://strandsagents.com | ModelThrottledError} If AgentCore reports throttling
+   * @throws {@link https://strandsagents.com | ModelError} If AgentCore or the Harness stream fails
+   */
+  async *stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentCoreHarnessStreamEvent, AgentResult, undefined> {
+    this._acquireLock()
+    this._cancelRequested = false
+    this._cancelledToolResults = undefined
+    let generator: ReturnType<Agent['stream']> | undefined
+    let completed = false
+    const rawEvents = new RawEventQueue()
+    const transportAbortController = new AbortController()
+    const cancelSignal = options?.cancelSignal
+    const cancelInvocation = (): void => {
+      this._cancelRequested = true
+      if (this._model.isInvokingHarness) {
+        transportAbortController.abort()
+      } else {
+        this._agent.cancel()
+      }
+    }
+    try {
+      assertSupportedInvocation(args, options)
+      if (cancelSignal?.aborted) {
+        this._cancelRequested = true
+        transportAbortController.abort()
+      } else {
+        cancelSignal?.addEventListener('abort', cancelInvocation, { once: true })
+      }
+      this._model.resetInvocationState(transportAbortController.signal, (event) => rawEvents.push(event))
+
+      generator = this._agent.stream(args, withoutCancelSignal(options))
+      let emittedResult: AgentResult | undefined
+      let agentOutcome = generator.next().then((next) => ({ type: 'agent' as const, next }))
+
+      while (true) {
+        const outcome = await Promise.race([agentOutcome, rawEvents.wait().then(() => ({ type: 'raw' as const }))])
+        yield* rawEventUpdates(rawEvents.drain())
+
+        if (outcome.type === 'raw') continue
+        if (outcome.next.done) {
+          const result = emittedResult ?? outcome.next.value
+          completed = true
+          yield new AgentCoreHarnessResultEvent({ result })
+          return result
+        }
+
+        if (outcome.next.value.type === 'agentResultEvent') {
+          emittedResult = outcome.next.value.result
+        }
+        agentOutcome = generator.next().then((next) => ({ type: 'agent' as const, next }))
+      }
+    } catch (error) {
+      yield* rawEventUpdates(rawEvents.drain())
+      throw error
+    } finally {
+      cancelSignal?.removeEventListener('abort', cancelInvocation)
+      try {
+        if (generator !== undefined && !completed) {
+          transportAbortController.abort()
+        }
+        if (generator !== undefined && !completed) {
+          await generator.return(undefined as never)
+        }
+      } finally {
+        this._model.clearInvocationState()
+        this._isInvoking = false
+      }
+    }
+  }
+
+  private _acquireLock(): void {
+    if (this._isInvoking) {
+      throw new ConcurrentInvocationError(
+        'AgentCoreHarnessAgent is already processing an invocation. ' +
+          'Wait for the current invoke() or stream() call to complete before invoking again.'
+      )
+    }
+    this._isInvoking = true
+  }
+
+  private _captureCancelledToolResults(event: MessageAddedEvent): void {
+    if (!this._cancelRequested || !this._model.hasPendingInlineFunctions || event.message.role !== 'user') return
+
+    const toolResults = event.message.content.filter(
+      (block): block is ToolResultBlock => block.type === 'toolResultBlock'
+    )
+    if (toolResults.length === event.message.content.length && toolResults.length > 0) {
+      this._cancelledToolResults = event.message
+    }
+  }
+
+  private _cancelPendingTools(): void {
+    if (this._cancelRequested) this._agent.cancel()
+  }
+
+  private _resumeCancelledInlineFunction(event: AfterInvocationEvent): void {
+    if (!this._cancelRequested || !this._model.hasPendingInlineFunctions) return
+
+    event.resume = this._model.cancellationContinuation(this._cancelledToolResults)
+    this._cancelledToolResults = undefined
+  }
+}
+
+class RawEventQueue {
+  private readonly _events: RawEventEntry[] = []
+  private _ready: Promise<void> | undefined
+  private _resolveReady: (() => void) | undefined
+
+  async push(event: InvokeHarnessStreamOutput): Promise<void> {
+    let markConsumed: () => void = () => {}
+    const consumed = new Promise<void>((resolve) => {
+      markConsumed = resolve
+    })
+    this._events.push({ event, markConsumed })
+    this._resolveReady?.()
+    await consumed
+  }
+
+  drain(): RawEventEntry[] {
+    const events = this._events.splice(0)
+    this._ready = undefined
+    this._resolveReady = undefined
+    return events
+  }
+
+  wait(): Promise<void> {
+    if (this._events.length > 0) return Promise.resolve()
+    this._ready ??= new Promise((resolve) => {
+      this._resolveReady = resolve
+    })
+    return this._ready
+  }
+}
+
+interface RawEventEntry {
+  event: InvokeHarnessStreamOutput
+  markConsumed: () => void
+}
+
+function* rawEventUpdates(events: RawEventEntry[]): Generator<AgentCoreHarnessStreamUpdateEvent, void, undefined> {
+  for (const { event, markConsumed } of events) {
+    try {
+      yield new AgentCoreHarnessStreamUpdateEvent(event as AgentCoreHarnessStreamUpdateEvent['event'])
+    } finally {
+      markConsumed()
+    }
+  }
+}
+
+function assertSupportedInvocation(args: InvokeArgs, options: InvokeOptions | undefined): void {
+  if (typeof args === 'string' && args.length === 0) {
+    throw new TypeError('AgentCoreHarnessAgent input must contain non-empty text.')
+  }
+  if (Array.isArray(args) && args.length === 0) {
+    throw new TypeError('AgentCoreHarnessAgent input must contain non-empty text.')
+  }
+  if (typeof args !== 'string' && !Array.isArray(args)) {
+    throw new TypeError('AgentCoreHarnessAgent does not support checkpoint resume input.')
+  }
+  if (options?.structuredOutputSchema !== undefined) {
+    throw new TypeError('InvokeOptions.structuredOutputSchema is not supported by AgentCoreHarnessAgent.')
+  }
+  if (options?.limits !== undefined) {
+    throw new TypeError('InvokeOptions.limits is not supported by AgentCoreHarnessAgent.')
+  }
+}
+
+function assertSupportedInterventions(interventions: InterventionHandler[] | undefined): void {
+  for (const intervention of interventions ?? []) {
+    const unsupportedMethods = (['beforeInvocation', 'beforeModelCall', 'afterModelCall'] as const).filter(
+      (method) => intervention[method] !== InterventionHandler.prototype[method]
+    )
+    if (unsupportedMethods.length > 0) {
+      throw new TypeError(
+        `AgentCoreHarnessAgent intervention '${intervention.name}' overrides unsupported lifecycle methods: ` +
+          `${unsupportedMethods.join(', ')}. Only beforeToolCall and afterToolCall are supported.`
+      )
+    }
+  }
+}
+
+function withoutCancelSignal(options: InvokeOptions | undefined): InvokeOptions | undefined {
+  if (options === undefined) return undefined
+
+  const agentOptions = { ...options }
+  delete agentOptions.cancelSignal
+  return agentOptions
+}

--- a/src/harness/integrations/strands/events.ts
+++ b/src/harness/integrations/strands/events.ts
@@ -1,0 +1,62 @@
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import { StreamEvent, type AgentResult } from '@strands-agents/sdk'
+
+type AgentCoreHarnessEventData = Exclude<
+  InvokeHarnessStreamOutput,
+  | InvokeHarnessStreamOutput.InternalServerExceptionMember
+  | InvokeHarnessStreamOutput.ValidationExceptionMember
+  | InvokeHarnessStreamOutput.RuntimeClientErrorMember
+>
+
+/** Wraps one raw event from the `InvokeHarness` response stream. */
+export class AgentCoreHarnessStreamUpdateEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessStreamUpdateEvent' as const
+  readonly event: AgentCoreHarnessEventData
+
+  /**
+   * Creates a Harness stream update.
+   *
+   * @param event - Raw non-error event received from `InvokeHarness`
+   */
+  constructor(event: AgentCoreHarnessEventData) {
+    super()
+    this.event = event
+  }
+
+  /**
+   * Serializes the event.
+   *
+   * @returns Event type and raw Harness event
+   */
+  toJSON(): Pick<AgentCoreHarnessStreamUpdateEvent, 'type' | 'event'> {
+    return { type: this.type, event: this.event }
+  }
+}
+
+/** Wraps the final result yielded by an AgentCore Harness agent stream. */
+export class AgentCoreHarnessResultEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessResultEvent' as const
+  readonly result: AgentResult
+
+  /**
+   * Creates a final Harness result event.
+   *
+   * @param data - Completed agent result
+   */
+  constructor(data: { result: AgentResult }) {
+    super()
+    this.result = data.result
+  }
+
+  /**
+   * Serializes the event.
+   *
+   * @returns Event type and completed result
+   */
+  toJSON(): Pick<AgentCoreHarnessResultEvent, 'type' | 'result'> {
+    return { type: this.type, result: this.result }
+  }
+}
+
+/** Events yielded by {@link AgentCoreHarnessAgent.stream}. */
+export type AgentCoreHarnessStreamEvent = AgentCoreHarnessStreamUpdateEvent | AgentCoreHarnessResultEvent

--- a/src/harness/integrations/strands/index.ts
+++ b/src/harness/integrations/strands/index.ts
@@ -1,0 +1,5 @@
+export { AgentCoreHarnessAgent } from './agent.js'
+export { AgentCoreHarnessResultEvent, AgentCoreHarnessStreamUpdateEvent } from './events.js'
+
+export type { AgentCoreHarnessAgentConfig } from './types.js'
+export type { AgentCoreHarnessStreamEvent } from './events.js'

--- a/src/harness/integrations/strands/model.ts
+++ b/src/harness/integrations/strands/model.ts
@@ -1,0 +1,628 @@
+import {
+  BedrockAgentCoreClient,
+  InvokeHarnessCommand,
+  type HarnessContentBlock,
+  type HarnessInlineFunctionConfig,
+  type HarnessMessage,
+  type HarnessReasoningContentBlock,
+  type HarnessTool,
+  type InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import {
+  GetHarnessCommand,
+  type BedrockAgentCoreControlClient,
+  type HarnessTool as ControlHarnessTool,
+} from '@aws-sdk/client-bedrock-agentcore-control'
+import {
+  ContextWindowOverflowError,
+  MaxTokensError,
+  Message,
+  Model,
+  ModelError,
+  ModelMetadataEvent,
+  ModelThrottledError,
+  TextBlock,
+  ToolResultBlock,
+} from '@strands-agents/sdk'
+import type {
+  BaseModelConfig,
+  ContentBlock,
+  JsonBlock,
+  ModelStreamEvent,
+  ReasoningBlock,
+  StopReason,
+  StreamOptions,
+  ToolSpec,
+  ToolUseBlock,
+} from '@strands-agents/sdk'
+import { HarnessStreamDecoder } from './stream-decoder.js'
+
+const CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
+  'input is too long for requested model',
+  'input length and `max_tokens` exceed context limit',
+  'too many total text bytes',
+  'prompt is too long',
+]
+const THROTTLING_ERROR_NAMES = new Set(['ThrottlingException', 'ThrottledException'])
+
+interface HarnessModelConfig extends BaseModelConfig {
+  modelId: string
+}
+
+interface HarnessModelOptions {
+  client: BedrockAgentCoreClient
+  controlClient: BedrockAgentCoreControlClient
+  harnessArn: string
+  runtimeSessionId: string
+}
+
+interface HarnessInvocationResult {
+  message: Message
+  stopReason: StopReason
+  metadata?: ModelMetadataEvent
+}
+
+interface DeployedToolConfiguration {
+  tools: HarnessTool[]
+  allowedTools?: string[]
+}
+
+interface HarnessToolOverrides {
+  tools?: HarnessTool[]
+  allowedTools?: string[]
+}
+
+/**
+ * Internal Strands model adapter that translates between `InvokeHarness` and Strands model events.
+ *
+ * The class is exported only for use by {@link AgentCoreHarnessAgent}; it is not part of the package
+ * entry point.
+ */
+export class HarnessModel extends Model<HarnessModelConfig> {
+  private readonly _client: BedrockAgentCoreClient
+  private readonly _controlClient: BedrockAgentCoreControlClient
+  private readonly _harnessArn: string
+  private readonly _runtimeSessionId: string
+  private _deployedToolConfiguration: Promise<DeployedToolConfiguration> | undefined
+  private _cancelSignal: AbortSignal | undefined
+  private _onRawEvent: ((event: InvokeHarnessStreamOutput) => Promise<void>) | undefined
+  private _isInvokingHarness = false
+  private _pendingInlineFunctionMessage: Message | undefined
+  private _cancellationRoot: Message | undefined
+
+  /**
+   * Creates the internal Harness model adapter.
+   *
+   * @param options - Harness transport and cancellation dependencies
+   */
+  constructor(options: HarnessModelOptions) {
+    super()
+    this._client = options.client
+    this._controlClient = options.controlClient
+    this._harnessArn = options.harnessArn
+    this._runtimeSessionId = options.runtimeSessionId
+  }
+
+  /**
+   * Indicates that conversation history is owned by the deployed Harness.
+   *
+   * @returns Always `true`
+   */
+  override get stateful(): boolean {
+    return true
+  }
+
+  /**
+   * Returns the fixed model configuration used for tracing.
+   *
+   * @returns Harness identity represented as a model configuration
+   */
+  getConfig(): HarnessModelConfig {
+    return { modelId: this._harnessArn }
+  }
+
+  /**
+   * Rejects runtime model configuration changes because the deployed Harness owns its model.
+   *
+   * @param _modelConfig - Unsupported model configuration update
+   */
+  updateConfig(_modelConfig: HarnessModelConfig): void {
+    throw new TypeError('AgentCoreHarnessAgent does not support model configuration updates.')
+  }
+
+  /** Whether an `InvokeHarness` request is currently active. */
+  get isInvokingHarness(): boolean {
+    return this._isInvokingHarness
+  }
+
+  /** Whether the Harness is waiting for inline-function results. */
+  get hasPendingInlineFunctions(): boolean {
+    return this._pendingInlineFunctionMessage !== undefined
+  }
+
+  /**
+   * Builds the continuation needed to resolve a cancelled local inline-function execution.
+   *
+   * @param toolResults - Results already produced by Strands before cancellation completed
+   * @returns Original Harness tool calls paired with success or cancellation results
+   */
+  cancellationContinuation(toolResults?: Message): Message[] {
+    const assistantMessage = this._pendingInlineFunctionMessage
+    if (assistantMessage === undefined) {
+      throw new ModelError('AgentCoreHarnessAgent has no pending inline function to cancel.')
+    }
+    const resultMessage =
+      this._cancellationRoot !== undefined || toolResults === undefined
+        ? cancelledToolResults(assistantMessage)
+        : toolResults
+    // Cancellation may have aborted the request that produced this tool call. Cleanup is a new
+    // transport phase and must be allowed to resolve the matching remote result.
+    this._cancelSignal = undefined
+    this._cancellationRoot ??= assistantMessage
+    return [assistantMessage, resultMessage]
+  }
+
+  /**
+   * Streams canonical Strands model events for one Harness request.
+   *
+   * @param messages - Current Strands conversation
+   * @param options - Strands model options containing dynamic inline-function definitions
+   * @returns Canonical model event stream
+   */
+  async *stream(messages: Message[], options?: StreamOptions): AsyncGenerator<ModelStreamEvent, void, undefined> {
+    yield* this._invoke(messages, options?.toolSpecs)
+  }
+
+  /**
+   * Streams canonical events while returning the message decoded from the complete Harness stream.
+   *
+   * Harness can stream tool-result messages that have no canonical Strands model-stream event. The
+   * returned message therefore comes from {@link HarnessStreamDecoder}, while supported deltas still
+   * flow through the standard Strands stream event types.
+   *
+   * @param messages - Current Strands conversation
+   * @param options - Strands model options containing dynamic inline-function definitions
+   * @returns Canonical events and the completed Harness message
+   */
+  override async *streamAggregated(
+    messages: Message[],
+    options?: StreamOptions
+  ): AsyncGenerator<ModelStreamEvent | ContentBlock, HarnessInvocationResult, undefined> {
+    return yield* this._invoke(messages, options?.toolSpecs)
+  }
+
+  /**
+   * Clears invocation-scoped transport state before the outer agent starts.
+   *
+   * @param cancelSignal - External cancellation signal for the Harness request
+   * @param onRawEvent - Callback invoked as each non-error Harness event arrives
+   */
+  resetInvocationState(
+    cancelSignal: AbortSignal | undefined,
+    onRawEvent: (event: InvokeHarnessStreamOutput) => Promise<void>
+  ): void {
+    this._deployedToolConfiguration = undefined
+    this._cancelSignal = cancelSignal
+    this._onRawEvent = onRawEvent
+  }
+
+  /**
+   * Releases invocation-scoped callbacks and cancellation state.
+   */
+  clearInvocationState(): void {
+    this._deployedToolConfiguration = undefined
+    this._cancelSignal = undefined
+    this._onRawEvent = undefined
+    this._cancellationRoot = undefined
+  }
+
+  private async *_invoke(
+    messages: Message[],
+    toolSpecs: ToolSpec[] | undefined
+  ): AsyncGenerator<ModelStreamEvent, HarnessInvocationResult, undefined> {
+    const decoder = new HarnessStreamDecoder()
+    const cancelSignal = this._cancelSignal
+    let metadata: ModelMetadataEvent | undefined
+    const continuation = this._pendingInlineFunctionMessage !== undefined
+    const requestMessages = harnessMessagesFromStrands(messages, this._pendingInlineFunctionMessage)
+
+    if (cancelSignal?.aborted) {
+      return this._cancelled(decoder)
+    }
+
+    this._isInvokingHarness = true
+    try {
+      if (continuation) {
+        this._pendingInlineFunctionMessage = undefined
+      }
+      const toolOverrides = await this._toolOverridesForInvocation(toolSpecs, cancelSignal)
+      const response = await this._client.send(
+        new InvokeHarnessCommand({
+          harnessArn: this._harnessArn,
+          runtimeSessionId: this._runtimeSessionId,
+          messages: requestMessages,
+          ...toolOverrides,
+        }),
+        cancelSignal ? { abortSignal: cancelSignal } : {}
+      )
+
+      if (response.stream) {
+        for await (const chunk of response.stream) {
+          if (cancelSignal?.aborted) {
+            return this._cancelled(decoder)
+          }
+          const streamError = harnessStreamError(chunk)
+          if (streamError) throw streamError
+
+          const event = chunk
+          const modelEvents = decoder.accept(event)
+          await this._onRawEvent?.(event)
+          for (const modelEvent of modelEvents) {
+            if (modelEvent.type === 'modelMetadataEvent') {
+              metadata = modelEvent
+            }
+            yield modelEvent
+          }
+        }
+      }
+    } catch (error) {
+      if (cancelSignal?.aborted) {
+        return this._cancelled(decoder)
+      }
+      throw normalizeHarnessError(error)
+    } finally {
+      this._isInvokingHarness = false
+    }
+
+    if (cancelSignal?.aborted) {
+      return this._cancelled(decoder)
+    }
+
+    const decoded = decoder.complete()
+    throwIfUnrecoverable(decoded)
+    if (decoded.terminalNonInlineToolUse) {
+      throw new ModelError('Harness returned an incomplete non-inline tool call.')
+    }
+    if (this._cancellationRoot !== undefined && continuation) {
+      if (decoded.stopReason === 'toolUse') {
+        this._pendingInlineFunctionMessage = decoded.message
+        return { message: decoded.message, stopReason: 'cancelled', ...(metadata !== undefined && { metadata }) }
+      }
+      const cancelledMessage = this._cancellationRoot
+      this._cancellationRoot = undefined
+      this._pendingInlineFunctionMessage = undefined
+      return { message: cancelledMessage, stopReason: 'cancelled', ...(metadata !== undefined && { metadata }) }
+    }
+    this._pendingInlineFunctionMessage = decoded.stopReason === 'toolUse' ? decoded.message : undefined
+    return {
+      message: decoded.message,
+      stopReason: decoded.stopReason,
+      ...(metadata !== undefined && { metadata }),
+    }
+  }
+
+  private _cancelled(decoder: HarnessStreamDecoder): HarnessInvocationResult {
+    const decoded = decoder.tryComplete()
+    if (
+      decoded?.stopReason === 'toolUse' &&
+      !decoded.terminalNonInlineToolUse &&
+      decoded.toolInputParseError === undefined
+    ) {
+      this._pendingInlineFunctionMessage = decoded.message
+    }
+    return { message: decoded?.message ?? decoder.partialMessage(), stopReason: 'cancelled' }
+  }
+
+  private async _toolOverridesForInvocation(
+    toolSpecs: ToolSpec[] | undefined,
+    cancelSignal: AbortSignal | undefined
+  ): Promise<HarnessToolOverrides> {
+    const inlineFunctions = inlineFunctionsFromStrands(toolSpecs)
+    if (inlineFunctions === undefined) return {}
+
+    this._deployedToolConfiguration ??= this._loadDeployedToolConfiguration(cancelSignal)
+    const deployed = await this._deployedToolConfiguration
+    return {
+      tools: mergeHarnessTools(deployed.tools, inlineFunctions),
+      ...(deployed.allowedTools !== undefined && {
+        allowedTools: mergeAllowedTools(deployed.allowedTools, inlineFunctions),
+      }),
+    }
+  }
+
+  private async _loadDeployedToolConfiguration(
+    cancelSignal: AbortSignal | undefined
+  ): Promise<DeployedToolConfiguration> {
+    const response = await this._controlClient.send(
+      new GetHarnessCommand({ harnessId: harnessIdFromArn(this._harnessArn) }),
+      cancelSignal ? { abortSignal: cancelSignal } : {}
+    )
+    return {
+      tools: (response.harness?.tools ?? []).map(controlToolToInvokeTool),
+      ...(response.harness?.allowedTools !== undefined && { allowedTools: response.harness.allowedTools }),
+    }
+  }
+}
+
+function inlineFunctionsFromStrands(toolSpecs: ToolSpec[] | undefined): HarnessTool[] | undefined {
+  if (toolSpecs === undefined || toolSpecs.length === 0) return undefined
+
+  return toolSpecs.map((toolSpec): HarnessTool => {
+    const inputSchema = toolSpec.inputSchema ?? {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    }
+    const inlineFunction: HarnessInlineFunctionConfig = {
+      description: toolSpec.description,
+      // Both types represent JSON documents, but JSONSchema7 lacks Smithy's string index signature.
+      inputSchema: inputSchema as unknown as HarnessInlineFunctionConfig['inputSchema'],
+    }
+    return {
+      type: 'inline_function',
+      name: toolSpec.name,
+      config: { inlineFunction },
+    }
+  })
+}
+
+function mergeHarnessTools(deployedTools: HarnessTool[], inlineFunctions: HarnessTool[]): HarnessTool[] {
+  const inlineFunctionNames = new Set(inlineFunctions.map((tool) => tool.name))
+  return [...deployedTools.filter((tool) => !inlineFunctionNames.has(tool.name)), ...inlineFunctions]
+}
+
+function mergeAllowedTools(deployedAllowedTools: string[], inlineFunctions: HarnessTool[]): string[] {
+  if (deployedAllowedTools.includes('*')) return deployedAllowedTools
+  return [
+    ...new Set([
+      ...deployedAllowedTools,
+      ...inlineFunctions.flatMap((tool) => (tool.name === undefined ? [] : [tool.name])),
+    ]),
+  ]
+}
+
+function controlToolToInvokeTool(tool: ControlHarnessTool): HarnessTool {
+  return {
+    type: tool.type,
+    ...(tool.name !== undefined && { name: tool.name }),
+    ...(tool.config !== undefined && {
+      // Control- and data-plane clients model the same service document as separate declarations.
+      config: tool.config as HarnessTool['config'],
+    }),
+  }
+}
+
+function harnessIdFromArn(harnessArn: string): string {
+  const match = /^arn:[^:]+:bedrock-agentcore:[^:]+:[^:]+:harness\/(.+)$/.exec(harnessArn)
+  if (match?.[1] === undefined) {
+    throw new TypeError(`Invalid AgentCore Harness ARN: ${harnessArn}`)
+  }
+  return match[1]
+}
+
+function harnessMessagesFromStrands(
+  messages: Message[],
+  pendingInlineFunctionMessage: Message | undefined
+): HarnessMessage[] {
+  const latestUserIndex = findLatestUserMessage(messages)
+  if (latestUserIndex < 0) {
+    throw new TypeError('AgentCoreHarnessAgent message input must include at least one user message.')
+  }
+
+  const latestUserMessage = messages[latestUserIndex]!
+  const toolResults = latestUserMessage.content.filter(
+    (block): block is ToolResultBlock => block.type === 'toolResultBlock'
+  )
+  if (toolResults.length === 0) {
+    if (pendingInlineFunctionMessage !== undefined) {
+      throw new ModelError(
+        'AgentCoreHarnessAgent cannot start a new user turn while the Harness is waiting for inline-function results.'
+      )
+    }
+    return [{ role: 'user', content: textContentFromStrands(latestUserMessage.content) }]
+  }
+  if (toolResults.length !== latestUserMessage.content.length) {
+    throw new TypeError('AgentCoreHarnessAgent cannot mix inline-function results with other user content.')
+  }
+
+  if (pendingInlineFunctionMessage === undefined) {
+    throw new ModelError('AgentCoreHarnessAgent received inline-function results without a pending Harness tool call.')
+  }
+  const pendingToolUses = pendingInlineFunctionMessage.content.filter(
+    (block): block is ToolUseBlock => block.type === 'toolUseBlock'
+  )
+  if (pendingToolUses.length !== toolResults.length) {
+    throw new ModelError(
+      `AgentCoreHarnessAgent received ${toolResults.length} inline-function results for ` +
+        `${pendingToolUses.length} pending Harness tool calls.`
+    )
+  }
+  return [
+    { role: 'assistant', content: assistantContentFromStrands(pendingInlineFunctionMessage.content) },
+    {
+      role: 'user',
+      content: toolResults.map((result, index) => toolResultFromStrands(result, pendingToolUses[index]!.toolUseId)),
+    },
+  ]
+}
+
+function findLatestUserMessage(messages: Message[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]!.role === 'user') return index
+  }
+  return -1
+}
+
+function textContentFromStrands(blocks: ContentBlock[]): HarnessContentBlock[] {
+  const unsupportedTypes = blocks.filter((block) => block.type !== 'textBlock').map((block) => block.type)
+  if (unsupportedTypes.length > 0) {
+    throw new TypeError(
+      `AgentCoreHarnessAgent accepts only text content blocks; received ${unsupportedTypes.join(', ')}.`
+    )
+  }
+  const text = blocks.map((block) => (block as TextBlock).text).join('\n')
+  if (text.length === 0) {
+    throw new TypeError('AgentCoreHarnessAgent input must contain non-empty text.')
+  }
+  return [{ text }]
+}
+
+function assistantContentFromStrands(blocks: ContentBlock[]): HarnessContentBlock[] {
+  return blocks.map((block) => {
+    switch (block.type) {
+      case 'textBlock':
+        return { text: block.text }
+      case 'toolUseBlock':
+        return toolUseFromStrands(block)
+      case 'reasoningBlock':
+        return reasoningFromStrands(block)
+      default:
+        throw new TypeError(
+          `AgentCoreHarnessAgent cannot continue an inline function after assistant content type ${block.type}.`
+        )
+    }
+  })
+}
+
+function toolUseFromStrands(block: ToolUseBlock): HarnessContentBlock {
+  return {
+    toolUse: {
+      name: block.name,
+      toolUseId: block.toolUseId,
+      input: block.input,
+      type: 'tool_use',
+    },
+  }
+}
+
+function reasoningFromStrands(block: ReasoningBlock): HarnessContentBlock {
+  let reasoningContent: HarnessReasoningContentBlock
+  if (block.redactedContent !== undefined) {
+    reasoningContent = { redactedContent: block.redactedContent }
+  } else {
+    reasoningContent = {
+      reasoningText: {
+        text: block.text ?? '',
+        ...(block.signature !== undefined && { signature: block.signature }),
+      },
+    }
+  }
+  return { reasoningContent }
+}
+
+function toolResultFromStrands(block: ToolResultBlock, toolUseId: string): HarnessContentBlock {
+  try {
+    return {
+      toolResult: {
+        toolUseId,
+        status: block.status,
+        type: 'tool_use',
+        content: block.content.map((item) => {
+          switch (item.type) {
+            case 'textBlock':
+              return { text: item.text }
+            case 'jsonBlock':
+              return { text: jsonToolResultText(item as JsonBlock) }
+            default:
+              throw new TypeError(
+                `AgentCoreHarnessAgent supports only text and JSON inline-function results; received ${item.type}.`
+              )
+          }
+        }),
+      },
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      toolResult: {
+        toolUseId,
+        status: 'error',
+        type: 'tool_use',
+        content: [{ text: message }],
+      },
+    }
+  }
+}
+
+function cancelledToolResults(assistantMessage: Message): Message {
+  const results = assistantMessage.content
+    .filter((block): block is ToolUseBlock => block.type === 'toolUseBlock')
+    .map(
+      (block) =>
+        new ToolResultBlock({
+          toolUseId: block.toolUseId,
+          status: 'error',
+          content: [new TextBlock('Tool execution cancelled')],
+        })
+    )
+  return new Message({ role: 'user', content: results })
+}
+
+function jsonToolResultText(block: JsonBlock): string {
+  const text = JSON.stringify(block.json)
+  if (text === undefined) {
+    throw new TypeError('AgentCoreHarnessAgent could not serialize an inline-function JSON result.')
+  }
+  return text
+}
+
+function throwIfUnrecoverable(decoded: ReturnType<HarnessStreamDecoder['complete']>): void {
+  switch (decoded.stopReason) {
+    case 'maxTokens':
+      throw new MaxTokensError(
+        'Model reached maximum token limit. This is an unrecoverable state that requires intervention.',
+        decoded.message
+      )
+    case 'interrupted':
+    case 'malformedModelOutput':
+    case 'malformedToolUse':
+      throw new ModelError(`Harness ended the turn with an unrecoverable stop reason: ${decoded.stopReason}`)
+  }
+  if (decoded.toolInputParseError) {
+    throw new ModelError('Unable to parse Harness tool input JSON.', { cause: decoded.toolInputParseError })
+  }
+}
+
+function harnessStreamError(chunk: InvokeHarnessStreamOutput): ModelError | undefined {
+  if ('internalServerException' in chunk && chunk.internalServerException) {
+    return new ModelError(chunk.internalServerException.message ?? 'AgentCore Harness internal server error', {
+      cause: chunk.internalServerException,
+    })
+  }
+  if ('validationException' in chunk && chunk.validationException) {
+    const message = chunk.validationException.message ?? 'AgentCore Harness validation error'
+    if (isContextWindowOverflow(message)) {
+      return contextWindowOverflowError(message, chunk.validationException)
+    }
+    return new ModelError(message, { cause: chunk.validationException })
+  }
+  if ('runtimeClientError' in chunk && chunk.runtimeClientError) {
+    return new ModelError(chunk.runtimeClientError.message ?? 'AgentCore Harness runtime client error', {
+      cause: chunk.runtimeClientError,
+    })
+  }
+  return undefined
+}
+
+function normalizeHarnessError(error: unknown): Error {
+  if (error instanceof ModelError) return error
+
+  const normalized = error instanceof Error ? error : new Error(String(error))
+  if (THROTTLING_ERROR_NAMES.has(normalized.name)) {
+    return new ModelThrottledError(normalized.message, { cause: error })
+  }
+  if (isContextWindowOverflow(normalized.message)) {
+    return contextWindowOverflowError(normalized.message, error)
+  }
+  return new ModelError(normalized.message, { cause: error })
+}
+
+function contextWindowOverflowError(message: string, cause: unknown): ContextWindowOverflowError {
+  const error = new ContextWindowOverflowError(message)
+  return Object.assign(error, { cause })
+}
+
+function isContextWindowOverflow(message: string): boolean {
+  const normalized = message.toLowerCase()
+  return CONTEXT_WINDOW_OVERFLOW_MESSAGES.some((phrase) => normalized.includes(phrase))
+}

--- a/src/harness/integrations/strands/stream-decoder.ts
+++ b/src/harness/integrations/strands/stream-decoder.ts
@@ -1,0 +1,447 @@
+import type {
+  HarnessContentBlockDelta,
+  HarnessContentBlockStart,
+  HarnessStopReason,
+  HarnessToolResultContentBlock,
+  InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import {
+  JsonBlock,
+  Message,
+  ModelContentBlockDeltaEvent,
+  ModelContentBlockStartEvent,
+  ModelContentBlockStopEvent,
+  ModelError,
+  ModelMessageStartEvent,
+  ModelMessageStopEvent,
+  ModelMetadataEvent,
+  ReasoningBlock,
+  TextBlock,
+  ToolResultBlock,
+  ToolUseBlock,
+} from '@strands-agents/sdk'
+import type {
+  ContentBlock,
+  JSONValue,
+  ModelStreamEvent,
+  Role,
+  StopReason,
+  ToolResultContent,
+  ToolResultStatus,
+} from '@strands-agents/sdk'
+
+/** Harness wire stop reasons mapped onto the Strands `StopReason` vocabulary. */
+const STOP_REASON_MAP = {
+  end_turn: 'endTurn',
+  tool_use: 'toolUse',
+  tool_result: 'toolResult',
+  max_tokens: 'maxTokens',
+  stop_sequence: 'stopSequence',
+  content_filtered: 'contentFiltered',
+  model_context_window_exceeded: 'modelContextWindowExceeded',
+  max_iterations_exceeded: 'limitTurns',
+  max_output_tokens_exceeded: 'limitOutputTokens',
+  timeout_exceeded: 'timeoutExceeded',
+  interrupted: 'interrupted',
+  partial_turn: 'pauseTurn',
+  malformed_model_output: 'malformedModelOutput',
+  malformed_tool_use: 'malformedToolUse',
+} satisfies Record<HarnessStopReason, StopReason>
+
+interface DecodedHarnessInvocation {
+  /** Most recent message completed by the Harness. */
+  message: Message
+
+  /** Reason the most recent message stopped. */
+  stopReason: StopReason
+
+  /** Deferred parse failure for a streamed tool input. */
+  toolInputParseError?: SyntaxError
+
+  /** Whether the final message stopped on a tool call that cannot execute locally. */
+  terminalNonInlineToolUse?: true
+}
+
+/**
+ * Reconstructs the final Strands message from an `InvokeHarness` event stream.
+ *
+ * The Harness streams a message as `messageStart`, interleaved content-block start/delta/stop events,
+ * and `messageStop`. A single invocation may stream several messages (an assistant tool-use turn, then
+ * the tool-result turn, then the final answer); each `messageStart` resets the accumulated content so
+ * the decoder holds the latest message only.
+ */
+export class HarnessStreamDecoder {
+  private readonly _state: StreamState = {
+    messageStarted: false,
+    role: 'assistant',
+    content: [],
+    pending: undefined,
+    stopReason: undefined,
+    toolInputParseError: undefined,
+    nonInlineToolUseInMessage: false,
+  }
+
+  /**
+   * Folds one Harness stream event into the invocation.
+   *
+   * @param event - Harness event to process
+   * @returns Canonical Strands model events represented by this Harness event
+   */
+  accept(event: InvokeHarnessStreamOutput): ModelStreamEvent[] {
+    const modelEvents: ModelStreamEvent[] = []
+    accumulate(this._state, event, modelEvents)
+    return modelEvents
+  }
+
+  /**
+   * Completes the invocation.
+   *
+   * @returns Final message and stop reason
+   * @throws {@link https://strandsagents.com | ModelError} When the stream did not complete a message
+   */
+  complete(): DecodedHarnessInvocation {
+    const decoded = this.tryComplete()
+    if (decoded === undefined) {
+      throw new ModelError('AgentCore Harness stream ended without completing a message')
+    }
+    return decoded
+  }
+
+  /**
+   * Completes the invocation when a message-stop event has already arrived.
+   *
+   * @returns Final message and stop reason, or `undefined` for an incomplete stream
+   */
+  tryComplete(): DecodedHarnessInvocation | undefined {
+    if (this._state.stopReason === undefined) return undefined
+
+    return {
+      message: toMessage(this._state),
+      stopReason: this._state.stopReason,
+      ...(this._state.toolInputParseError !== undefined && {
+        toolInputParseError: this._state.toolInputParseError,
+      }),
+      ...(this._state.stopReason === 'toolUse' &&
+        this._state.nonInlineToolUseInMessage && { terminalNonInlineToolUse: true }),
+    }
+  }
+
+  /**
+   * Returns the message assembled before a cancelled stream ended.
+   *
+   * @returns Partially reconstructed message
+   */
+  partialMessage(): Message {
+    return toMessage(this._state)
+  }
+}
+
+/** A content block still accumulating deltas, not yet appended to the message. */
+type PendingBlock =
+  | { kind: 'text'; text: string }
+  | { kind: 'toolUse'; toolUseId: string; name: string; input: string }
+  | { kind: 'toolResult'; toolUseId: string; status: ToolResultStatus; content: ToolResultContent[] }
+  | { kind: 'reasoning'; text: string; signature?: string; redactedContent?: Uint8Array }
+
+interface StreamState {
+  messageStarted: boolean
+  role: Role
+  content: ContentBlock[]
+  pending: PendingBlock | undefined
+  stopReason: StopReason | undefined
+  toolInputParseError: SyntaxError | undefined
+  nonInlineToolUseInMessage: boolean
+}
+
+function accumulate(state: StreamState, event: InvokeHarnessStreamOutput, modelEvents: ModelStreamEvent[]): void {
+  if ('messageStart' in event && event.messageStart) {
+    flushPending(state, modelEvents)
+    state.messageStarted = true
+    state.content.length = 0
+    state.stopReason = undefined
+    state.toolInputParseError = undefined
+    state.nonInlineToolUseInMessage = false
+    state.role = roleFromHarness(event.messageStart.role)
+    modelEvents.push(new ModelMessageStartEvent({ type: 'modelMessageStartEvent', role: state.role }))
+  }
+  if ('contentBlockStart' in event && event.contentBlockStart) {
+    assertMessageStarted(state)
+    flushPending(state, modelEvents)
+    state.pending = startBlock(state, event.contentBlockStart.start, modelEvents)
+  }
+  if ('contentBlockDelta' in event && event.contentBlockDelta) {
+    assertMessageStarted(state)
+    applyDelta(state, event.contentBlockDelta.delta, modelEvents)
+  }
+  if ('contentBlockStop' in event && event.contentBlockStop) {
+    assertMessageStarted(state)
+    if (state.pending === undefined) {
+      throw new ModelError('AgentCore Harness contentBlockStop event has no active content block')
+    }
+    flushPending(state, modelEvents)
+  }
+  if ('messageStop' in event && event.messageStop) {
+    assertMessageStarted(state)
+    flushPending(state, modelEvents)
+    state.stopReason = stopReasonFromHarness(event.messageStop.stopReason)
+    state.messageStarted = false
+    modelEvents.push(new ModelMessageStopEvent({ type: 'modelMessageStopEvent', stopReason: state.stopReason }))
+  }
+  if ('metadata' in event && event.metadata) {
+    modelEvents.push(metadataFromHarness(event.metadata))
+  }
+}
+
+function assertMessageStarted(state: StreamState): void {
+  if (!state.messageStarted) {
+    throw new ModelError('AgentCore Harness content event arrived outside a message')
+  }
+}
+
+function toMessage(state: StreamState): Message {
+  flushPending(state)
+  return new Message({ role: state.role, content: state.content })
+}
+
+function roleFromHarness(role: string | undefined): Role {
+  if (role === 'assistant' || role === 'user') return role
+  throw new ModelError(`AgentCore Harness messageStart event has invalid role '${String(role)}'`)
+}
+
+/**
+ * Maps a Harness wire stop reason to the Strands vocabulary.
+ *
+ * @param stopReason - Harness wire stop reason
+ * @returns Corresponding Strands stop reason
+ */
+function stopReasonFromHarness(stopReason: string | undefined): StopReason {
+  if (stopReason === undefined || stopReason.trim().length === 0) {
+    throw new ModelError('AgentCore Harness messageStop event is missing a non-empty stopReason')
+  }
+  const mapped = STOP_REASON_MAP[stopReason as HarnessStopReason]
+  if (mapped !== undefined) return mapped
+  throw new ModelError(`AgentCore Harness returned unsupported stop reason '${stopReason}'`)
+}
+
+function startBlock(
+  state: StreamState,
+  start: HarnessContentBlockStart | undefined,
+  modelEvents: ModelStreamEvent[]
+): PendingBlock | undefined {
+  if (start && 'toolUse' in start && start.toolUse) {
+    const toolUseId = requiredWireString(start.toolUse.toolUseId, 'tool-use start', 'toolUseId')
+    const name = requiredWireString(start.toolUse.name, 'tool-use start', 'name')
+    state.nonInlineToolUseInMessage ||= start.toolUse.type !== 'tool_use'
+    modelEvents.push(
+      new ModelContentBlockStartEvent({
+        type: 'modelContentBlockStartEvent',
+        start: { type: 'toolUseStart', toolUseId, name },
+      })
+    )
+    return {
+      kind: 'toolUse',
+      toolUseId,
+      name,
+      input: '',
+    }
+  }
+  if (start && 'toolResult' in start && start.toolResult) {
+    return {
+      kind: 'toolResult',
+      toolUseId: requiredWireString(start.toolResult.toolUseId, 'tool-result start', 'toolUseId'),
+      status: start.toolResult.status === 'error' ? 'error' : 'success',
+      content: [],
+    }
+  }
+  throw new ModelError('AgentCore Harness returned an unsupported content-block start')
+}
+
+function requiredWireString(value: string | undefined, event: string, field: string): string {
+  if (value !== undefined && value.length > 0) return value
+  throw new ModelError(`AgentCore Harness ${event} event is missing a non-empty ${field}`)
+}
+
+function applyDelta(
+  state: StreamState,
+  delta: HarnessContentBlockDelta | undefined,
+  modelEvents: ModelStreamEvent[]
+): void {
+  if (!delta) return
+  const pending = state.pending
+
+  if ('text' in delta && delta.text !== undefined) {
+    if (pending?.kind === 'reasoning') {
+      pending.text += delta.text
+      modelEvents.push(
+        new ModelContentBlockDeltaEvent({
+          type: 'modelContentBlockDeltaEvent',
+          delta: { type: 'reasoningContentDelta', text: delta.text },
+        })
+      )
+    } else {
+      if (pending?.kind === 'text') pending.text += delta.text
+      else {
+        if (pending !== undefined) {
+          throw new ModelError(`AgentCore Harness text delta interrupted a ${pending.kind} content block`)
+        }
+        state.pending = { kind: 'text', text: delta.text }
+        modelEvents.push(new ModelContentBlockStartEvent({ type: 'modelContentBlockStartEvent' }))
+      }
+      modelEvents.push(
+        new ModelContentBlockDeltaEvent({
+          type: 'modelContentBlockDeltaEvent',
+          delta: { type: 'textDelta', text: delta.text },
+        })
+      )
+    }
+    return
+  }
+  if ('toolUse' in delta && delta.toolUse && pending?.kind === 'toolUse') {
+    const input = delta.toolUse.input ?? ''
+    pending.input += input
+    modelEvents.push(
+      new ModelContentBlockDeltaEvent({
+        type: 'modelContentBlockDeltaEvent',
+        delta: { type: 'toolUseInputDelta', input },
+      })
+    )
+    return
+  }
+  if ('toolUse' in delta && delta.toolUse) {
+    throw new ModelError('AgentCore Harness tool-use delta has no active tool-use block')
+  }
+  if ('toolResult' in delta && delta.toolResult && pending?.kind === 'toolResult') {
+    for (const item of delta.toolResult) {
+      pending.content.push(toolResultContentFromHarness(item))
+    }
+    return
+  }
+  if ('toolResult' in delta && delta.toolResult) {
+    throw new ModelError('AgentCore Harness tool-result delta has no active tool-result block')
+  }
+  if ('reasoningContent' in delta && delta.reasoningContent) {
+    applyReasoningDelta(state, delta.reasoningContent, modelEvents)
+    return
+  }
+  throw new ModelError('AgentCore Harness returned an unsupported content-block delta')
+}
+
+function applyReasoningDelta(
+  state: StreamState,
+  reasoning: HarnessReasoningDelta,
+  modelEvents: ModelStreamEvent[]
+): void {
+  const pending = state.pending
+  if (pending?.kind === 'reasoning') {
+    if ('text' in reasoning && reasoning.text !== undefined) pending.text += reasoning.text
+    if ('signature' in reasoning && reasoning.signature !== undefined) {
+      pending.signature = (pending.signature ?? '') + reasoning.signature
+    }
+    if ('redactedContent' in reasoning && reasoning.redactedContent !== undefined) {
+      pending.redactedContent = concatBytes(pending.redactedContent, reasoning.redactedContent)
+    }
+  } else {
+    if (pending !== undefined) {
+      throw new ModelError(`AgentCore Harness reasoning delta interrupted a ${pending.kind} content block`)
+    }
+    state.pending = {
+      kind: 'reasoning',
+      text: 'text' in reasoning && reasoning.text ? reasoning.text : '',
+      ...('signature' in reasoning && reasoning.signature !== undefined && { signature: reasoning.signature }),
+      ...('redactedContent' in reasoning &&
+        reasoning.redactedContent !== undefined && { redactedContent: reasoning.redactedContent }),
+    }
+    modelEvents.push(new ModelContentBlockStartEvent({ type: 'modelContentBlockStartEvent' }))
+  }
+  modelEvents.push(
+    new ModelContentBlockDeltaEvent({
+      type: 'modelContentBlockDeltaEvent',
+      delta: { type: 'reasoningContentDelta', ...reasoning },
+    })
+  )
+}
+
+function metadataFromHarness(
+  metadata: NonNullable<InvokeHarnessStreamOutput.MetadataMember['metadata']>
+): ModelMetadataEvent {
+  const usage = metadata.usage
+  const metrics = metadata.metrics
+  return new ModelMetadataEvent({
+    type: 'modelMetadataEvent',
+    ...(usage?.inputTokens !== undefined &&
+      usage.outputTokens !== undefined &&
+      usage.totalTokens !== undefined && {
+        usage: {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          totalTokens: usage.totalTokens,
+          ...(usage.cacheReadInputTokens !== undefined && {
+            cacheReadInputTokens: usage.cacheReadInputTokens,
+          }),
+          ...(usage.cacheWriteInputTokens !== undefined && {
+            cacheWriteInputTokens: usage.cacheWriteInputTokens,
+          }),
+        },
+      }),
+    ...(metrics?.latencyMs !== undefined && { metrics: { latencyMs: metrics.latencyMs } }),
+  })
+}
+
+/** The reasoning arm of {@link HarnessContentBlockDelta}, which the AWS SDK does not name separately. */
+type HarnessReasoningDelta = Extract<HarnessContentBlockDelta, { reasoningContent: unknown }>['reasoningContent']
+
+function concatBytes(current: Uint8Array | undefined, chunk: Uint8Array): Uint8Array {
+  if (current === undefined) return chunk
+  const combined = new Uint8Array(current.length + chunk.length)
+  combined.set(current)
+  combined.set(chunk, current.length)
+  return combined
+}
+
+function flushPending(state: StreamState, modelEvents?: ModelStreamEvent[]): void {
+  const pending = state.pending
+  if (!pending) return
+  switch (pending.kind) {
+    case 'text':
+      if (pending.text) state.content.push(new TextBlock(pending.text))
+      break
+    case 'toolUse': {
+      let input: JSONValue = {}
+      if (pending.input) {
+        try {
+          input = JSON.parse(pending.input) as JSONValue
+        } catch (error) {
+          // Retain the first failure and keep decoding: the caller raises it once the turn ends, so a
+          // truncated tool input does not mask a stop reason or later content in the same stream.
+          if (error instanceof SyntaxError && !state.toolInputParseError) state.toolInputParseError = error
+        }
+      }
+      state.content.push(new ToolUseBlock({ toolUseId: pending.toolUseId, name: pending.name, input }))
+      break
+    }
+    case 'toolResult':
+      state.content.push(
+        new ToolResultBlock({ toolUseId: pending.toolUseId, status: pending.status, content: pending.content })
+      )
+      break
+    case 'reasoning':
+      state.content.push(
+        new ReasoningBlock({
+          ...(pending.text && { text: pending.text }),
+          ...(pending.signature !== undefined && { signature: pending.signature }),
+          ...(pending.redactedContent !== undefined && { redactedContent: pending.redactedContent }),
+        })
+      )
+      break
+  }
+  if (modelEvents !== undefined && pending.kind !== 'toolResult') {
+    modelEvents.push(new ModelContentBlockStopEvent({ type: 'modelContentBlockStopEvent' }))
+  }
+  state.pending = undefined
+}
+
+function toolResultContentFromHarness(item: HarnessToolResultContentBlock): ToolResultContent {
+  if ('json' in item && item.json !== undefined) return new JsonBlock({ json: item.json as JSONValue })
+  if ('text' in item && item.text !== undefined) return new TextBlock(item.text)
+  throw new ModelError(`AgentCore Harness returned unsupported tool-result content '${item.$unknown[0]}'`)
+}

--- a/src/harness/integrations/strands/types.ts
+++ b/src/harness/integrations/strands/types.ts
@@ -1,0 +1,38 @@
+import type { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore'
+import type { BedrockAgentCoreControlClient } from '@aws-sdk/client-bedrock-agentcore-control'
+import type { InterventionHandler, ToolList } from '@strands-agents/sdk'
+
+/**
+ * Config for an {@link AgentCoreHarnessAgent}.
+ */
+export interface AgentCoreHarnessAgentConfig {
+  /** ARN of the deployed AgentCore Harness. */
+  readonly harnessArn: string
+
+  /** Conversation session ID. Reuse it across calls to continue one Harness conversation. */
+  readonly runtimeSessionId: string
+
+  /** Identifier unique to this agent instance; defaults to `"{harnessArn}:{runtimeSessionId}"`. */
+  readonly id?: string
+
+  /** Optional name surfaced to Strands multi-agent primitives. */
+  readonly name?: string
+
+  /** Optional description surfaced to Strands multi-agent primitives. */
+  readonly description?: string
+
+  /** Pre-constructed AgentCore data-plane client. */
+  readonly client?: BedrockAgentCoreClient
+
+  /** Pre-constructed AgentCore control-plane client used to load deployed Harness tools. */
+  readonly controlClient?: BedrockAgentCoreControlClient
+
+  /**
+   * Local Strands tools translated into dynamic Harness inline functions and executed client-side.
+   * They are merged with the deployed Harness tools for each invocation.
+   */
+  readonly tools?: ToolList
+
+  /** Tool lifecycle intervention handlers applied to local inline-function callbacks. */
+  readonly interventions?: InterventionHandler[]
+}

--- a/tests_integ/harness-strands.test.ts
+++ b/tests_integ/harness-strands.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration tests for AgentCoreHarnessAgent against a deployed AgentCore Harness.
+ *
+ * Prerequisites:
+ * - AGENTCORE_HARNESS_ARN for a READY Harness
+ * - AWS credentials and AWS_REGION for the Harness account and region
+ *
+ * To run: npm run test:integ -- harness-strands
+ */
+
+import { randomUUID } from 'node:crypto'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  BeforeToolCallEvent,
+  FunctionTool,
+  InterruptResponseContent,
+  InterventionActions,
+  InterventionHandler,
+} from '@strands-agents/sdk'
+import { AgentCoreHarnessAgent } from '../src/harness/integrations/strands/index.js'
+
+const HARNESS_ARN = process.env.AGENTCORE_HARNESS_ARN
+
+class ConfirmInlineFunction extends InterventionHandler {
+  readonly name = 'confirm-inline-function'
+
+  override beforeToolCall(event: BeforeToolCallEvent): ReturnType<(typeof InterventionActions)['confirm']> {
+    return InterventionActions.confirm(`Approve ${event.toolUse.name}?`)
+  }
+}
+
+describe.skipIf(!HARNESS_ARN)('AgentCoreHarnessAgent integration', () => {
+  it('streams a deployed Harness response and continues its session', async () => {
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN!,
+      runtimeSessionId: randomUUID(),
+    })
+    const token = randomUUID()
+
+    const events: string[] = []
+    const generator = agent.stream(`Remember this token for my next message: ${token}. Reply only with "stored".`)
+    let next = await generator.next()
+    while (!next.done) {
+      events.push(next.value.type)
+      next = await generator.next()
+    }
+    const first = next.value
+    const second = await agent.invoke('What token did I ask you to remember? Reply with only the token.')
+
+    expect(events.at(-1)).toBe('agentCoreHarnessResultEvent')
+    expect(events).toContain('agentCoreHarnessStreamUpdateEvent')
+    expect(first.stopReason).toBe('endTurn')
+    expect(second.stopReason).toBe('endTurn')
+    expect(first.toString().length).toBeGreaterThan(0)
+    expect(second.toString()).toContain(token)
+  }, 120_000)
+
+  it('registers and executes a dynamic inline function after human approval', async () => {
+    const token = randomUUID()
+    const functionName = `dynamic_echo_${randomUUID().replaceAll('-', '').slice(0, 8)}`
+    const callback = vi.fn((input: unknown): string => `CLIENT_CALLBACK:${(input as { text: string }).text}`)
+    const agent = new AgentCoreHarnessAgent({
+      harnessArn: HARNESS_ARN!,
+      runtimeSessionId: randomUUID(),
+      tools: [
+        new FunctionTool({
+          name: functionName,
+          description: 'Return text through the client callback',
+          inputSchema: {
+            type: 'object',
+            properties: { text: { type: 'string' } },
+            required: ['text'],
+            additionalProperties: false,
+          },
+          callback,
+        }),
+      ],
+      interventions: [new ConfirmInlineFunction()],
+    })
+
+    const interrupted = await agent.invoke(
+      `Call ${functionName} exactly once with text "${token}", then include its result in your final answer.`
+    )
+
+    expect(interrupted).toMatchObject({
+      stopReason: 'interrupt',
+      interrupts: [{ name: 'confirm-inline-function', reason: `Approve ${functionName}?` }],
+    })
+    expect(callback).not.toHaveBeenCalled()
+
+    const result = await agent.invoke([
+      new InterruptResponseContent({
+        interruptId: interrupted.interrupts![0]!.id,
+        response: 'yes',
+      }),
+    ])
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith({ text: token }, expect.anything())
+    expect(result.stopReason).toBe('endTurn')
+    expect(result.toString()).toContain(token)
+  }, 120_000)
+})


### PR DESCRIPTION
## Description

Introducing `AgentCoreHarnessAgent`, an implementation of the Strands `InvokableAgent` [interface](https://github.com/strands-agents/harness-sdk/blob/11ad6366a1578d432ea4cd2c3ed41b610953d297/strands-ts/src/types/agent.ts#L199-L232) for a deployed [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html). Now, developers can invoke their Harness agent and integrate it into their agentic applications / multi-agent `Graphs` just as easily as a typical Strands Agent today.

The deployed Harness continues to own its model, prompt, default tools, memory, limits, and
server-side agent loop, running in a managed microVM. And now, developers can also pass custom tools to be run *client side*, either human-in-the-loop or automatically. When custom tools are supplied, the adapter calls `GetHarness` to load the deployed tool configuration, merges the custom `inline_function` definitions with those deployed tools, and sends the combined list to InvokeHarness.

### Developer Experience

A normal Strands Agent, today:

```typescript
import { Agent } from '@strands-agents/sdk'

const agent = new Agent({
  systemPrompt: '...',
  tools: [customTool]
})

await agent.invoke('List your tools')
```

Initializing an `AgentCoreHarnessAgent` is practically identical. 

```typescript
import { AgentCoreHarnessAgent } from 'bedrock-agentcore/experimental/harness/strands'

const agent = new AgentCoreHarnessAgent({
  harnessArn: '...',
  runtimeSessionId: '...',
})

await agent.invoke('List your tools')
```

Registering custom tools to be run client side is straightforward.

```typescript
import { FunctionTool } from '@strands-agents/sdk'
import { AgentCoreHarnessAgent } from 'bedrock-agentcore/experimental/harness/strands'

const clientEcho = new FunctionTool({
  name: 'client_echo',
  description: 'Return text from the client',
  inputSchema: {
    type: 'object',
    properties: {
      text: { type: 'string' },
    },
    required: ['text'],
    additionalProperties: false,
  },
  callback: (input) => {
    const { text } = input as { text: string }
    return `CLIENT_CALLBACK:${text}`
  },
})

const agent = new AgentCoreHarnessAgent({
  harnessArn: '...',
  runtimeSessionId: '...',
  tools: [clientEcho],
})

const result = await agent.invoke('Call client_echo with "hello".')
```

## Related Issues

Closes https://github.com/strands-agents/harness-sdk/issues/3052

## Documentation PR

Not yet

## Type of Change

New feature

## Testing

- [x] I ran `npm run check`
- [x] I ran `npm run build`
- [x] I imported the experimental Harness subpath from a packed consumer installation
- [x] I ran the deployed Harness integration tests, including inline-function approval and resume
- [x] I tested the integration in a chat loop (talking to the agent, testing tools calls, etc)

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
