### PR TITLE
feat(runtime): provide tools for consuming and propagating WAT

### DIFF
--- a/src/identity/index.ts
+++ b/src/identity/index.ts
@@ -19,7 +19,10 @@
  */
 
 // Higher-order functions for wrapping tools
-export { withAccessToken, withApiKey } from './wrappers.js'
+export { withAccessToken, withApiKey, withWAT } from './wrappers.js'
+
+// Middleware for automatic WAT propagation on AWS SDK clients
+export { withWatPropagation } from './middleware.js'
 
 // All type definitions
 export * from './types.js'

--- a/src/identity/middleware.ts
+++ b/src/identity/middleware.ts
@@ -3,6 +3,7 @@ import type {
   FinalizeHandler,
   FinalizeHandlerArguments,
   FinalizeHandlerOutput,
+  HandlerExecutionContext,
   MetadataBearer,
   MiddlewareStack,
 } from '@smithy/types'
@@ -18,7 +19,7 @@ interface AwsClient {
 
 /**
  * Registers middleware that attaches the WAT header to outbound AWS SDK requests.
- * No-ops when no WAT is present in context.
+ * Only applies to Invoke* operations. No-ops when no WAT is present in context.
  *
  * @param client - Any AWS SDK v3 client instance
  *
@@ -34,9 +35,12 @@ interface AwsClient {
 export function withWatPropagation(client: AwsClient): void {
   client.middlewareStack.add(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (next: FinalizeHandler<any, any>): FinalizeHandler<any, any> =>
+    (next: FinalizeHandler<any, any>, context: HandlerExecutionContext): FinalizeHandler<any, any> =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       async (args: FinalizeHandlerArguments<any>): Promise<FinalizeHandlerOutput<any>> => {
+        if (!context.commandName?.startsWith('Invoke')) {
+          return next(args)
+        }
         const wat = getContext()?.workloadAccessToken
         if (wat && HttpRequest.isInstance(args.request)) {
           args.request.headers[IDENTITY_WAT_HEADER] = wat

--- a/src/identity/middleware.ts
+++ b/src/identity/middleware.ts
@@ -1,0 +1,48 @@
+import { HttpRequest } from '@aws-sdk/protocol-http'
+import type {
+  FinalizeHandler,
+  FinalizeHandlerArguments,
+  FinalizeHandlerOutput,
+  MetadataBearer,
+  MiddlewareStack,
+} from '@smithy/types'
+import { getContext } from '../runtime/context.js'
+import { IDENTITY_WAT_HEADER } from '../runtime/constants.js'
+
+// AWS SDK v3 does not export a generic client interface.
+// https://github.com/aws/aws-sdk-js-v3/issues/5856#issuecomment-2096950979
+interface AwsClient {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  middlewareStack: MiddlewareStack<any, MetadataBearer>
+}
+
+/**
+ * Registers middleware that attaches the WAT header to outbound AWS SDK requests.
+ * No-ops when no WAT is present in context.
+ *
+ * @param client - Any AWS SDK v3 client instance
+ *
+ * @example
+ * ```typescript
+ * import { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore'
+ * import { withWatPropagation } from 'bedrock-agentcore/identity'
+ *
+ * const client = new BedrockAgentCoreClient({ region: 'us-west-2' })
+ * withWatPropagation(client)
+ * ```
+ */
+export function withWatPropagation(client: AwsClient): void {
+  client.middlewareStack.add(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (next: FinalizeHandler<any, any>): FinalizeHandler<any, any> =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async (args: FinalizeHandlerArguments<any>): Promise<FinalizeHandlerOutput<any>> => {
+        const wat = getContext()?.workloadAccessToken
+        if (wat && HttpRequest.isInstance(args.request)) {
+          args.request.headers[IDENTITY_WAT_HEADER] = wat
+        }
+        return next(args)
+      },
+    { step: 'finalizeRequest', priority: 'high', name: 'identityWatPropagation' }
+  )
+}

--- a/src/identity/wrappers.ts
+++ b/src/identity/wrappers.ts
@@ -119,3 +119,36 @@ export function withApiKey(config: ApiKeyWrapperConfig) {
     }
   }
 }
