### PR TITLE
chore(deps): bump fast-uri from 3.1.2 to 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5801,9 +5801,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Unblocks the `Security Scanning` workflow on `main`, which has been failing on the prod-only npm audit gate.

`fast-uri` 3.1.2 carries three high-severity host-confusion advisories:

- [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) — literal backslash authority delimiter
- [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) — failed IDN canonicalization
- [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — backslash authority introducer

All three cover `3.0.0 - 3.1.4`, so #222's bump to 3.1.4 does not clear the gate — 3.1.5 is the first patched release. #222 can be closed as superseded.

`fast-uri` is transitive via `fastify` → `@fastify/ajv-compiler`, and 3.1.5 is already in range for the pinned `fastify` 5.8.5. Lockfile-only: no `package.json` edit, no major bump.

## Context

`Security Scanning` on `main` was failing on **two** high-severity prod findings. #223 fixed the first (`find-my-way` 9.5.0 → 9.7.0). This is the second and last one — see [run 30925759149](https://github.com/aws/bedrock-agentcore-sdk-typescript/actions/runs/30925759149/job/92053108657), which is down to `1 high severity vulnerability`, all of it `fast-uri`.

## Testing

Against current `main` (`6f22b55`, i.e. with #223 already merged):

```
$ npm audit --omit=dev --audit-level=high
found 0 vulnerabilities
$ echo $?
0
```

The advisory-only `Run npm audit` step (all severities, `continue-on-error: true`) still reports dev-tree findings; it does not gate the job. Only the `--omit=dev --audit-level=high` step does, and it passes with this change.