### PR TITLE
feat(harness): add experimental AgentCore Harness Strands adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,16 @@ bedrock-agentcore-sdk-typescript/
 │   └── TESTING.md                # Comprehensive testing guidelines
 │
 ├── src/                          # Source code (all production code)
+│   ├── harness/                  # AgentCore Harness integrations
+│   │   └── integrations/         # Framework-specific integrations
+│   │       └── strands/          # AgentCoreHarnessAgent (Strands InvokableAgent)
+│   │           ├── __tests__/    # Unit tests for the Harness adapter
+│   │           ├── README.md     # Harness Strands usage and ownership guide
+│   │           ├── agent.ts      # AgentCoreHarnessAgent implementation
+│   │           ├── events.ts     # Harness stream event wrappers
+│   │           ├── index.ts      # Harness Strands integration exports
+│   │           ├── stream-decoder.ts  # InvokeHarness stream to Strands message
+│   │           └── types.ts      # Harness adapter type definitions
 │   ├── runtime/                  # Runtime server for hosting agents
 │   │   ├── __tests__/            # Unit tests for runtime
 │   │   ├── app.ts                # BedrockAgentCoreApp implementation
@@ -129,6 +139,8 @@ bedrock-agentcore-sdk-typescript/
 - **`.husky/`**: Git hooks for pre-commit quality checks and validation
 - **`docs/`**: Comprehensive documentation for development processes and guidelines
 - **`src/`**: All production source code for the SDK
+- **`src/harness/`**: Adapters exposing a deployed AgentCore Harness through agent-framework interfaces
+- **`src/harness/integrations/strands/`**: `AgentCoreHarnessAgent`, a Strands `InvokableAgent` backed by `InvokeHarness`
 - **`src/runtime/`**: HTTP server for hosting agents on AWS Bedrock AgentCore Runtime
 - **`src/tools/`**: Tool definitions and implementations for browser automation and code interpretation
 - **`src/tools/browser/`**: Browser automation client with AWS Bedrock integration
@@ -187,6 +199,10 @@ The SDK follows a layered integration pattern:
 2. **Integrations translate**: Convert between framework types and AWS types
 3. **Clear separation**: Each framework gets its own subdirectory
 4. **Testability**: Mock at client layer, not AWS SDK layer