+
+/**
+ * Wraps an async function to automatically inject the Workload Access Token (WAT).
+ * The WAT is read from the current request context and injected as the last parameter.
+ *
+ *
+ * @param fn - Async function whose last parameter receives the WAT
+ * @returns Wrapped function that injects the WAT automatically
+ *
+ * @example
+ * ```typescript
+ * const callGateway = withWAT(async (query: string, wat: string) => {
+ *   return fetch('https://gateway.example.com/mcp', {
+ *     headers: { 'X-Amz-Bedrock-AgentCore-Identity-WAT': wat }
+ *   })
+ * })
+ *
+ * // Inside a request handler — wat injected from context
+ * await callGateway('what is the weather?')
+ * ```
+ */
+export function withWAT<TParams extends unknown[], TReturn>(
+  fn: (...args: [...TParams, string]) => Promise<TReturn>
+): (...args: TParams) => Promise<TReturn> {
+  return async (...args: TParams): Promise<TReturn> => {
+    const context = getContext()
+    const wat = context?.workloadAccessToken
+    if (!wat) {
+      throw new Error('No workload access token in context. Ensure the agent is running on AgentCore Runtime.')
+    }
+    return fn(...args, wat)
+  }
+}

--- a/src/runtime/__tests__/identity-wat.test.ts
+++ b/src/runtime/__tests__/identity-wat.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { BedrockAgentCoreApp } from '../app.js'
+import { withWAT } from '../../identity/wrappers.js'
+import type { RequestContext } from '../types.js'
+
+async function createApp(handler: (request: unknown, context: RequestContext) => Promise<unknown>) {
+  const app = new BedrockAgentCoreApp({ invocationHandler: { process: handler } })
+  await app['_registerPlugins']()
+  app['_setupContentTypeParsers']()
+  app['_setupRoutes']()
+  await app['_app'].ready()
+  return app
+}
+
+function post(app: BedrockAgentCoreApp, headers: Record<string, string>) {
+  return app['_app'].inject({
+    method: 'POST',
+    url: '/invocations',
+    headers: {
+      'content-type': 'application/json',
+      'x-amzn-bedrock-agentcore-runtime-session-id': 'session-1',
+      ...headers,
+    },
+    payload: {},
+  })
+}
+
+describe('Identity WAT propagation', () => {
+  it.each<{ name: string; headers: Record<string, string>; expectedWat: string | undefined }>([
+    {
+      name: 'extracts WAT from new header',
+      headers: { 'x-amz-bedrock-agentcore-identity-wat': 'new-token' },
+      expectedWat: 'new-token',
+    },
+    {
+      name: 'falls back to legacy header',
+      headers: { workloadaccesstoken: 'legacy-token' },
+      expectedWat: 'legacy-token',
+    },
+    {
+      name: 'new header takes precedence over legacy',
+      headers: {
+        'x-amz-bedrock-agentcore-identity-wat': 'new-wins',
+        workloadaccesstoken: 'legacy-loses',
+      },
+      expectedWat: 'new-wins',
+    },
+    {
+      name: 'no WAT headers results in undefined',
+      headers: {},
+      expectedWat: undefined,
+    },
+  ])('$name', async ({ headers, expectedWat }) => {
+    let injectedWat: string | undefined
+
+    const captureToken = withWAT(async (wat: string) => {
+      injectedWat = wat
+    })
+
+    const app = await createApp(async (_request, context) => {
+      if (context.workloadAccessToken) {
+        await captureToken()
+      }
+      return { contextWat: context.workloadAccessToken, injectedWat }
+    })
+
+    const resp = await post(app, headers)
+    const body = JSON.parse(resp.body)
+
+    expect(body.contextWat).toBe(expectedWat)
+    if (expectedWat) {
+      expect(body.injectedWat).toBe(expectedWat)
+    }
+  })
+
+  it('withWAT throws when no WAT in context', async () => {
+    const captureToken = withWAT(async (wat: string) => wat)
+
+    const app = await createApp(async () => {
+      try {
+        await captureToken()
+        return { error: null }
+      } catch (e) {
+        return { error: (e as Error).message }
+      }
+    })
+
+    const resp = await post(app, {})
+    const body = JSON.parse(resp.body)
+
+    expect(body.error).toMatch(/no workload access token in context/i)
+  })
+})

--- a/src/runtime/app.ts
+++ b/src/runtime/app.ts
@@ -27,6 +27,7 @@ import type {
   HealthStatus,
 } from './types.js'
 import { runWithContext } from './context.js'
+import { IDENTITY_WAT_HEADER } from './constants.js'
 
 const require = createRequire(import.meta.url)
 const fastifySse = require('@fastify/sse')
