### PR TITLE
Document and test invocation input validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ const app = new BedrockAgentCoreApp({
 app.run()
 ```
 
+Use `requestSchema` to validate agent entrypoint input. Keep user prompts typed as strings and pass only prompt text
+to the agent framework.
+
 `BedrockAgentCoreApp` creates an AgentCore Runtime-compliant server—handling request parsing, streaming responses, and session management for seamless deployment.
 
 ---

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -74,7 +74,10 @@ app.run()
 
 - **Type Safety**: Request is automatically typed based on your Zod schema
 - **Runtime Validation**: Invalid requests are rejected with 400 status code
-- **Optional**: Validation is opt-in - omit `requestSchema` for untyped requests
+- **String Typing**: String schemas keep text-only agent inputs typed as strings
+
+`requestSchema` is optional for compatibility with arbitrary handlers, but no-schema handlers receive the raw request
+body and should validate input before forwarding it to an agent framework.
 
 ## Handler Function
 

--- a/src/runtime/__tests__/app.test.ts
+++ b/src/runtime/__tests__/app.test.ts
@@ -809,6 +809,34 @@ describe('BedrockAgentCoreApp', () => {
         details: expect.any(Array),
       })
     })
+
+    it('rejects non-string prompts when the prompt schema requires a string', async () => {
+      const requestSchema = z.object({ prompt: z.string() })
+      const mockHandler = vi.fn(async (_request, _context) => ({ result: 'success' }))
+      const app = new BedrockAgentCoreApp({ invocationHandler: { process: mockHandler, requestSchema } })
+      const mockApp = app['_app'] as any
+
+      app['_setupRoutes']()
+
+      const postCall = mockApp.post.mock.calls.find((call: any[]) => call[0] === '/invocations')
+      const invocationHandler = postCall[2]
+      const mockReq = {
+        body: {
+          prompt: [{ type: 'text', text: 'not a string prompt' }],
+        },
+        headers: { 'x-amzn-bedrock-agentcore-runtime-session-id': 'session-123' },
+      }
+      const mockReply = { send: vi.fn(), status: vi.fn().mockReturnThis() }
+
+      await invocationHandler(mockReq, mockReply)
+
+      expect(mockHandler).not.toHaveBeenCalled()
+      expect(mockReply.status).toHaveBeenCalledWith(400)
+      expect(mockReply.send).toHaveBeenCalledWith({
+        error: 'Invalid request body format',
+        details: expect.any(Array),
+      })
+    })
   })
 
   describe('websocket handler', () => {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -249,7 +249,8 @@ export interface BedrockAgentCoreAppParams<TSchema extends z.ZodSchema = z.ZodSc
     /**
      * Optional Zod schema for request validation and TypeScript typing.
      * When provided, validates request.body before passing to handler.
-     * When omitted, handler receives unknown request type.
+     * When omitted, the handler receives the raw request body as an unknown type and should validate it
+     * before forwarding it to an agent framework.
      */
     requestSchema?: TSchema
   }

--- a/tests_integ/runtime.test.ts
+++ b/tests_integ/runtime.test.ts
@@ -23,6 +23,8 @@ describe('BedrockAgentCoreApp Integration', () => {
       }
     }
 
+    // This suite intentionally verifies raw no-schema passthrough. Production agent handlers should validate input
+    // before forwarding it to an agent framework.
     app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
     fastify = (app as any)._app
     await (app as any)._registerPlugins()


### PR DESCRIPTION
## What

Clarify that `requestSchema` validates entrypoint input and add a test covering non-string prompt rejection.

- README / runtime README / `types.ts` note that no-schema handlers receive the raw request body and should validate it; string schemas keep text-only inputs typed as strings.
- New test asserts a string-typed prompt schema rejects a non-string prompt with a 400.

## Testing

`npm test` — 618 tests pass. Lint, format:check, type-check pass.