### PR TITLE
ci: use dedicated release runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     outputs:
       version: ${{ steps.bump.outputs.version }}
       branch: ${{ steps.bump.outputs.branch }}
@@ -198,7 +198,7 @@ jobs:
   test-and-build:
     name: Test and Build
     needs: prepare-release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
 
     steps:
       - uses: actions/checkout@v6
@@ -256,7 +256,7 @@ jobs:
   release-approval:
     name: Release Approval
     needs: test-and-build
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     environment:
       name: npm-approval
 
@@ -279,7 +279,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: [prepare-release, release-approval]
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     # CRITICAL: Only run from main branch
     if: github.ref == 'refs/heads/main'
     environment:


### PR DESCRIPTION
## Description

Moves the release workflow to the dedicated `aws-release-4-core` GitHub-hosted runner group. This prevents releases from waiting behind the shared `ubuntu-latest` pool while keeping npm provenance on GitHub Actions.

The workflow remains manually triggered with `workflow_dispatch`; no pull-request-triggered workflow can target the release runner. There are no public API changes.

## Related Issues

N/A - operational CI capacity change.

## Documentation PR

N/A

## Type of Change

Other: CI configuration

## Testing

How have you tested the change?

- [ ] I ran `npm run check`
- [x] Parsed the modified workflow as YAML
- [x] Verified every release job uses `aws-release-4-core`
- [x] Verified the workflow has no `pull_request` trigger

Source tests were not run because this change only updates workflow runner labels.

## Checklist

- [ ] I have read the CONTRIBUTING document
- [x] No source tests are needed for this workflow-only change
- [x] No documentation changes are needed
- [x] My changes generate no new warnings
- [x] No dependent changes are required

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
