### PR TITLE
fix(ci): remove interpolated context value in script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,11 @@ jobs:
 
     steps:
       - name: Validate running from main
+        env: 
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "⚠️  WARNING: Running from ${{ github.ref }}"
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "⚠️  WARNING: Running from $GITHUB_REF"
             echo "⚠️  Production releases should only run from main branch"
           fi
 


### PR DESCRIPTION
## Problem

we are not following best practices from https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks. 

## Solution

Move `github.ref` to an environment variable (`GITHUB_REF`) and reference it as `$GITHUB_REF` in the shell script. Environment variables are safely handled by the shell and not subject to pre-execution interpolation.

Note: the practical risk is low here since ref is difficult to manipulate and only injectable by users with write access. 