### PR TITLE
ci: add Slack PR review notification caller

### DIFF
--- a/.github/workflows/slack-pr-review-notification.yml
+++ b/.github/workflows/slack-pr-review-notification.yml
@@ -1,0 +1,19 @@
+# Caller: posts PR-review activity to the "PR Summary" Slack workflow with @-mentions.
+# Repo-agnostic (the reusable auto-detects github.repository).
+name: Slack PR Review Notification
+
+on:
+  pull_request:
+    types: [review_requested, synchronize]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
+
+jobs:
+  call:
+    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@626595f508220b53805c86c1b54d089420add4d3
+    secrets: inherit


### PR DESCRIPTION
Adds the caller that pings PR reviewers in Slack via the shared reusable `reusable-slack-pr-review-notification` (pinned `@626595f`, merged to devtools main).

| event | pings |
|---|---|
| review requested | the requested reviewer |
| review submitted | the PR author |
| new revision (synchronize) | prior reviewers + commenters + pending requested reviewers |

Mentions render as real Slack pills (Person-type vars via `SLACK_PR_REVIEW_USER_MAP`). Secrets + reader-role grants already in place for this repo. Same caller already merged/open for agentcore-cli.