### PR TITLE
feat: code-interpreter accept binary blob entries in writeFiles

### DIFF
--- a/src/tools/code-interpreter/__tests__/client.test.ts
+++ b/src/tools/code-interpreter/__tests__/client.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { InvokeCodeInterpreterCommand } from '@aws-sdk/client-bedrock-agentcore'
 import { CodeInterpreter } from '../client.js'
+import { WriteFilesParamsSchema } from '../types.js'
 
 // Mock AWS SDK
 const mockSessionIds = new Map<string, string>()
@@ -425,7 +427,19 @@ describe('CodeInterpreter', () => {
   describe('writeFiles', () => {
     let interpreter: CodeInterpreter
 
+    const lastWriteContent = (): any[] => {
+      const calls = vi.mocked(InvokeCodeInterpreterCommand).mock.calls
+      for (let i = calls.length - 1; i >= 0; i--) {
+        const input = calls[i]![0] as any
+        if (input.name === 'writeFiles') {
+          return input.arguments.content
+        }
+      }
+      throw new Error('No writeFiles command was sent')
+    }
+
     beforeEach(() => {
+      vi.mocked(InvokeCodeInterpreterCommand).mockClear()
       interpreter = new CodeInterpreter({ region: 'us-east-1' })
     })
 
@@ -450,6 +464,67 @@ describe('CodeInterpreter', () => {
 
       expect(result).toBeDefined()
       expect(result).toContain('Files written successfully')
+    })
+
+    it('maps text entries to the text field', async () => {
+      await interpreter.writeFiles({
+        files: [{ path: 'test.txt', content: 'Hello' }],
+      })
+
+      const content = lastWriteContent()
+      expect(content[0]).toEqual({ path: 'test.txt', text: 'Hello' })
+      expect(content[0].blob).toBeUndefined()
+    })
+
+    it('maps binary entries to the blob field', async () => {
+      const blob = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+
+      await interpreter.writeFiles({
+        files: [{ path: 'image.png', blob }],
+      })
+
+      const content = lastWriteContent()
+      expect(content[0].path).toBe('image.png')
+      expect(content[0].blob).toEqual(blob)
+      expect(content[0].text).toBeUndefined()
+    })
+
+    it('maps a mixed batch of text and binary entries in order', async () => {
+      const blob = new Uint8Array([1, 2, 3])
+
+      await interpreter.writeFiles({
+        files: [
+          { path: 'script.py', content: 'print(1)' },
+          { path: 'data.bin', blob },
+        ],
+      })
+
+      const content = lastWriteContent()
+      expect(content[0]).toEqual({ path: 'script.py', text: 'print(1)' })
+      expect(content[1].path).toBe('data.bin')
+      expect(content[1].blob).toEqual(blob)
+      expect(content[1].text).toBeUndefined()
+    })
+
+    it('rejects an entry with both content and blob', () => {
+      const result = WriteFilesParamsSchema.safeParse({
+        files: [{ path: 'file.txt', content: 'Hello', blob: new Uint8Array([1]) }],
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an entry with neither content nor blob', () => {
+      const result = WriteFilesParamsSchema.safeParse({
+        files: [{ path: 'file.txt' }],
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts a Buffer as blob', () => {
+      const result = WriteFilesParamsSchema.safeParse({
+        files: [{ path: 'data.bin', blob: Buffer.from('Hello') }],
+      })
+      expect(result.success).toBe(true)
     })
   })
 

--- a/src/tools/code-interpreter/client.ts
+++ b/src/tools/code-interpreter/client.ts
@@ -394,7 +394,8 @@ export class CodeInterpreter {
    * await interpreter.writeFiles({
    *   files: [
    *     { path: 'script.py', content: 'print("Hello")' },
-   *     { path: 'data.json', content: '{"key": "value"}' }
+   *     { path: 'data.json', content: '{"key": "value"}' },
+   *     { path: 'data.xlsx', blob: xlsxBytes } // Uint8Array | Buffer
    *   ]
    * })
    * ```
@@ -410,10 +411,9 @@ export class CodeInterpreter {
         sessionId: this._session!.sessionId,
         name: 'writeFiles',
         arguments: {
-          content: params.files.map((f) => ({
-            path: f.path,
-            text: f.content,
-          })),
+          content: params.files.map((f) =>
+            'blob' in f ? { path: f.path, blob: f.blob } : { path: f.path, text: f.content }
+          ),
         },
       })
 

--- a/src/tools/code-interpreter/types.ts
+++ b/src/tools/code-interpreter/types.ts
@@ -383,22 +383,39 @@ export interface ReadFilesResult {
 }
 
 /**
+ * A single file to write to the sandbox.
+ * Either text content or a binary blob, never both.
+ */
+type WriteFileEntry =
+  | {
+      /**
+       * File path.
+       */
+      path: string
+      /**
+       * File content as UTF-8 text.
+       */
+      content: string
+    }
+  | {
+      /**
+       * File path.
+       */
+      path: string
+      /**
+       * File content as raw binary.
+       */
+      blob: Uint8Array
+    }
+
+/**
  * Parameters for writing files to sandbox.
  */
 export interface WriteFilesParams {
   /**
    * Array of files to write.
    */
-  files: Array<{
-    /**
-     * File path.
-     */
-    path: string
-    /**
-     * File content.
-     */
-    content: string
-  }>
+  files: WriteFileEntry[]
 }
 
 /**
@@ -526,15 +543,19 @@ export const ReadFilesParamsSchema = z.object({
   paths: z.array(z.string()).min(1, 'At least one path required'),
 })
 
+const writeFileEntrySchema = z.union([
+  z.strictObject({
+    path: z.string().min(1, 'File path cannot be empty'),
+    content: z.string(),
+  }),
+  z.strictObject({
+    path: z.string().min(1, 'File path cannot be empty'),
+    blob: z.instanceof(Uint8Array),
+  }),
+])
+
 export const WriteFilesParamsSchema = z.object({
-  files: z
-    .array(
-      z.object({
-        path: z.string().min(1, 'File path cannot be empty'),
-        content: z.string(),
-      })
-    )
-    .min(1, 'At least one file required'),
+  files: z.array(writeFileEntrySchema).min(1, 'At least one file required'),
 })
 
 export const ListFilesParamsSchema = z.object({

--- a/tests_integ/code-interpreter.test.ts
+++ b/tests_integ/code-interpreter.test.ts
@@ -232,6 +232,35 @@ print(json.dumps(data))
   })
 
   describe('File Operations', () => {
+    it('writes a binary file byte-exact', async () => {
+      const testInterpreter = new CodeInterpreter({ region: testRegion })
+      await testInterpreter.startSession({ sessionName: 'binary-write-test' })
+
+      const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47])
+
+      await testInterpreter.writeFiles({
+        files: [{ path: 'signature.png', blob: bytes }],
+      })
+
+      const sizeResult = await testInterpreter.executeCommand({
+        command: 'wc -c < signature.png',
+      })
+
+      expect(sizeResult).toBeDefined()
+      expect(sizeResult.trim()).toBe(String(bytes.length))
+
+      const hexResult = await testInterpreter.executeCommand({
+        command: 'od -An -tx1 signature.png',
+      })
+
+      const expectedHex = Array.from(bytes)
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join(' ')
+      expect(hexResult).toContain(expectedHex)
+
+      await testInterpreter.stopSession()
+    }, 30000)
+
     it('writes, lists, reads, and removes files', async () => {
       const testInterpreter = new CodeInterpreter({ region: testRegion })
       await testInterpreter.startSession({ sessionName: 'file-test' })


### PR DESCRIPTION
## Description

Allow code-interpreter to accept binary blob entries in writeFiles.

## Type of Change

New feature

## Testing

How have you tested the change?

- [X] I ran `npm run check`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