+
+The Harness integration translates directly between Strands and
+`@aws-sdk/client-bedrock-agentcore` because `InvokeHarness` is already the framework-agnostic client
+surface. It does not introduce a redundant Harness base client.
 
 ## Development Workflow for Agents
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ const agent = new Agent({
 - **Browser** — Cloud-based web automation → [Examples](https://github.com/awslabs/bedrock-agentcore-samples-typescript/tree/main/primitives/tools/browser)
 - **Identity** — Manage API keys and OAuth tokens → [Examples](https://github.com/awslabs/bedrock-agentcore-samples-typescript/tree/main/primitives/identity)
 - **Memory** — Persistent knowledge across sessions → [Guide](docs/MEMORY.md)
+- **Harness** — Invoke a deployed Harness as a Strands agent (experimental) → [Guide](src/harness/integrations/strands/README.md)
 - **Gateway** — Transform APIs into MCP tools (coming soon)
 - **Observability** — OpenTelemetry tracing (coming soon)
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
       "import": "./dist/src/memory/integrations/strands/index.js",
       "types": "./dist/src/memory/integrations/strands/index.d.ts"
     },
+    "./experimental/harness/strands": {
+      "import": "./dist/src/harness/integrations/strands/index.js",
+      "types": "./dist/src/harness/integrations/strands/index.d.ts"
+    },
     "./runtime": {
       "import": "./dist/src/runtime/index.js",
       "types": "./dist/src/runtime/index.d.ts"

--- a/src/harness/integrations/strands/README.md
+++ b/src/harness/integrations/strands/README.md
@@ -1,0 +1,83 @@
+# AgentCore Harness for Strands (`bedrock-agentcore/experimental/harness/strands`)
+
+`AgentCoreHarnessAgent` adapts a deployed
+[AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html) to the
+Strands `InvokableAgent` interface, so it can be invoked directly or composed into a `Graph`.
+
+This integration is experimental and may change before promotion to a stable import path. It requires
+`@strands-agents/sdk` 1.5.0 or later.
+
+## Installation
+
+```bash
+npm install bedrock-agentcore @strands-agents/sdk
+```
+
+## Usage
+
+```typescript
+import { randomUUID } from 'node:crypto'
+import { AgentCoreHarnessAgent } from 'bedrock-agentcore/experimental/harness/strands'
+
+const agent = new AgentCoreHarnessAgent({
+  harnessArn: process.env.AGENTCORE_HARNESS_ARN!,
+  runtimeSessionId: randomUUID(),
+})
+
+const result = await agent.invoke('Tell me about your local environment.')
+console.log(result.toString())
+```
+
+Each `invoke()` or `stream()` call sends one text message through `InvokeHarness`. Reuse the same
+`runtimeSessionId` to continue the Harness-owned conversation.
+
+## Streaming
+
+`stream()` yields an `AgentCoreHarnessStreamUpdateEvent` for every non-error `InvokeHarness` event,
+followed by one `AgentCoreHarnessResultEvent`.
+
+```typescript
+for await (const event of agent.stream('Summarize the worktree.')) {
+  if (event.type === 'agentCoreHarnessStreamUpdateEvent' && 'contentBlockDelta' in event.event) {
+    process.stdout.write(event.event.contentBlockDelta?.delta?.text ?? '')
+  }
+}
+```
+
+## Composition
+
+```typescript
+import { Graph } from '@strands-agents/sdk/multiagent'
+
+const graph = new Graph({
+  nodes: [localResearcher, harnessAgent],
+  edges: [[localResearcher.id, harnessAgent.id]],
+})
+
+await graph.invoke('Research and summarize.')
+```
+
+## Ownership Boundary
+
+The deployed Harness owns its model, system prompt, tools, skills, memory, limits, and server-side
+agent loop. This adapter does not register or execute client-side tools, continue inline functions,
+answer interrupts, or override Harness configuration per request.
+
+The following inputs are rejected before a request is made:
+
+| Input or option          | Reason                                                                 |
+| ------------------------ | ---------------------------------------------------------------------- |
+| Non-text content blocks  | `InvokeHarness` receives text only through this adapter                |
+| Interrupt responses      | The Harness owns its loop; there is no client-side interrupt to answer |
+| `structuredOutputSchema` | Structured output is not part of the Harness invocation contract       |
+| `limits`                 | Execution limits belong to the deployed Harness                        |
+
+A string is sent verbatim, text blocks are joined with newlines, and message history contributes only
+its latest user message. Earlier turns already live in the Harness session and are not replayed.
+
+The default data-plane client uses standard AWS configuration resolution with `maxAttempts: 1`.
+Provide a pre-built `BedrockAgentCoreClient` through `client` to customize its configuration, but it
+must also resolve `maxAttempts` to `1`. Retrying a stateful Harness turn could duplicate work.
+
+An instance supports one invocation at a time. Concurrent calls throw `ConcurrentInvocationError`;
+construct one adapter per concurrent conversation.

--- a/src/harness/integrations/strands/__tests__/agent.test.ts
+++ b/src/harness/integrations/strands/__tests__/agent.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it, type MockInstance, vi } from 'vitest'
+import {
+  BedrockAgentCoreClient,
+  InvokeHarnessCommand,
+  type HarnessReasoningContentBlockDelta,
+  type InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import {
+  ConcurrentInvocationError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  Message,
+  ModelThrottledError,
+  ReasoningBlock,
+  TextBlock,
+} from '@strands-agents/sdk'
+import { Graph } from '@strands-agents/sdk/multiagent'
+import { AgentCoreHarnessAgent } from '../agent.js'
+import type { AgentCoreHarnessStreamUpdateEvent } from '../events.js'
+import type { AgentCoreHarnessAgentConfig } from '../types.js'
+
+const HARNESS_ARN = 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/TestHarness-abcdefghij'
+const RUNTIME_SESSION_ID = 'session-id-padded-to-thirty-three'
+
+type SendMock = MockInstance<BedrockAgentCoreClient['send']>
+type HarnessEvent = AgentCoreHarnessStreamUpdateEvent['event']
+
+const harnessEvent = {
+  messageStart: (role: 'assistant' | 'user' = 'assistant'): HarnessEvent =>
+    ({ messageStart: { role } }) as HarnessEvent,
+  textDelta: (text: string): HarnessEvent => ({ contentBlockDelta: { delta: { text } } }) as HarnessEvent,
+  reasoningDelta: (reasoningContent: HarnessReasoningContentBlockDelta): HarnessEvent =>
+    ({ contentBlockDelta: { delta: { reasoningContent } } }) as HarnessEvent,
+  contentBlockStop: (): HarnessEvent => ({ contentBlockStop: {} }) as HarnessEvent,
+  messageStop: (stopReason: string): HarnessEvent => ({ messageStop: { stopReason } }) as HarnessEvent,
+}
+
+describe('AgentCoreHarnessAgent', () => {
+  it('rejects an injected client that can retry a stateful turn', async () => {
+    const client = new BedrockAgentCoreClient({ region: 'us-east-1', maxAttempts: 2 })
+    const send = vi.spyOn(client, 'send')
+
+    await expect(createHarnessAgent({ client }).invoke('Run it.')).rejects.toThrow(
+      'requires an AgentCore client configured with maxAttempts: 1; received 2'
+    )
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('sends one text request and streams raw events before the final result', async () => {
+    const events = [
+      harnessEvent.messageStart(),
+      harnessEvent.textDelta('Discarded turn'),
+      harnessEvent.messageStop('tool_use'),
+      harnessEvent.messageStart(),
+      harnessEvent.reasoningDelta({ text: 'considering' }),
+      harnessEvent.reasoningDelta({ signature: 'signed' }),
+      harnessEvent.contentBlockStop(),
+      harnessEvent.textDelta('Complete.'),
+      harnessEvent.messageStop('end_turn'),
+    ]
+    const { client, send } = createMockClient(harnessStream(...events))
+    const { items, result } = await collectGenerator(
+      createHarnessAgent({ client }).stream([
+        new Message({ role: 'user', content: [new TextBlock('Earlier')] }),
+        new Message({ role: 'assistant', content: [new TextBlock('Reply')] }),
+        new Message({ role: 'user', content: [new TextBlock('Latest'), new TextBlock('request')] }),
+      ])
+    )
+
+    expect(commandInput(send)).toStrictEqual({
+      harnessArn: HARNESS_ARN,
+      runtimeSessionId: RUNTIME_SESSION_ID,
+      messages: [{ role: 'user', content: [{ text: 'Latest\nrequest' }] }],
+    })
+    expect(result).toMatchObject({
+      stopReason: 'endTurn',
+      lastMessage: {
+        role: 'assistant',
+        content: [new ReasoningBlock({ text: 'considering', signature: 'signed' }), new TextBlock('Complete.')],
+      },
+    })
+    expect(items.map((event) => event.toJSON())).toStrictEqual([
+      ...events.map((event) => ({ type: 'agentCoreHarnessStreamUpdateEvent', event })),
+      { type: 'agentCoreHarnessResultEvent', result },
+    ])
+  })
+
+  it('does not decode a buffered chunk returned by the read that triggers cancellation', async () => {
+    const controller = new globalThis.AbortController()
+    const events = [harnessEvent.messageStart(), harnessEvent.textDelta('before'), harnessEvent.textDelta(' after')]
+    const stream = (async function* (): AsyncGenerator<InvokeHarnessStreamOutput> {
+      yield events[0]!
+      yield events[1]!
+      controller.abort()
+      yield events[2]!
+    })()
+
+    const { items, result } = await collectGenerator(
+      createHarnessAgent({ client: createMockClient(stream).client }).stream('Run it.', {
+        cancelSignal: controller.signal,
+      })
+    )
+
+    expect(result).toMatchObject({ stopReason: 'cancelled', lastMessage: { content: [new TextBlock('before')] } })
+    expect(items.map((event) => event.type)).toStrictEqual([
+      'agentCoreHarnessStreamUpdateEvent',
+      'agentCoreHarnessStreamUpdateEvent',
+      'agentCoreHarnessResultEvent',
+    ])
+  })
+
+  it('rejects concurrent work, then aborts and releases when the consumer stops', async () => {
+    const { client, send } = createMockClient()
+    send.mockImplementationOnce((_command, options) => {
+      return new Promise((_resolve, reject) => {
+        options!.abortSignal!.onabort = (): void => reject(new Error('aborted'))
+      }) as never
+    })
+    send.mockResolvedValueOnce({ stream: textTurn('Available again.') } as never)
+    const agent = createHarnessAgent({ client })
+    const generator = agent.stream('Run it.')
+
+    const pendingNext = generator.next()
+    await expect(agent.invoke('Concurrent')).rejects.toBeInstanceOf(ConcurrentInvocationError)
+    const pendingReturn = generator.return(undefined as never)
+
+    await expect(pendingNext).resolves.toMatchObject({ value: { result: { stopReason: 'cancelled' } } })
+    await pendingReturn
+    await expect(agent.invoke('Run it again.')).resolves.toMatchObject({ stopReason: 'endTurn' })
+  })
+
+  it.each([
+    ['empty input', '', undefined],
+    ['non-text input', [new ReasoningBlock({ text: 'private' })], undefined],
+    ['interrupt response', [{ interruptResponse: { interruptId: 'interrupt-1', response: 'continue' } }], undefined],
+    ['structured output', 'Hi', { structuredOutputSchema: {} }],
+    ['limits', 'Hi', { limits: { turns: 1 } }],
+  ])('rejects %s before calling AgentCore', async (_label, args, options) => {
+    const { client, send } = createMockClient()
+    const invocation = createHarnessAgent({ client }).invoke(args as never, options as never)
+
+    await expect(invocation).rejects.toBeInstanceOf(TypeError)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('translates a context-window validation error from the stream', async () => {
+    const { client } = createMockClient(
+      harnessStream({ validationException: { message: 'Prompt is too long' } } as InvokeHarnessStreamOutput)
+    )
+    await expect(createHarnessAgent({ client }).invoke('Run it.')).rejects.toBeInstanceOf(ContextWindowOverflowError)
+  })
+
+  it('rejects a terminal tool request instead of reporting a successful result', async () => {
+    const { client } = createMockClient(
+      harnessStream(harnessEvent.messageStart(), harnessEvent.messageStop('tool_use'))
+    )
+    await expect(createHarnessAgent({ client }).invoke('Run it.')).rejects.toThrow(
+      'cannot complete a Harness continuation with stop reason: toolUse'
+    )
+  })
+
+  it('surfaces max-token termination with the partial message', async () => {
+    const { client } = createMockClient(
+      harnessStream(
+        harnessEvent.messageStart(),
+        harnessEvent.textDelta('partial'),
+        harnessEvent.messageStop('max_tokens')
+      )
+    )
+    const error = await createHarnessAgent({ client })
+      .invoke('Run it.')
+      .catch((thrown: unknown) => thrown)
+
+    expect(error).toBeInstanceOf(MaxTokensError)
+    expect((error as MaxTokensError).partialMessage.content).toStrictEqual([new TextBlock('partial')])
+  })
+
+  it('normalizes a throttled AgentCore request', async () => {
+    const error = Object.assign(new Error('request failed'), { name: 'ThrottlingException' })
+    const { client, send } = createMockClient()
+    send.mockRejectedValueOnce(error)
+
+    await expect(createHarnessAgent({ client }).invoke('Run it.')).rejects.toBeInstanceOf(ModelThrottledError)
+  })
+
+  it('runs as a Graph node and receives its predecessor output', async () => {
+    const { client, send } = createMockClient(textTurn('Upstream summary'), textTurn('Harness graph result'))
+    const upstream = createHarnessAgent({ client, id: 'upstream' })
+    const downstream = createHarnessAgent({ client, id: 'downstream' })
+    const graph = new Graph({ nodes: [upstream, downstream], edges: [[upstream.id, downstream.id]] })
+
+    const result = await graph.invoke('Original task')
+
+    expect(result.content).toStrictEqual([new TextBlock('Harness graph result')])
+    expect(commandInput(send, 1).messages![0]!.content![0]).toMatchObject({
+      text: expect.stringContaining('Upstream summary'),
+    })
+  })
+})
+
+async function* harnessStream(...events: InvokeHarnessStreamOutput[]): AsyncGenerator<InvokeHarnessStreamOutput> {
+  yield* events
+}
+
+function textTurn(text: string): AsyncGenerator<InvokeHarnessStreamOutput> {
+  return harnessStream(harnessEvent.messageStart(), harnessEvent.textDelta(text), harnessEvent.messageStop('end_turn'))
+}
+
+function createMockClient(...streams: AsyncIterable<InvokeHarnessStreamOutput>[]): {
+  client: BedrockAgentCoreClient
+  send: SendMock
+} {
+  const client = new BedrockAgentCoreClient({ region: 'us-east-1', maxAttempts: 1 })
+  const send = vi.spyOn(client, 'send')
+  streams.forEach((stream) => send.mockResolvedValueOnce({ stream } as never))
+  return { client, send }
+}
+
+function commandInput(send: SendMock, index = 0): InvokeHarnessCommand['input'] {
+  return (send.mock.calls[index]![0] as InvokeHarnessCommand).input
+}
+
+function createHarnessAgent(config: Partial<AgentCoreHarnessAgentConfig> = {}): AgentCoreHarnessAgent {
+  return new AgentCoreHarnessAgent({
+    harnessArn: HARNESS_ARN,
+    runtimeSessionId: RUNTIME_SESSION_ID,
+    ...config,
+  })
+}
+
+async function collectGenerator<T, R>(generator: AsyncGenerator<T, R, undefined>): Promise<{ items: T[]; result: R }> {
+  const items: T[] = []
+  let next = await generator.next()
+  while (!next.done) {
+    items.push(next.value)
+    next = await generator.next()
+  }
+  return { items, result: next.value }
+}

--- a/src/harness/integrations/strands/agent.ts
+++ b/src/harness/integrations/strands/agent.ts
@@ -1,0 +1,275 @@
+import { BedrockAgentCoreClient, InvokeHarnessCommand } from '@aws-sdk/client-bedrock-agentcore'
+import {
+  AgentResult,
+  ConcurrentInvocationError,
+  ContextWindowOverflowError,
+  MaxTokensError,
+  ModelError,
+  ModelThrottledError,
+} from '@strands-agents/sdk'
+import type { ContentBlock, ContentBlockData, InvokeArgs, InvokeOptions, MessageData } from '@strands-agents/sdk'
+import {
+  AgentCoreHarnessResultEvent,
+  AgentCoreHarnessStreamUpdateEvent,
+  type AgentCoreHarnessStreamEvent,
+} from './events.js'
+import { HarnessStreamDecoder } from './stream-decoder.js'
+import type { AgentCoreHarnessAgentConfig } from './types.js'
+
+const DEFAULT_MAX_ATTEMPTS = 1
+const CONTEXT_WINDOW_OVERFLOW_MESSAGES = [
+  'input is too long for requested model',
+  'input length and `max_tokens` exceed context limit',
+  'too many total text bytes',
+  'prompt is too long',
+]
+
+/**
+ * Adapts one deployed [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html)
+ * to the Strands `InvokableAgent` interface, so a Harness composes into a Strands `Graph`.
+ *
+ * Each call sends one non-empty text message through `InvokeHarness`; message history contributes only
+ * its latest user message.
+ *
+ * The deployed Harness owns its model, system prompt, tools, skills, memory, limits, and agent loop, and
+ * runs tool calls inside its own microVM. Reuse one `runtimeSessionId` to continue a conversation.
+ *
+ * @experimental
+ *
+ * @example
+ * ```typescript
+ * import { randomUUID } from 'node:crypto'
+ * import { AgentCoreHarnessAgent } from 'bedrock-agentcore/experimental/harness/strands'
+ *
+ * const agent = new AgentCoreHarnessAgent({
+ *   harnessArn: process.env.AGENTCORE_HARNESS_ARN!,
+ *   runtimeSessionId: randomUUID(),
+ * })
+ *
+ * const result = await agent.invoke('Tell me about your local environment.')
+ * console.log(result.toString())
+ * ```
+ */
+export class AgentCoreHarnessAgent {
+  private readonly _client: BedrockAgentCoreClient
+  private readonly _harnessArn: string
+  private readonly _runtimeSessionId: string
+  private _isInvoking = false
+
+  /** Identifier unique to this Harness session. */
+  readonly id: string
+
+  /** Name surfaced to Strands multi-agent primitives. */
+  readonly name?: string
+
+  /** Description surfaced to Strands multi-agent primitives. */
+  readonly description?: string
+
+  /**
+   * Creates a Harness adapter.
+   *
+   * @param config - Harness identity, session, and optional AgentCore client
+   */
+  constructor(config: AgentCoreHarnessAgentConfig) {
+    this._harnessArn = config.harnessArn
+    this._runtimeSessionId = config.runtimeSessionId
+    this.id = config.id ?? `${config.harnessArn}:${config.runtimeSessionId}`
+    if (config.name !== undefined) this.name = config.name
+    if (config.description !== undefined) this.description = config.description
+
+    // AgentCore owns Harness ARN and session-ID validation.
+    this._client = config.client ?? new BedrockAgentCoreClient({ maxAttempts: DEFAULT_MAX_ATTEMPTS })
+  }
+
+  /**
+   * Invokes the deployed Harness and returns its final result.
+   *
+   * @param args - Non-empty text as a string, text blocks, or message history
+   * @param options - Cancellation and invocation state; other options are unsupported
+   * @returns Final Harness result
+   */
+  async invoke(args: InvokeArgs, options?: InvokeOptions): Promise<AgentResult> {
+    const generator = this.stream(args, options)
+    let next = await generator.next()
+    while (!next.done) {
+      next = await generator.next()
+    }
+    return next.value
+  }
+
+  /**
+   * Streams one `InvokeHarness` request.
+   *
+   * @param args - Non-empty text as a string, text blocks, or message history
+   * @param options - Cancellation and invocation state; other options are unsupported
+   * @returns Raw Harness events followed by the final result event and generator return value
+   */
+  stream(
+    args: InvokeArgs,
+    options?: InvokeOptions
+  ): AsyncGenerator<AgentCoreHarnessStreamEvent, AgentResult, undefined> {
+    const transportAbortController = new AbortController()
+    const generator = this._stream(args, options, transportAbortController)
+    const close = generator.return.bind(generator)
+    const fail = generator.throw.bind(generator)
+
+    generator.return = (
+      value: AgentResult | PromiseLike<AgentResult>
+    ): Promise<IteratorResult<AgentCoreHarnessStreamEvent, AgentResult>> => {
+      transportAbortController.abort()
+      return close(value)
+    }
+    generator.throw = (error?: unknown): Promise<IteratorResult<AgentCoreHarnessStreamEvent, AgentResult>> => {
+      transportAbortController.abort()
+      return fail(error)
+    }
+    return generator
+  }
+
+  private async *_stream(
+    args: InvokeArgs,
+    options: InvokeOptions | undefined,
+    transportAbortController: AbortController
+  ): AsyncGenerator<AgentCoreHarnessStreamEvent, AgentResult, undefined> {
+    if (this._isInvoking) {
+      throw new ConcurrentInvocationError(
+        'AgentCoreHarnessAgent is already processing an invocation. Wait for the current invoke() or stream() call to complete before invoking again.'
+      )
+    }
+    this._isInvoking = true
+    const invocationState = options?.invocationState ?? {}
+    const abortSignal = options?.cancelSignal
+      ? AbortSignal.any([transportAbortController.signal, options.cancelSignal])
+      : transportAbortController.signal
+    const decoder = new HarnessStreamDecoder()
+
+    try {
+      const text = textFromInvokeArgs(args)
+      if (options?.structuredOutputSchema !== undefined) {
+        throw new TypeError('InvokeOptions.structuredOutputSchema is not supported by AgentCoreHarnessAgent.')
+      }
+      if (options?.limits !== undefined) {
+        throw new TypeError('InvokeOptions.limits is not supported by AgentCoreHarnessAgent.')
+      }
+
+      if (!abortSignal.aborted) {
+        const maxAttempts = await this._client.config.maxAttempts()
+        if (maxAttempts !== DEFAULT_MAX_ATTEMPTS) {
+          throw new TypeError(
+            `AgentCoreHarnessAgent requires an AgentCore client configured with maxAttempts: 1; received ${maxAttempts}.`
+          )
+        }
+
+        try {
+          const response = await this._client.send(
+            new InvokeHarnessCommand({
+              harnessArn: this._harnessArn,
+              runtimeSessionId: this._runtimeSessionId,
+              messages: [{ role: 'user', content: [{ text }] }],
+            }),
+            { abortSignal }
+          )
+          for await (const chunk of response.stream ?? []) {
+            if (abortSignal.aborted) break
+
+            const streamError = chunk.internalServerException ?? chunk.validationException ?? chunk.runtimeClientError
+            if (streamError) throw streamError
+
+            const event = chunk as AgentCoreHarnessStreamUpdateEvent['event']
+            yield new AgentCoreHarnessStreamUpdateEvent(event)
+            decoder.accept(event)
+          }
+        } catch (error) {
+          if (!abortSignal.aborted) throw normalizeHarnessError(error)
+        }
+      }
+
+      const decoded = decoder.complete(abortSignal.aborted ? 'cancelled' : undefined)
+      if (!abortSignal.aborted) throwIfUnrecoverable(decoded.stopReason, decoded.message)
+      const result = new AgentResult({
+        stopReason: decoded.stopReason,
+        lastMessage: decoded.message,
+        invocationState,
+      })
+      yield new AgentCoreHarnessResultEvent({ result })
+      return result
+    } finally {
+      this._isInvoking = false
+    }
+  }
+}
+
+function textFromInvokeArgs(args: InvokeArgs): string {
+  if (args.length === 0) throw new TypeError('AgentCoreHarnessAgent input must contain non-empty text.')
+  if (typeof args === 'string') return args
+
+  const first = args[0]!
+  if ('interruptResponse' in first) {
+    throw new TypeError('AgentCoreHarnessAgent does not support interrupt response input.')
+  }
+
+  if ('role' in first) {
+    // Message history: the Harness owns conversation state under `runtimeSessionId`, so only the
+    // newest user message is sent. Replaying earlier turns would duplicate them server-side.
+    const latestUserMessage = Array.from(args as MessageData[])
+      .reverse()
+      .find((message) => message.role === 'user')
+    if (latestUserMessage === undefined) {
+      throw new TypeError('AgentCoreHarnessAgent message input must include at least one user message.')
+    }
+    return textFromContentBlocks(latestUserMessage.content)
+  }
+
+  return textFromContentBlocks(args as ContentBlock[] | ContentBlockData[])
+}
+
+function textFromContentBlocks(blocks: ContentBlock[] | ContentBlockData[]): string {
+  const text: string[] = []
+  for (const value of blocks) {
+    if ('type' in value && value.type !== 'textBlock') {
+      throw new TypeError(`AgentCoreHarnessAgent accepts only text content blocks; received ${value.type}.`)
+    }
+    if (!('text' in value)) {
+      throw new TypeError('AgentCoreHarnessAgent accepts only text content blocks.')
+    }
+    text.push(value.text)
+  }
+  const joined = text.join('\n')
+  if (joined.length === 0) throw new TypeError('AgentCoreHarnessAgent input must contain non-empty text.')
+  return joined
+}
+
+function throwIfUnrecoverable(stopReason: AgentResult['stopReason'], message: AgentResult['lastMessage']): void {
+  switch (stopReason) {
+    case 'maxTokens':
+      throw new MaxTokensError(
+        'Model reached maximum token limit. This is an unrecoverable state that requires intervention.',
+        message
+      )
+    case 'interrupted':
+    case 'malformedModelOutput':
+    case 'malformedToolUse':
+      throw new ModelError(`Harness ended the turn with an unrecoverable stop reason: ${stopReason}`)
+    case 'toolUse':
+    case 'toolResult':
+    case 'pauseTurn':
+      throw new ModelError(
+        `AgentCoreHarnessAgent cannot complete a Harness continuation with stop reason: ${stopReason}`
+      )
+  }
+}
+
+function normalizeHarnessError(error: unknown): ModelError {
+  if (error instanceof ModelError) return error
+
+  const message =
+    typeof error === 'object' && error !== null && 'message' in error ? String(error.message) : String(error)
+  if (error instanceof Error && error.name === 'ThrottlingException') {
+    return new ModelThrottledError(message, { cause: error })
+  }
+  const normalizedMessage = message.toLowerCase()
+  if (CONTEXT_WINDOW_OVERFLOW_MESSAGES.some((phrase) => normalizedMessage.includes(phrase))) {
+    return new ContextWindowOverflowError(message)
+  }
+  return new ModelError(message, { cause: error })
+}

--- a/src/harness/integrations/strands/events.ts
+++ b/src/harness/integrations/strands/events.ts
@@ -1,0 +1,54 @@
+import type { InvokeHarnessStreamOutput } from '@aws-sdk/client-bedrock-agentcore'
+import { StreamEvent, type AgentResult } from '@strands-agents/sdk'
+
+type AgentCoreHarnessEventData = Exclude<
+  InvokeHarnessStreamOutput,
+  | InvokeHarnessStreamOutput.InternalServerExceptionMember
+  | InvokeHarnessStreamOutput.ValidationExceptionMember
+  | InvokeHarnessStreamOutput.RuntimeClientErrorMember
+>
+
+/**
+ * Wraps one raw event from the `InvokeHarness` response stream.
+ *
+ * @experimental
+ */
+export class AgentCoreHarnessStreamUpdateEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessStreamUpdateEvent' as const
+  readonly event: AgentCoreHarnessEventData
+
+  constructor(event: AgentCoreHarnessEventData) {
+    super()
+    this.event = event
+  }
+
+  toJSON(): Pick<AgentCoreHarnessStreamUpdateEvent, 'type' | 'event'> {
+    return { type: this.type, event: this.event }
+  }
+}
+
+/**
+ * Wraps the final result yielded by an AgentCore Harness agent stream.
+ *
+ * @experimental
+ */
+export class AgentCoreHarnessResultEvent extends StreamEvent {
+  readonly type = 'agentCoreHarnessResultEvent' as const
+  readonly result: AgentResult
+
+  constructor(data: { result: AgentResult }) {
+    super()
+    this.result = data.result
+  }
+
+  toJSON(): Pick<AgentCoreHarnessResultEvent, 'type' | 'result'> {
+    return { type: this.type, result: this.result }
+  }
+}
+
+/**
+ * Events yielded by {@link AgentCoreHarnessAgent.stream}.
+ *
+ * @experimental
+ */
+export type AgentCoreHarnessStreamEvent = AgentCoreHarnessStreamUpdateEvent | AgentCoreHarnessResultEvent

--- a/src/harness/integrations/strands/index.ts
+++ b/src/harness/integrations/strands/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Experimental Strands integration for invoking a deployed AgentCore Harness.
+ *
+ * This API is subject to breaking changes before promotion to a stable import path.
+ *
+ * @experimental
+ */
+
+export { AgentCoreHarnessAgent } from './agent.js'
+
+export type { AgentCoreHarnessAgentConfig } from './types.js'
+export type {
+  AgentCoreHarnessResultEvent,
+  AgentCoreHarnessStreamEvent,
+  AgentCoreHarnessStreamUpdateEvent,
+} from './events.js'

--- a/src/harness/integrations/strands/stream-decoder.ts
+++ b/src/harness/integrations/strands/stream-decoder.ts
@@ -1,0 +1,118 @@
+import type {
+  HarnessContentBlockDelta,
+  HarnessStopReason,
+  InvokeHarnessStreamOutput,
+} from '@aws-sdk/client-bedrock-agentcore'
+import { Message, ModelError, ReasoningBlock, TextBlock } from '@strands-agents/sdk'
+import type { ContentBlock, Role, StopReason } from '@strands-agents/sdk'
+
+/** Harness wire stop reasons mapped onto the Strands `StopReason` vocabulary. */
+const STOP_REASON_MAP = {
+  end_turn: 'endTurn',
+  tool_use: 'toolUse',
+  tool_result: 'toolResult',
+  max_tokens: 'maxTokens',
+  stop_sequence: 'stopSequence',
+  content_filtered: 'contentFiltered',
+  model_context_window_exceeded: 'modelContextWindowExceeded',
+  max_iterations_exceeded: 'limitTurns',
+  max_output_tokens_exceeded: 'limitOutputTokens',
+  timeout_exceeded: 'timeoutExceeded',
+  interrupted: 'interrupted',
+  partial_turn: 'pauseTurn',
+  malformed_model_output: 'malformedModelOutput',
+  malformed_tool_use: 'malformedToolUse',
+} satisfies Record<HarnessStopReason, StopReason>
+
+/** Reconstructs the latest Strands message from an `InvokeHarness` stream. */
+export class HarnessStreamDecoder {
+  private _role: Role = 'assistant'
+  private _content: ContentBlock[] = []
+  private _pending: PendingBlock | undefined
+  private _stopReason: StopReason | undefined
+
+  /** Folds one Harness event into the latest message. */
+  accept(event: InvokeHarnessStreamOutput): void {
+    if (event.messageStart) {
+      this._content = []
+      this._pending = undefined
+      this._stopReason = undefined
+      this._role = event.messageStart.role ?? 'assistant'
+      return
+    }
+    if (event.contentBlockStart || event.contentBlockStop) {
+      this._flushPending()
+    } else if (event.contentBlockDelta?.delta) {
+      this._acceptDelta(event.contentBlockDelta.delta)
+    } else if (event.messageStop) {
+      this._flushPending()
+      const stopReason = event.messageStop.stopReason
+      this._stopReason = stopReason && (STOP_REASON_MAP[stopReason] ?? stopReason)
+    }
+  }
+
+  /** Returns the completed message, optionally overriding its stop reason for cancellation. */
+  complete(stopReason: StopReason | undefined = this._stopReason): { message: Message; stopReason: StopReason } {
+    this._flushPending()
+    if (stopReason === undefined) {
+      throw new ModelError('AgentCore Harness stream ended without completing a message')
+    }
+
+    return { message: new Message({ role: this._role, content: this._content }), stopReason }
+  }
+
+  private _acceptDelta(delta: HarnessContentBlockDelta): void {
+    if (delta.text !== undefined) {
+      if (this._pending?.kind !== 'text') {
+        this._flushPending()
+        this._pending = { kind: 'text', text: '' }
+      }
+      this._pending.text += delta.text
+      return
+    }
+    const reasoning = delta.reasoningContent
+    if (!reasoning || '$unknown' in reasoning) return
+
+    if (this._pending?.kind !== 'reasoning') {
+      this._flushPending()
+      this._pending = { kind: 'reasoning', text: '' }
+    }
+    if (reasoning.text !== undefined) {
+      this._pending.text += reasoning.text
+    } else if (reasoning.signature !== undefined) {
+      this._pending.signature = (this._pending.signature ?? '') + reasoning.signature
+    } else if (reasoning.redactedContent !== undefined) {
+      this._pending.redactedContent = concatBytes(this._pending.redactedContent, reasoning.redactedContent)
+    }
+  }
+
+  private _flushPending(): void {
+    const pending = this._pending
+    if (!pending) return
+
+    if (pending.kind === 'text') {
+      if (pending.text) this._content.push(new TextBlock(pending.text))
+    } else {
+      this._content.push(
+        new ReasoningBlock({
+          ...(pending.text && { text: pending.text }),
+          ...(pending.signature !== undefined && { signature: pending.signature }),
+          ...(pending.redactedContent !== undefined && { redactedContent: pending.redactedContent }),
+        })
+      )
+    }
+    this._pending = undefined
+  }
+}
+
+type PendingBlock =
+  | { kind: 'text'; text: string }
+  | { kind: 'reasoning'; text: string; signature?: string; redactedContent?: Uint8Array }
+
+function concatBytes(current: Uint8Array | undefined, chunk: Uint8Array): Uint8Array {
+  if (current === undefined) return chunk
+  const combined = new Uint8Array(current.length + chunk.length)
+  combined.set(current)
+  combined.set(chunk, current.length)
+  return combined
+}

--- a/src/harness/integrations/strands/types.ts
+++ b/src/harness/integrations/strands/types.ts
@@ -1,0 +1,26 @@
+import type { BedrockAgentCoreClient } from '@aws-sdk/client-bedrock-agentcore'
+
+/**
+ * Config for an experimental {@link AgentCoreHarnessAgent}.
+ *
+ * @experimental
+ */
+export interface AgentCoreHarnessAgentConfig {
+  /** ARN of the deployed AgentCore Harness. */
+  readonly harnessArn: string
+
+  /** Conversation session ID. Reuse it across calls to continue one Harness conversation. */
+  readonly runtimeSessionId: string
+
+  /** Identifier unique to this agent instance; defaults to `"{harnessArn}:{runtimeSessionId}"`. */
+  readonly id?: string
+
+  /** Optional name surfaced to Strands multi-agent primitives. */
+  readonly name?: string
+
+  /** Optional description surfaced to Strands multi-agent primitives. */
+  readonly description?: string
+
+  /** Pre-constructed AgentCore data-plane client configured with `maxAttempts: 1`. */
+  readonly client?: BedrockAgentCoreClient
+}


### PR DESCRIPTION
## Description

Introducing `AgentCoreHarnessAgent`, an implementation of the Strands `InvokableAgent` [interface](https://github.com/strands-agents/harness-sdk/blob/11ad6366a1578d432ea4cd2c3ed41b610953d297/strands-ts/src/types/agent.ts#L199-L232) for a deployed [AgentCore Harness](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness.html). Now, developers can invoke their Harness agent and integrate it into their agentic applications / multi-agent `Graphs` just as easily as a typical Strands Agent today.

The deployed Harness continues to own its model, prompt, default tools, memory, limits, and
server-side agent loop, running in a managed microVM.

```typescript
import { AgentCoreHarnessAgent } from 'bedrock-agentcore/experimental/harness/strands'

const agent = new AgentCoreHarnessAgent({
  harnessArn: '...',
  runtimeSessionId: '...',
})

await agent.invoke('Summarize your environment.')
```

Client-side custom tool calling powered by the Managed Harness' `inline_function` capability will be added in a separate PR.

## Related Issues

https://github.com/strands-agents/harness-sdk/issues/3052

## Type of Change

New feature

## Testing

How have you tested the change?

- [x] I ran `npm run check`
- [x] I ran the full unit test suite, lint, type checks, and build
- [x] I verified the experimental package subpath and package contents

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