@@ -575,23 +576,27 @@ export class BedrockAgentCoreApp<TSchema extends z.ZodSchema = z.ZodSchema<unkno
     // Filter headers to include only Authorization and Custom-* headers
     const filteredHeaders: Record<string, string> = {}
     for (const [key, value] of Object.entries(request.headers)) {
-      const lowerKey = key.toLowerCase()
-      const stringValue = typeof value === 'string' ? value : Array.isArray(value) ? value.join(', ') : undefined
+      const lowerCaseHeaderName = key.toLowerCase()
+      const headerValue = typeof value === 'string' ? value : Array.isArray(value) ? value.join(', ') : undefined
 
-      if (stringValue) {
+      if (headerValue) {
         // Include Authorization header
-        if (lowerKey === 'authorization') {
-          filteredHeaders[key] = stringValue
+        if (lowerCaseHeaderName === 'authorization') {
+          filteredHeaders[key] = headerValue
         }
         // Include Custom-* headers
-        else if (lowerKey.startsWith('x-amzn-bedrock-agentcore-runtime-custom-')) {
-          filteredHeaders[key] = stringValue
+        else if (lowerCaseHeaderName.startsWith('x-amzn-bedrock-agentcore-runtime-custom-')) {
+          filteredHeaders[key] = headerValue
+        } else if (lowerCaseHeaderName === IDENTITY_WAT_HEADER) {
+          filteredHeaders[key] = headerValue
         }
       }
     }
 
     // Extract workload token from header (if present)
-    const workloadAccessToken = request.headers['workloadaccesstoken'] as string | undefined
+    const workloadAccessToken = (request.headers[IDENTITY_WAT_HEADER] || request.headers['workloadaccesstoken']) as
+      | string
+      | undefined
 
     return {
       sessionId,

--- a/src/runtime/constants.ts
+++ b/src/runtime/constants.ts
@@ -1,0 +1,1 @@
+export const IDENTITY_WAT_HEADER = 'x-amz-bedrock-agentcore-identity-wat'

--- a/tests_integ/runtime.test.ts
+++ b/tests_integ/runtime.test.ts
@@ -7,7 +7,10 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import request from 'supertest'
 import WebSocket from 'ws'
+import { BedrockAgentCoreClient, InvokeCodeInterpreterCommand } from '@aws-sdk/client-bedrock-agentcore'
 import { BedrockAgentCoreApp } from '../src/runtime/app.js'
+import { withWatPropagation } from '../src/identity/middleware.js'
+import { runWithContext } from '../src/runtime/context.js'
 import type { InvocationHandler } from '../src/runtime/types.js'
 
 describe('BedrockAgentCoreApp Integration', () => {
@@ -154,7 +157,10 @@ describe('BedrockAgentCoreApp Integration', () => {
       await request(fastify.server).post('/invocations').send({ test: 'data' }).expect(400)
     })
 
-    it('extracts workloadAccessToken from header', async () => {
+    it.each([
+      { headerName: 'workloadaccesstoken', token: 'legacy-token-123' },
+      { headerName: 'x-amz-bedrock-agentcore-identity-wat', token: 'wat-token-456' },
+    ])('extracts workloadAccessToken from $headerName header', async ({ headerName, token }) => {
       const handler: InvocationHandler = async (req, context) => {
         return { token: context.workloadAccessToken }
       }
@@ -166,11 +172,11 @@ describe('BedrockAgentCoreApp Integration', () => {
       await request((testApp as any)._app.server)
         .post('/invocations')
         .set('x-amzn-bedrock-agentcore-runtime-session-id', 'test-session')
-        .set('workloadaccesstoken', 'test-token-123')
+        .set(headerName, token)
         .send({})
         .expect(200)
         .expect(function (res) {
-          expect(res.body.token).toBe('test-token-123')
+          expect(res.body.token).toBe(token)
         })
     })
 
@@ -1519,6 +1525,43 @@ Bob Johnson,35,Chicago`
           mixedServer.close(() => resolve())
         })
       }
+    })
+  })
+
+  describe('Identity WAT Propagation', () => {
+    it('middleware attaches WAT header to outbound SDK requests', async () => {
+      const client = new BedrockAgentCoreClient({ region: 'us-east-1' })
+      withWatPropagation(client)
+
+      let capturedHeaders: Record<string, string> = {}
+
+      // Interceptor: capture headers, don't send to AWS
+      client.middlewareStack.add(
+        ((_next: any) => async (args: any) => {
+          capturedHeaders = args.request.headers
+          return { output: {}, response: {} }
+        }) as any,
+        { step: 'finalizeRequest', priority: 'low', name: 'testInterceptor' }
+      )
+
+      // Run inside a context that has a WAT
+      await runWithContext(
+        { sessionId: 'test', headers: {}, workloadAccessToken: 'my-wat-token', log: console as any },
+        async () => {
+          try {
+            await client.send(
+              new InvokeCodeInterpreterCommand({
+                codeInterpreterIdentifier: 'fake',
+                name: 'executeCode',
+              })
+            )
+          } catch {
+            /* expected */
+          }
+        }
+      )
+
+      expect(capturedHeaders['x-amz-bedrock-agentcore-identity-wat']).toBe('my-wat-token')
     })
   })
 })

--- a/tests_integ/runtime.test.ts
+++ b/tests_integ/runtime.test.ts
@@ -7,7 +7,11 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import request from 'supertest'
 import WebSocket from 'ws'
-import { BedrockAgentCoreClient, InvokeCodeInterpreterCommand } from '@aws-sdk/client-bedrock-agentcore'
+import {
+  BedrockAgentCoreClient,
+  InvokeCodeInterpreterCommand,
+  CreateEventCommand,
+} from '@aws-sdk/client-bedrock-agentcore'
 import { BedrockAgentCoreApp } from '../src/runtime/app.js'
 import { withWatPropagation } from '../src/identity/middleware.js'
 import { runWithContext } from '../src/runtime/context.js'
@@ -1529,13 +1533,27 @@ Bob Johnson,35,Chicago`
   })
 
   describe('Identity WAT Propagation', () => {
-    it('middleware attaches WAT header to outbound SDK requests', async () => {
-      const client = new BedrockAgentCoreClient({ region: 'us-east-1' })
+    it.each([
+      {
+        name: 'attaches WAT on Invoke operations',
+        command: new InvokeCodeInterpreterCommand({ codeInterpreterIdentifier: 'fake', name: 'executeCode' }),
+        expectHeader: true,
+      },
+      {
+        name: 'does not attach WAT on non-Invoke operations',
+        command: new CreateEventCommand({ memoryId: 'fake', actorId: 'fake', eventTimestamp: new Date(), payload: [] }),
+        expectHeader: false,
+      },
+    ])('$name', async ({ command, expectHeader }) => {
+      const client = new BedrockAgentCoreClient({
+        region: 'us-east-1',
+        endpoint: 'https://fake.example.com',
+        credentials: { accessKeyId: 'fake', secretAccessKey: 'fake' },
+      })
       withWatPropagation(client)
 
       let capturedHeaders: Record<string, string> = {}
 
-      // Interceptor: capture headers, don't send to AWS
       client.middlewareStack.add(
         ((_next: any) => async (args: any) => {
           capturedHeaders = args.request.headers
@@ -1544,24 +1562,22 @@ Bob Johnson,35,Chicago`
         { step: 'finalizeRequest', priority: 'low', name: 'testInterceptor' }
       )
 
-      // Run inside a context that has a WAT
       await runWithContext(
         { sessionId: 'test', headers: {}, workloadAccessToken: 'my-wat-token', log: console as any },
         async () => {
           try {
-            await client.send(
-              new InvokeCodeInterpreterCommand({
-                codeInterpreterIdentifier: 'fake',
-                name: 'executeCode',
-              })
-            )
+            await client.send(command as any)
           } catch {
             /* expected */
           }
         }
       )
 
-      expect(capturedHeaders['x-amz-bedrock-agentcore-identity-wat']).toBe('my-wat-token')
+      if (expectHeader) {
+        expect(capturedHeaders['x-amz-bedrock-agentcore-identity-wat']).toBe('my-wat-token')
+      } else {
+        expect(capturedHeaders['x-amz-bedrock-agentcore-identity-wat']).toBeUndefined()
+      }
     })
   })
 })


### PR DESCRIPTION
### Problem 
Closes: https://github.com/aws/bedrock-agentcore-sdk-typescript/issues/235

Summary: The python sdk received some changes to make it easier to consume and propagate the WAT, we want the same here. 


### Solution
- Add `withWat` wrapper that injects WAT from context into function as last paramter (following existing pattern). 
- Add `registerIdentityWatPropagation` middleware that propagates the token on all outbound requests for a given AWS SDK client. 
- add logic to accept incoming WAT. 

### Testing/Verification 
- added unit tests that verify the flow up to the network call. 
- added integ tests the verify the whole flow. 